### PR TITLE
feat: 마이페이지 UI 구현 및 앱 시작점 재설정 (#35)

### DIFF
--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'theme.dart';
 // import 'screens/dashboard_screen.dart';
-import 'screens/main_screen.dart';
-// import 'screens/login_screen.dart'; 
+// import 'screens/main_screen.dart';
+import 'screens/login_screen.dart'; 
 
 void main() {
   runApp(const NutriAgentApp());
@@ -17,8 +17,8 @@ class NutriAgentApp extends StatelessWidget {
       title: 'NUTRI Agent',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.lightTheme,
-      
-      home: const MainScreen(),
+      home: const LoginScreen(),
+      // home: const MainScreen(),
       // home: const LoginScreen(),
     );
   }

--- a/flutter_app/lib/screens/login_screen.dart
+++ b/flutter_app/lib/screens/login_screen.dart
@@ -1,7 +1,16 @@
 import 'package:flutter/material.dart';
+import 'onboarding_screen.dart';
 
 class LoginScreen extends StatelessWidget {
   const LoginScreen({super.key});
+
+  // 온보딩 화면으로 이동
+  void _navigateToOnboarding(BuildContext context) {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (context) => const OnboardingScreen()),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -15,69 +24,58 @@ class LoginScreen extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               const Spacer(flex: 2),
-              
-              // 1. 메인 타이틀
               const Text(
                 '고물가 시대에 사는\n당신을 위한 메뉴 추천\n어플리케이션',
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 25,
                   fontWeight: FontWeight.w800,
-                  color: Color.fromARGB(255, 0, 0, 0),
+                  color: Colors.black,
                   height: 1.4,
                   letterSpacing: -0.5,
                 ),
               ),
-              
               const Spacer(flex: 2),
               
-              // 이메일로 계속하기
               _buildLoginButton(
                 text: '이메일로 계속하기',
                 backgroundColor: const Color(0xFF8CA384), 
                 textColor: Colors.white,
-                onPressed: () {
-                  // TODO: 이메일 가입/로그인 라우팅
-                },
+                onPressed: () => _navigateToOnboarding(context),
               ),
               const SizedBox(height: 16),
 
-              // 카카오로 계속하기
               _buildLoginButton(
                 text: '카카오로 계속하기',
                 backgroundColor: const Color(0xFFEAE145),
                 textColor: Colors.white,
-                onPressed: () {},
+                onPressed: () => _navigateToOnboarding(context),
               ),
               const SizedBox(height: 16),
 
-              // 네이버로 계속하기
               _buildLoginButton(
                 text: '네이버로 계속하기',
                 backgroundColor: const Color(0xFF5CC959), 
                 textColor: Colors.white,
-                onPressed: () {},
+                onPressed: () => _navigateToOnboarding(context),
               ),
               const SizedBox(height: 16),
 
-              // Google로 계속하기
               _buildLoginButton(
                 text: 'Google로 계속하기',
                 backgroundColor: const Color(0xFF4A31FF),
                 textColor: Colors.white,
-                onPressed: () {},
+                onPressed: () => _navigateToOnboarding(context),
               ),
               const SizedBox(height: 16),
 
-              // Apple로 계속하기
               _buildLoginButton(
                 text: 'Apple로 계속하기',
                 backgroundColor: Colors.black,
                 textColor: Colors.white,
-                onPressed: () {},
+                onPressed: () => _navigateToOnboarding(context),
               ),
-
-              const Spacer(flex: 3), // 버튼 하단 여백 확보
+              const Spacer(flex: 3),
             ],
           ),
         ),
@@ -85,7 +83,6 @@ class LoginScreen extends StatelessWidget {
     );
   }
 
-  // 버튼을 찍어내는 공통 위젯 함수
   Widget _buildLoginButton({
     required String text,
     required Color backgroundColor,
@@ -100,17 +97,9 @@ class LoginScreen extends StatelessWidget {
           backgroundColor: backgroundColor,
           foregroundColor: textColor,
           elevation: 0,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(30),
-          ),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
         ),
-        child: Text(
-          text,
-          style: const TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
+        child: Text(text, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
       ),
     );
   }

--- a/flutter_app/lib/screens/main_screen.dart
+++ b/flutter_app/lib/screens/main_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'dashboard_screen.dart';
+import 'mypage_screen.dart';
 
 class MainScreen extends StatefulWidget {
   const MainScreen({super.key});
@@ -14,7 +15,7 @@ class _MainScreenState extends State<MainScreen> {
   // 탭별로 보여줄 화면 목록
   static const List<Widget> _widgetOptions = <Widget>[
     DashboardScreen(),
-    Center(child: Text('마이페이지 화면입니다')),
+    MyPageScreen(),
   ];
 
   void _onItemTapped(int index) {

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -9,12 +9,13 @@ class MyPageScreen extends StatefulWidget {
 
 class _MyPageScreenState extends State<MyPageScreen> {
   final _formKey = GlobalKey<FormState>();
+  bool _isEditMode = false;
 
-  // 1. 기본 정보 컨트롤러
-  final TextEditingController _nicknameController = TextEditingController(text: "김철수"); // 초기값 예시
+  // 1. 기본 정보
+  final TextEditingController _nicknameController = TextEditingController(text: "김철수");
   String? _selectedGender = '남성';
 
-  // 2. 인바디 정보 컨트롤러
+  // 2. 인바디 정보
   final TextEditingController _heightController = TextEditingController(text: "175");
   final TextEditingController _weightController = TextEditingController(text: "70");
   final TextEditingController _muscleController = TextEditingController(text: "35");
@@ -22,13 +23,14 @@ class _MyPageScreenState extends State<MyPageScreen> {
   final TextEditingController _bmrController = TextEditingController(text: "1600");
   final TextEditingController _inbodyScoreController = TextEditingController(text: "80");
 
-  // 3. 식습관 및 예산 컨트롤러
+  // 3. 식습관 및 예산
   final TextEditingController _budgetController = TextEditingController(text: "8000");
   String _selectedVegType = 'NONE';
   double _spicyLevel = 3;
 
   // 4. 알레르기 정보
-  final Set<String> _selectedAllergies = {'우유', '밀가루'}; // 초기값 예시
+  Set<String> _selectedAllergies = {'우유', '밀가루'};
+  
   final List<String> _allergyOptions = ['땅콩', '갑각류', '대두', '우유', '밀가루', '계란', '견과류', '생선'];
   final Map<String, String> _vegOptions = {
     'NONE': '해당 없음',
@@ -37,6 +39,14 @@ class _MyPageScreenState extends State<MyPageScreen> {
     'OVO': '오보 (계란 허용)',
     'PESCO': '페스코 (해산물 허용)'
   };
+
+  // 취소 버튼을 위한 데이터 백업 저장소
+  late String _bkNickname;
+  late String? _bkGender;
+  late String _bkHeight, _bkWeight, _bkMuscle, _bkFat, _bkBmr, _bkScore, _bkBudget;
+  late String _bkVegType;
+  late double _bkSpicy;
+  late Set<String> _bkAllergies;
 
   @override
   void dispose() {
@@ -51,32 +61,80 @@ class _MyPageScreenState extends State<MyPageScreen> {
     super.dispose();
   }
 
-  // 수정된 정보 저장 로직
+  // ✏️ 수정 모드 켜기 (현재 데이터 백업)
+  void _enableEditMode() {
+    _bkNickname = _nicknameController.text;
+    _bkGender = _selectedGender;
+    _bkHeight = _heightController.text;
+    _bkWeight = _weightController.text;
+    _bkMuscle = _muscleController.text;
+    _bkFat = _fatController.text;
+    _bkBmr = _bmrController.text;
+    _bkScore = _inbodyScoreController.text;
+    _bkBudget = _budgetController.text;
+    _bkVegType = _selectedVegType;
+    _bkSpicy = _spicyLevel;
+    _bkAllergies = Set.from(_selectedAllergies);
+
+    setState(() {
+      _isEditMode = true;
+    });
+  }
+
+  // ❌ 수정 취소하기 (백업 데이터로 원상 복구)
+  void _cancelEdit() {
+    _nicknameController.text = _bkNickname;
+    _selectedGender = _bkGender;
+    _heightController.text = _bkHeight;
+    _weightController.text = _bkWeight;
+    _muscleController.text = _bkMuscle;
+    _fatController.text = _bkFat;
+    _bmrController.text = _bkBmr;
+    _inbodyScoreController.text = _bkScore;
+    _budgetController.text = _bkBudget;
+    _selectedVegType = _bkVegType;
+    _spicyLevel = _bkSpicy;
+    _selectedAllergies = Set.from(_bkAllergies);
+
+    setState(() {
+      _isEditMode = false;
+    });
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('수정이 취소되어 원래 정보로 복구되었습니다.')),
+    );
+  }
+
+  // 💾 변경사항 저장하기
   void _saveProfile() {
     if (_formKey.currentState!.validate()) {
+      setState(() {
+        _isEditMode = false;
+      });
+
       final updatedData = {
         'nickname': _nicknameController.text,
         'gender': _selectedGender,
         'health': {
-          'height': _heightController.text,
-          'weight': _weightController.text,
-          'muscle': _muscleController.text,
-          'fat': _fatController.text,
-          'bmr': _bmrController.text,
-          'score': _inbodyScoreController.text,
+          'height': double.parse(_heightController.text),
+          'weight': double.parse(_weightController.text),
+          'muscle': double.parse(_muscleController.text),
+          'fat': double.parse(_fatController.text),
+          'bmr': int.parse(_bmrController.text),
+          'score': int.parse(_inbodyScoreController.text),
         },
         'preference': {
-          'budget': _budgetController.text,
+          'budget': int.parse(_budgetController.text),
           'vegType': _selectedVegType,
           'spicy': _spicyLevel.toInt(),
         },
         'allergies': _selectedAllergies.toList(),
       };
 
-      print('수정된 프로필 데이터: $updatedData');
-      
+      print('서버로 전송될 수정 데이터: $updatedData');
+
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('프로필 정보가 수정되었습니다.')),
+        const SnackBar(content: Text('프로필 정보가 성공적으로 업데이트되었습니다!')),
       );
     }
   }
@@ -88,99 +146,176 @@ class _MyPageScreenState extends State<MyPageScreen> {
         title: const Text('마이페이지', style: TextStyle(fontWeight: FontWeight.bold)),
         centerTitle: true,
         elevation: 0,
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         actions: [
-          TextButton(
-            onPressed: _saveProfile,
-            child: const Text('저장', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
-          ),
+          if (!_isEditMode)
+            TextButton(
+              onPressed: _enableEditMode,
+              child: Text(
+                '수정',
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16, color: Theme.of(context).primaryColor),
+              ),
+            ),
         ],
       ),
-      body: Form(
-        key: _formKey,
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(20.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _buildSectionTitle('기본 정보 수정'),
-              _buildTextField(_nicknameController, '닉네임', isNumber: false),
-              const SizedBox(height: 16),
-              DropdownButtonFormField<String>(
-                decoration: const InputDecoration(labelText: '성별'),
-                value: _selectedGender,
-                items: ['남성', '여성'].map((s) => DropdownMenuItem(value: s, child: Text(s))).toList(),
-                onChanged: (v) => setState(() => _selectedGender = v),
-              ),
-              const SizedBox(height: 32),
+      body: SafeArea(
+        child: Form(
+          key: _formKey,
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(20.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildSectionTitle('1. 기본 정보'),
+                _buildTextField(_nicknameController, '닉네임', isNumber: false),
+                const SizedBox(height: 16),
+                DropdownButtonFormField<String>(
+                  decoration: InputDecoration(
+                    labelText: '성별',
+                    filled: true,
+                    fillColor: _isEditMode ? Colors.white : Colors.grey.shade100, 
+                  ),
+                  value: _selectedGender,
+                  onChanged: _isEditMode ? (v) => setState(() => _selectedGender = v!) : null,
+                  items: ['남성', '여성'].map((s) => DropdownMenuItem(value: s, child: Text(s))).toList(),
+                ),
+                const SizedBox(height: 32),
 
-              _buildSectionTitle('인바디 정보 수정'),
-              Row(
-                children: [
-                  Expanded(child: _buildTextField(_heightController, '키', suffix: 'cm')),
-                  const SizedBox(width: 12),
-                  Expanded(child: _buildTextField(_weightController, '몸무게', suffix: 'kg')),
-                ],
-              ),
-              const SizedBox(height: 12),
-              Row(
-                children: [
-                  Expanded(child: _buildTextField(_muscleController, '골격근량', suffix: 'kg')),
-                  const SizedBox(width: 12),
-                  Expanded(child: _buildTextField(_fatController, '체지방률', suffix: '%')),
-                ],
-              ),
-              const SizedBox(height: 12),
-              Row(
-                children: [
-                  Expanded(child: _buildTextField(_bmrController, '기초대사량', suffix: 'kcal')),
-                  const SizedBox(width: 12),
-                  Expanded(child: _buildTextField(_inbodyScoreController, '인바디 점수', suffix: '점')),
-                ],
-              ),
-              const SizedBox(height: 32),
+                _buildSectionTitle('2. 체성분 (InBody) 정보'),
+                Row(
+                  children: [
+                    Expanded(child: _buildTextField(_heightController, '키', suffix: 'cm')),
+                    const SizedBox(width: 12),
+                    Expanded(child: _buildTextField(_weightController, '몸무게', suffix: 'kg')),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(child: _buildTextField(_muscleController, '골격근량', suffix: 'kg')),
+                    const SizedBox(width: 12),
+                    Expanded(child: _buildTextField(_fatController, '체지방률', suffix: '%')),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(child: _buildTextField(_bmrController, '기초대사량', suffix: 'kcal')),
+                    const SizedBox(width: 12),
+                    Expanded(child: _buildTextField(_inbodyScoreController, '인바디 점수', suffix: '점')),
+                  ],
+                ),
+                const SizedBox(height: 32),
 
-              _buildSectionTitle('식습관 및 예산 수정'),
-              _buildTextField(_budgetController, '끼니당 예산', suffix: '원'),
-              const SizedBox(height: 16),
-              DropdownButtonFormField<String>(
-                decoration: const InputDecoration(labelText: '채식 유형'),
-                value: _selectedVegType,
-                items: _vegOptions.entries.map((e) => DropdownMenuItem(value: e.key, child: Text(e.value))).toList(),
-                onChanged: (v) => setState(() => _selectedVegType = v!),
-              ),
-              const SizedBox(height: 16),
-              Text('매운맛 선호도 (${_spicyLevel.toInt()}단계)', style: const TextStyle(fontWeight: FontWeight.w500)),
-              Slider(
-                value: _spicyLevel,
-                min: 1, max: 5, divisions: 4,
-                onChanged: (v) => setState(() => _spicyLevel = v),
-              ),
-              const SizedBox(height: 32),
+                _buildSectionTitle('3. 식습관 및 예산 설정'),
+                _buildTextField(_budgetController, '끼니당 허용 예산', suffix: '원'),
+                const SizedBox(height: 16),
+                DropdownButtonFormField<String>(
+                  decoration: InputDecoration(
+                    labelText: '채식 유형 선택',
+                    filled: true,
+                    fillColor: _isEditMode ? Colors.white : Colors.grey.shade100,
+                  ),
+                  value: _selectedVegType,
+                  onChanged: _isEditMode ? (v) => setState(() => _selectedVegType = v!) : null,
+                  items: _vegOptions.entries.map((e) => DropdownMenuItem(value: e.key, child: Text(e.value))).toList(),
+                ),
+                const SizedBox(height: 24),
+                
+                Opacity(
+                  opacity: _isEditMode ? 1.0 : 0.5,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('매운맛 선호도 (${_spicyLevel.toInt()}단계)', style: const TextStyle(fontWeight: FontWeight.bold)),
+                      Slider(
+                        value: _spicyLevel,
+                        min: 1, max: 5, divisions: 4,
+                        activeColor: Theme.of(context).primaryColor,
+                        onChanged: _isEditMode ? (v) => setState(() => _spicyLevel = v) : null,
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 32),
 
-              _buildSectionTitle('알레르기 정보 수정'),
-              Wrap(
-                spacing: 8,
-                children: _allergyOptions.map((allergy) {
-                  final isSelected = _selectedAllergies.contains(allergy);
-                  return FilterChip(
-                    label: Text(allergy),
-                    selected: isSelected,
-                    onSelected: (bool selected) {
-                      setState(() {
-                        selected ? _selectedAllergies.add(allergy) : _selectedAllergies.remove(allergy);
-                      });
-                    },
-                  );
-                }).toList(),
-              ),
-              const SizedBox(height: 40),
-              
-              ElevatedButton(
-                onPressed: _saveProfile,
-                child: const Text('수정완료', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
-              ),
-              const SizedBox(height: 20),
-            ],
+                _buildSectionTitle('4. 알레르기 유발 물질'),
+                Container(
+                  width: double.infinity,
+                  padding: EdgeInsets.all(_isEditMode ? 0 : 16.0),
+                  decoration: BoxDecoration(
+                    color: _isEditMode ? Colors.transparent : Colors.grey.shade100,
+                    borderRadius: BorderRadius.circular(12),
+                    border: _isEditMode ? null : Border.all(color: Colors.grey.shade300),
+                  ),
+                  child: IgnorePointer(
+                    ignoring: !_isEditMode,
+                    child: Wrap(
+                      spacing: 8.0,
+                      runSpacing: 8.0,
+                      children: _allergyOptions.map((allergy) {
+                        final isSelected = _selectedAllergies.contains(allergy);
+                        return FilterChip(
+                          label: Text(
+                            allergy,
+                            style: TextStyle(
+                              // 💡 텍스트 색상도 읽기 전용일 땐 회색으로 변경
+                              color: _isEditMode ? Colors.black87 : Colors.grey.shade600,
+                            ),
+                          ),
+                          selected: isSelected,
+                          // 💡 핵심 수정: 배경색과 선택된 색상 모두 음영 처리
+                          backgroundColor: _isEditMode ? Colors.white : Colors.grey.shade200,
+                          selectedColor: _isEditMode 
+                              ? Theme.of(context).primaryColor.withOpacity(0.2) 
+                              : Colors.grey.shade300,
+                          checkmarkColor: _isEditMode 
+                              ? Theme.of(context).primaryColor 
+                              : Colors.grey.shade600,
+                          shape: RoundedRectangleBorder(
+                            side: BorderSide(
+                              color: _isEditMode ? Colors.grey.shade300 : Colors.transparent,
+                            ),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          onSelected: (bool selected) {
+                            setState(() {
+                              selected ? _selectedAllergies.add(allergy) : _selectedAllergies.remove(allergy);
+                            });
+                          },
+                        );
+                      }).toList(),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 40),
+
+                if (_isEditMode)
+                  Row(
+                    children: [
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: _cancelEdit,
+                          style: OutlinedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(vertical: 18),
+                            side: BorderSide(color: Colors.grey.shade400),
+                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                          ),
+                          child: const Text('취소', style: TextStyle(fontSize: 16, color: Colors.grey, fontWeight: FontWeight.bold)),
+                        ),
+                      ),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: ElevatedButton(
+                          onPressed: _saveProfile,
+                          child: const Text('변경사항 저장', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                        ),
+                      ),
+                    ],
+                  ),
+                const SizedBox(height: 20),
+              ],
+            ),
           ),
         ),
       ),
@@ -189,10 +324,10 @@ class _MyPageScreenState extends State<MyPageScreen> {
 
   Widget _buildSectionTitle(String title) {
     return Padding(
-      padding: const EdgeInsets.only(bottom: 16.0),
+      padding: const EdgeInsets.only(bottom: 12.0),
       child: Text(
         title,
-        style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Theme.of(context).primaryColor),
+        style: TextStyle(fontSize: 18, fontWeight: FontWeight.w900, color: Theme.of(context).primaryColor),
       ),
     );
   }
@@ -200,9 +335,19 @@ class _MyPageScreenState extends State<MyPageScreen> {
   Widget _buildTextField(TextEditingController controller, String label, {String? suffix, bool isNumber = true}) {
     return TextFormField(
       controller: controller,
-      keyboardType: isNumber ? TextInputType.number : TextInputType.text,
-      decoration: InputDecoration(labelText: label, suffixText: suffix),
-      validator: (v) => (v == null || v.isEmpty) ? '필수 입력 항목입니다.' : null,
+      readOnly: !_isEditMode,
+      keyboardType: isNumber ? const TextInputType.numberWithOptions(decimal: true) : TextInputType.text,
+      decoration: InputDecoration(
+        labelText: label,
+        suffixText: suffix,
+        filled: true,
+        fillColor: _isEditMode ? Colors.white : Colors.grey.shade100,
+      ),
+      validator: (value) {
+        if (value == null || value.isEmpty) return '필수 입력 항목입니다.';
+        if (isNumber && double.tryParse(value) == null) return '숫자만 입력';
+        return null;
+      },
     );
   }
 }

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+
+class MyPageScreen extends StatefulWidget {
+  const MyPageScreen({super.key});
+
+  @override
+  State<MyPageScreen> createState() => _MyPageScreenState();
+}
+
+class _MyPageScreenState extends State<MyPageScreen> {
+  final _formKey = GlobalKey<FormState>();
+
+  // 1. 기본 정보 컨트롤러
+  final TextEditingController _nicknameController = TextEditingController(text: "김철수"); // 초기값 예시
+  String? _selectedGender = '남성';
+
+  // 2. 인바디 정보 컨트롤러
+  final TextEditingController _heightController = TextEditingController(text: "175");
+  final TextEditingController _weightController = TextEditingController(text: "70");
+  final TextEditingController _muscleController = TextEditingController(text: "35");
+  final TextEditingController _fatController = TextEditingController(text: "15");
+  final TextEditingController _bmrController = TextEditingController(text: "1600");
+  final TextEditingController _inbodyScoreController = TextEditingController(text: "80");
+
+  // 3. 식습관 및 예산 컨트롤러
+  final TextEditingController _budgetController = TextEditingController(text: "8000");
+  String _selectedVegType = 'NONE';
+  double _spicyLevel = 3;
+
+  // 4. 알레르기 정보
+  final Set<String> _selectedAllergies = {'우유', '밀가루'}; // 초기값 예시
+  final List<String> _allergyOptions = ['땅콩', '갑각류', '대두', '우유', '밀가루', '계란', '견과류', '생선'];
+  final Map<String, String> _vegOptions = {
+    'NONE': '해당 없음',
+    'VEGAN': '비건 (완전 채식)',
+    'LACTO': '락토 (우유 허용)',
+    'OVO': '오보 (계란 허용)',
+    'PESCO': '페스코 (해산물 허용)'
+  };
+
+  @override
+  void dispose() {
+    _nicknameController.dispose();
+    _heightController.dispose();
+    _weightController.dispose();
+    _muscleController.dispose();
+    _fatController.dispose();
+    _bmrController.dispose();
+    _inbodyScoreController.dispose();
+    _budgetController.dispose();
+    super.dispose();
+  }
+
+  // 수정된 정보 저장 로직
+  void _saveProfile() {
+    if (_formKey.currentState!.validate()) {
+      final updatedData = {
+        'nickname': _nicknameController.text,
+        'gender': _selectedGender,
+        'health': {
+          'height': _heightController.text,
+          'weight': _weightController.text,
+          'muscle': _muscleController.text,
+          'fat': _fatController.text,
+          'bmr': _bmrController.text,
+          'score': _inbodyScoreController.text,
+        },
+        'preference': {
+          'budget': _budgetController.text,
+          'vegType': _selectedVegType,
+          'spicy': _spicyLevel.toInt(),
+        },
+        'allergies': _selectedAllergies.toList(),
+      };
+
+      print('수정된 프로필 데이터: $updatedData');
+      
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('프로필 정보가 수정되었습니다.')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('마이페이지', style: TextStyle(fontWeight: FontWeight.bold)),
+        centerTitle: true,
+        elevation: 0,
+        actions: [
+          TextButton(
+            onPressed: _saveProfile,
+            child: const Text('저장', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+          ),
+        ],
+      ),
+      body: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(20.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildSectionTitle('기본 정보 수정'),
+              _buildTextField(_nicknameController, '닉네임', isNumber: false),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<String>(
+                decoration: const InputDecoration(labelText: '성별'),
+                value: _selectedGender,
+                items: ['남성', '여성'].map((s) => DropdownMenuItem(value: s, child: Text(s))).toList(),
+                onChanged: (v) => setState(() => _selectedGender = v),
+              ),
+              const SizedBox(height: 32),
+
+              _buildSectionTitle('인바디 정보 수정'),
+              Row(
+                children: [
+                  Expanded(child: _buildTextField(_heightController, '키', suffix: 'cm')),
+                  const SizedBox(width: 12),
+                  Expanded(child: _buildTextField(_weightController, '몸무게', suffix: 'kg')),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(child: _buildTextField(_muscleController, '골격근량', suffix: 'kg')),
+                  const SizedBox(width: 12),
+                  Expanded(child: _buildTextField(_fatController, '체지방률', suffix: '%')),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(child: _buildTextField(_bmrController, '기초대사량', suffix: 'kcal')),
+                  const SizedBox(width: 12),
+                  Expanded(child: _buildTextField(_inbodyScoreController, '인바디 점수', suffix: '점')),
+                ],
+              ),
+              const SizedBox(height: 32),
+
+              _buildSectionTitle('식습관 및 예산 수정'),
+              _buildTextField(_budgetController, '끼니당 예산', suffix: '원'),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<String>(
+                decoration: const InputDecoration(labelText: '채식 유형'),
+                value: _selectedVegType,
+                items: _vegOptions.entries.map((e) => DropdownMenuItem(value: e.key, child: Text(e.value))).toList(),
+                onChanged: (v) => setState(() => _selectedVegType = v!),
+              ),
+              const SizedBox(height: 16),
+              Text('매운맛 선호도 (${_spicyLevel.toInt()}단계)', style: const TextStyle(fontWeight: FontWeight.w500)),
+              Slider(
+                value: _spicyLevel,
+                min: 1, max: 5, divisions: 4,
+                onChanged: (v) => setState(() => _spicyLevel = v),
+              ),
+              const SizedBox(height: 32),
+
+              _buildSectionTitle('알레르기 정보 수정'),
+              Wrap(
+                spacing: 8,
+                children: _allergyOptions.map((allergy) {
+                  final isSelected = _selectedAllergies.contains(allergy);
+                  return FilterChip(
+                    label: Text(allergy),
+                    selected: isSelected,
+                    onSelected: (bool selected) {
+                      setState(() {
+                        selected ? _selectedAllergies.add(allergy) : _selectedAllergies.remove(allergy);
+                      });
+                    },
+                  );
+                }).toList(),
+              ),
+              const SizedBox(height: 40),
+              
+              ElevatedButton(
+                onPressed: _saveProfile,
+                child: const Text('수정완료', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+              ),
+              const SizedBox(height: 20),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSectionTitle(String title) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16.0),
+      child: Text(
+        title,
+        style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Theme.of(context).primaryColor),
+      ),
+    );
+  }
+
+  Widget _buildTextField(TextEditingController controller, String label, {String? suffix, bool isNumber = true}) {
+    return TextFormField(
+      controller: controller,
+      keyboardType: isNumber ? TextInputType.number : TextInputType.text,
+      decoration: InputDecoration(labelText: label, suffixText: suffix),
+      validator: (v) => (v == null || v.isEmpty) ? '필수 입력 항목입니다.' : null,
+    );
+  }
+}

--- a/flutter_app/lib/screens/onboarding_screen.dart
+++ b/flutter_app/lib/screens/onboarding_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'main_screen.dart'; 
 
 class OnboardingScreen extends StatefulWidget {
   const OnboardingScreen({super.key});
@@ -10,31 +11,27 @@ class OnboardingScreen extends StatefulWidget {
 class _OnboardingScreenState extends State<OnboardingScreen> {
   final _formKey = GlobalKey<FormState>();
 
-  // 1. users 테이블 정보
+  // 1. 기본 정보 컨트롤러
   final TextEditingController _nicknameController = TextEditingController();
+  String _selectedGender = '남성';
 
-  // 2. user_health_profiles 테이블 정보 (인바디)
-  final TextEditingController _heightController = TextEditingController(); 
-  final TextEditingController _weightController = TextEditingController(); 
-  final TextEditingController _muscleController = TextEditingController(); 
-  final TextEditingController _fatController = TextEditingController(); 
-  final TextEditingController _bmrController = TextEditingController(); 
-  final TextEditingController _inbodyScoreController = TextEditingController(); 
+  // 2. 인바디 정보 컨트롤러
+  final TextEditingController _heightController = TextEditingController();
+  final TextEditingController _weightController = TextEditingController();
+  final TextEditingController _muscleController = TextEditingController();
+  final TextEditingController _fatController = TextEditingController();
+  final TextEditingController _bmrController = TextEditingController();
+  final TextEditingController _inbodyScoreController = TextEditingController();
 
-  // 3. user_preferences 테이블 정보 (예산)
-  final TextEditingController _budgetController = TextEditingController(); 
+  // 3. 식습관 및 예산 컨트롤러
+  final TextEditingController _budgetController = TextEditingController();
+  String _selectedVegType = 'NONE';
+  double _spicyLevel = 3;
 
-  // 식습관 및 취향 상태 관리
-  String _selectedVegType = 'NONE'; 
-  double _spicyLevel = 3; 
-  
-  // 성별 선택 관리
-  String? _selectedGender;
-  
-  // 알레르기 다중 선택 (user_allergies 테이블 매핑용)
+  // 4. 알레르기 정보
   final Set<String> _selectedAllergies = {};
   
-  // DB 도메인에 맞춘 마스터 데이터 옵션
+  final List<String> _allergyOptions = ['땅콩', '갑각류', '대두', '우유', '밀가루', '계란', '견과류', '생선'];
   final Map<String, String> _vegOptions = {
     'NONE': '해당 없음',
     'VEGAN': '비건 (완전 채식)',
@@ -42,8 +39,6 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     'OVO': '오보 (계란 허용)',
     'PESCO': '페스코 (해산물 허용)'
   };
-  
-  final List<String> _allergyOptions = ['땅콩', '갑각류', '대두', '우유', '밀가루', '계란', '견과류', '생선'];
 
   @override
   void dispose() {
@@ -58,36 +53,41 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     super.dispose();
   }
 
-  void _submitForm() {
+  // 💡 정보 저장 및 대시보드로 이동
+  void _finishOnboarding() {
     if (_formKey.currentState!.validate()) {
-      final Map<String, dynamic> requestData = {
-        'user': {
-          'nickname': _nicknameController.text,
-          'gender': _selectedGender == '남성' ? 'MALE' : 'FEMALE',
-        },
-        'health_profile': {
+      // 1. 수집된 데이터를 백엔드로 보낼 JSON 형태로 정리 (마이페이지와 동일한 구조)
+      final initialData = {
+        'nickname': _nicknameController.text,
+        'gender': _selectedGender,
+        'health': {
           'height': double.parse(_heightController.text),
           'weight': double.parse(_weightController.text),
-          'skeletal_muscle_mass': double.parse(_muscleController.text),
-          'body_fat_percentage': double.parse(_fatController.text),
+          'muscle': double.parse(_muscleController.text),
+          'fat': double.parse(_fatController.text),
           'bmr': int.parse(_bmrController.text),
-          'inbody_score': int.parse(_inbodyScoreController.text),
+          'score': int.parse(_inbodyScoreController.text),
         },
         'preference': {
-          'meal_budget': int.parse(_budgetController.text),
-          'vegetarian_type': _selectedVegType,
-          'spicy_preference': _spicyLevel.toInt(),
+          'budget': int.parse(_budgetController.text),
+          'vegType': _selectedVegType,
+          'spicy': _spicyLevel.toInt(),
         },
         'allergies': _selectedAllergies.toList(),
       };
 
-      print('서버로 전송될 통합 데이터: $requestData');
+      print('서버로 전송될 초기 가입 데이터: $initialData');
+      // TODO: 백엔드 API (POST /api/v1/users/profile) 호출 로직 추가
 
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('맞춤 추천을 위한 설정이 완료되었습니다!')),
+      // 2. 대시보드로 이동 (뒤로 가기 방지)
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => const MainScreen()),
       );
-
-      // TODO: 저장 완료 후 홈 화면 이동 로직 추가
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('입력하지 않은 필수 항목이 있습니다.')),
+      );
     }
   }
 
@@ -95,118 +95,82 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('프로필 및 설정', style: TextStyle(fontWeight: FontWeight.bold)),
-        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        elevation: 0,
+        title: const Text('기초 정보 입력', style: TextStyle(fontWeight: FontWeight.bold)),
         centerTitle: true,
+        elevation: 0,
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       ),
       body: SafeArea(
         child: Form(
           key: _formKey,
           child: SingleChildScrollView(
-            padding: const EdgeInsets.all(20.0),
+            padding: const EdgeInsets.all(24.0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                _buildSectionHeader('1. 기본 정보'),
-                _buildTextField(
-                  controller: _nicknameController,
-                  label: '닉네임',
-                  validatorMsg: '닉네임을 입력하세요',
-                  isNumber: false,
+                const Text(
+                  'NUTRI Agent에 오신 것을 환영합니다!\nAI가 완벽한 맞춤 식단을 추천해 드릴 수 있도록\n아래 정보를 정확하게 입력해 주세요.',
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, height: 1.5),
                 ),
+                const SizedBox(height: 32),
+
+                _buildSectionTitle('1. 기본 정보'),
+                _buildTextField(_nicknameController, '닉네임', hint: '예: 준용', isNumber: false),
                 const SizedBox(height: 16),
-                
                 DropdownButtonFormField<String>(
-                  decoration: const InputDecoration(labelText: '성별'),
+                  decoration: const InputDecoration(labelText: '성별', filled: true, fillColor: Colors.white),
                   value: _selectedGender,
-                  items: ['남성', '여성'].map((String value) {
-                    return DropdownMenuItem<String>(
-                      value: value,
-                      child: Text(value),
-                    );
-                  }).toList(),
-                  onChanged: (newValue) {
-                    setState(() {
-                      _selectedGender = newValue;
-                    });
-                  },
-                  validator: (value) => value == null ? '성별을 선택해주세요' : null,
+                  onChanged: (v) => setState(() => _selectedGender = v!),
+                  items: ['남성', '여성'].map((s) => DropdownMenuItem(value: s, child: Text(s))).toList(),
                 ),
+                const SizedBox(height: 32),
 
-                const SizedBox(height: 30),
-
-                _buildSectionHeader('2. 체성분 (InBody) 정보'),
+                _buildSectionTitle('2. 체성분 (InBody) 정보'),
                 Row(
                   children: [
-                    Expanded(child: _buildTextField(controller: _heightController, label: '키', suffixText: 'cm', validatorMsg: '입력 요망')),
-                    const SizedBox(width: 16),
-                    Expanded(child: _buildTextField(controller: _weightController, label: '몸무게', suffixText: 'kg', validatorMsg: '입력 요망')),
+                    Expanded(child: _buildTextField(_heightController, '키', suffix: 'cm', hint: '175')),
+                    const SizedBox(width: 12),
+                    Expanded(child: _buildTextField(_weightController, '몸무게', suffix: 'kg', hint: '70')),
                   ],
                 ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(child: _buildTextField(_muscleController, '골격근량', suffix: 'kg', hint: '35')),
+                    const SizedBox(width: 12),
+                    Expanded(child: _buildTextField(_fatController, '체지방률', suffix: '%', hint: '15')),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(child: _buildTextField(_bmrController, '기초대사량', suffix: 'kcal', hint: '1600')),
+                    const SizedBox(width: 12),
+                    Expanded(child: _buildTextField(_inbodyScoreController, '인바디 점수', suffix: '점', hint: '80')),
+                  ],
+                ),
+                const SizedBox(height: 32),
+
+                _buildSectionTitle('3. 식습관 및 예산 설정'),
+                _buildTextField(_budgetController, '끼니당 허용 예산', suffix: '원', hint: '8000'),
                 const SizedBox(height: 16),
-                Row(
-                  children: [
-                    Expanded(child: _buildTextField(controller: _muscleController, label: '골격근량', suffixText: 'kg', validatorMsg: '입력 요망')),
-                    const SizedBox(width: 16),
-                    Expanded(child: _buildTextField(controller: _fatController, label: '체지방률', suffixText: '%', validatorMsg: '입력 요망')),
-                  ],
-                ),
-                const SizedBox(height: 16),
-                Row(
-                  children: [
-                    Expanded(child: _buildTextField(controller: _bmrController, label: '기초대사량', suffixText: 'kcal', validatorMsg: '입력 요망')),
-                    const SizedBox(width: 16),
-                    Expanded(child: _buildTextField(controller: _inbodyScoreController, label: '인바디 점수', suffixText: '점', validatorMsg: '입력 요망')),
-                  ],
-                ),
-                const SizedBox(height: 30),
-
-                _buildSectionHeader('3. 식습관 및 예산 설정'),
-                _buildTextField(
-                  controller: _budgetController,
-                  label: '끼니당 허용 예산',
-                  suffixText: '원',
-                  validatorMsg: '예산을 입력하세요 (예: 8000)',
-                ),
-                const SizedBox(height: 20),
-
-                const Text('채식주의 단계 (Vegetarian Type)', style: TextStyle(fontWeight: FontWeight.bold)),
-                const SizedBox(height: 8),
                 DropdownButtonFormField<String>(
-                  decoration: const InputDecoration(labelText: '채식 유형 선택'),
+                  decoration: const InputDecoration(labelText: '채식 유형 선택', filled: true, fillColor: Colors.white),
                   value: _selectedVegType,
-                  items: _vegOptions.entries.map((entry) {
-                    return DropdownMenuItem<String>(
-                      value: entry.key,
-                      child: Text(entry.value),
-                    );
-                  }).toList(),
-                  onChanged: (newValue) {
-                    setState(() {
-                      _selectedVegType = newValue!;
-                    });
-                  },
+                  onChanged: (v) => setState(() => _selectedVegType = v!),
+                  items: _vegOptions.entries.map((e) => DropdownMenuItem(value: e.key, child: Text(e.value))).toList(),
                 ),
                 const SizedBox(height: 24),
-
-                const Text('매운맛 선호도 (1: 진라면 순한맛 ~ 5: 불닭볶음면)', style: TextStyle(fontWeight: FontWeight.bold)),
+                Text('매운맛 선호도 (${_spicyLevel.toInt()}단계)', style: const TextStyle(fontWeight: FontWeight.bold)),
                 Slider(
                   value: _spicyLevel,
-                  min: 1,
-                  max: 5,
-                  divisions: 4,
-                  label: _spicyLevel.toInt().toString(),
+                  min: 1, max: 5, divisions: 4,
                   activeColor: Theme.of(context).primaryColor,
-                  onChanged: (double value) {
-                    setState(() {
-                      _spicyLevel = value;
-                    });
-                  },
+                  onChanged: (v) => setState(() => _spicyLevel = v),
                 ),
-                const SizedBox(height: 30),
+                const SizedBox(height: 32),
 
-                _buildSectionHeader('4. 알레르기 유발 물질 (다중 선택)'),
+                _buildSectionTitle('4. 알레르기 유발 물질 (해당 시 선택)'),
                 Wrap(
                   spacing: 8.0,
                   runSpacing: 8.0,
@@ -217,29 +181,29 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                       selected: isSelected,
                       selectedColor: Theme.of(context).primaryColor.withOpacity(0.2),
                       checkmarkColor: Theme.of(context).primaryColor,
+                      shape: RoundedRectangleBorder(
+                        side: BorderSide(color: isSelected ? Theme.of(context).primaryColor : Colors.grey.shade300),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
                       onSelected: (bool selected) {
                         setState(() {
-                          if (selected) {
-                            _selectedAllergies.add(allergy);
-                          } else {
-                            _selectedAllergies.remove(allergy);
-                          }
+                          selected ? _selectedAllergies.add(allergy) : _selectedAllergies.remove(allergy);
                         });
                       },
                     );
                   }).toList(),
                 ),
-                const SizedBox(height: 40),
+                const SizedBox(height: 48),
 
-                // 최종 제출 버튼
-                SizedBox(
-                  width: double.infinity,
-                  child: ElevatedButton(
-                    onPressed: _submitForm,
-                    child: const Text('가입 및 설정 완료', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                ElevatedButton(
+                  onPressed: _finishOnboarding,
+                  style: ElevatedButton.styleFrom(
+                    minimumSize: const Size(double.infinity, 56),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
                   ),
+                  child: const Text('정보 저장하고 시작하기', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
                 ),
-                const SizedBox(height: 30),
+                const SizedBox(height: 20),
               ],
             ),
           ),
@@ -248,44 +212,30 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     );
   }
 
-  // 섹션 제목 위젯
-  Widget _buildSectionHeader(String title) {
+  Widget _buildSectionTitle(String title) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 12.0),
       child: Text(
         title,
-        style: TextStyle(
-          fontSize: 18,
-          fontWeight: FontWeight.w900,
-          color: Theme.of(context).primaryColor,
-        ),
+        style: TextStyle(fontSize: 18, fontWeight: FontWeight.w900, color: Theme.of(context).primaryColor),
       ),
     );
   }
 
-  // 텍스트 필드 공통 생성기 (숫자/문자 겸용)
-  // suffixText를 선택적 파라미터로 변경 --> 닉네임 입력 시 빈 문자열을 넣지 않아도 됨
-  Widget _buildTextField({
-    required TextEditingController controller,
-    required String label,
-    String? suffixText, 
-    required String validatorMsg,
-    bool isNumber = true,
-  }) {
+  Widget _buildTextField(TextEditingController controller, String label, {String? suffix, String? hint, bool isNumber = true}) {
     return TextFormField(
       controller: controller,
       keyboardType: isNumber ? const TextInputType.numberWithOptions(decimal: true) : TextInputType.text,
       decoration: InputDecoration(
         labelText: label,
-        suffixText: suffixText,
+        hintText: hint,
+        suffixText: suffix,
+        filled: true,
+        fillColor: Colors.white,
       ),
       validator: (value) {
-        if (value == null || value.isEmpty) {
-          return validatorMsg;
-        }
-        if (isNumber && double.tryParse(value) == null) {
-          return '숫자만 입력';
-        }
+        if (value == null || value.isEmpty) return '필수 입력 항목입니다.';
+        if (isNumber && double.tryParse(value) == null) return '숫자만 입력해 주세요.';
         return null;
       },
     );


### PR DESCRIPTION
마이페이지에서 사용자의 정보를 수정할 수 있도록 UI를 구성하였습니다
앱 시작 후 진행 순서를 로그인 -> 설문(기본정보입력) -> 대시보드 순서로 설정하였습니다.

TODO
1. 로그인 된 사용자는 대시보드에서 시작
2. 마이페이지의 사용자 정보를 DB에서 읽어오기
3. 마이페이지 수정 사항을 DB에 반영하기