### PR TITLE
feat: 마이페이지 열람 및 수정 구현

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/entity/Allergy.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/entity/Allergy.java
@@ -2,9 +2,14 @@ package capstone.ai_meal_assistant_backend.domain.menu.entity;
 
 import capstone.ai_meal_assistant_backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Table(name = "allergies")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Allergy extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/entity/UserAllergy.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/entity/UserAllergy.java
@@ -3,7 +3,14 @@ package capstone.ai_meal_assistant_backend.domain.menu.entity;
 import capstone.ai_meal_assistant_backend.domain.user.entity.User;
 import capstone.ai_meal_assistant_backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.*;
 
+@Entity
+@Table(name = "user_allergies")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class UserAllergy extends BaseEntity {
 
     @Id

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/AllergyRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/AllergyRepository.java
@@ -1,0 +1,12 @@
+package capstone.ai_meal_assistant_backend.domain.menu.repository;
+
+import capstone.ai_meal_assistant_backend.domain.menu.entity.Allergy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AllergyRepository extends JpaRepository<Allergy, Long> {
+    Optional<Allergy> findByName(String name);
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/UserAllergyRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/UserAllergyRepository.java
@@ -1,0 +1,14 @@
+package capstone.ai_meal_assistant_backend.domain.menu.repository;
+
+import capstone.ai_meal_assistant_backend.domain.menu.entity.UserAllergy;
+import capstone.ai_meal_assistant_backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface UserAllergyRepository extends JpaRepository<UserAllergy, Long> {
+    List<UserAllergy> findByUser(User user);
+    void deleteByUser(User user);
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/UserProfileController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/UserProfileController.java
@@ -3,6 +3,9 @@ package capstone.ai_meal_assistant_backend.domain.user.controller;
 import capstone.ai_meal_assistant_backend.domain.user.dto.UserProfileRequest;
 import capstone.ai_meal_assistant_backend.domain.user.dto.UserProfileResponse;
 import capstone.ai_meal_assistant_backend.domain.user.service.UserProfileService;
+import capstone.ai_meal_assistant_backend.global.security.JwtUtil;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +16,23 @@ import org.springframework.web.bind.annotation.*;
 public class UserProfileController {
 
     private final UserProfileService userProfileService;
+    private final JwtUtil jwtUtil;
+
+    @Getter
+    @AllArgsConstructor
+    private static class ApiResponse<T> {
+        private boolean success;
+        private T data;
+        private String error;
+
+        static <T> ApiResponse<T> ok(T data) {
+            return new ApiResponse<>(true, data, null);
+        }
+
+        static <T> ApiResponse<T> fail(String error) {
+            return new ApiResponse<>(false, null, error);
+        }
+    }
 
     /**
      * 사용자 프로필 저장 또는 수정
@@ -21,30 +41,48 @@ public class UserProfileController {
      * - 알러지 정보
      */
     @PostMapping("/profile")
-    public ResponseEntity<UserProfileResponse> saveProfile(
-            @RequestParam Long userId,
+    public ResponseEntity<ApiResponse<UserProfileResponse>> saveProfile(
+            @RequestHeader("Authorization") String authHeader,
             @RequestBody UserProfileRequest request) {
-        UserProfileResponse response = userProfileService.saveOrUpdateProfile(userId, request);
-        return ResponseEntity.ok(response);
+
+        String email = extractEmailFromToken(authHeader);
+        UserProfileResponse response = userProfileService.saveOrUpdateProfile(email, request);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
     /**
      * 사용자 프로필 수정 (PUT 방식)
      */
     @PutMapping("/profile")
-    public ResponseEntity<UserProfileResponse> updateProfile(
-            @RequestParam Long userId,
+    public ResponseEntity<ApiResponse<UserProfileResponse>> updateProfile(
+            @RequestHeader("Authorization") String authHeader,
             @RequestBody UserProfileRequest request) {
-        UserProfileResponse response = userProfileService.saveOrUpdateProfile(userId, request);
-        return ResponseEntity.ok(response);
+
+        String email = extractEmailFromToken(authHeader);
+        UserProfileResponse response = userProfileService.saveOrUpdateProfile(email, request);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
     /**
      * 사용자 프로필 조회
      */
     @GetMapping("/profile")
-    public ResponseEntity<UserProfileResponse> getProfile(@RequestParam Long userId) {
-        UserProfileResponse response = userProfileService.getProfile(userId);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<ApiResponse<UserProfileResponse>> getProfile(
+            @RequestHeader("Authorization") String authHeader) {
+
+        String email = extractEmailFromToken(authHeader);
+        UserProfileResponse response = userProfileService.getProfile(email);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    /**
+     * Authorization 헤더에서 이메일 추출
+     */
+    private String extractEmailFromToken(String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new IllegalArgumentException("유효하지 않은 인증 헤더입니다.");
+        }
+        String token = authHeader.substring(7);
+        return jwtUtil.getEmailFromToken(token);
     }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/UserProfileController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/UserProfileController.java
@@ -1,0 +1,50 @@
+package capstone.ai_meal_assistant_backend.domain.user.controller;
+
+import capstone.ai_meal_assistant_backend.domain.user.dto.UserProfileRequest;
+import capstone.ai_meal_assistant_backend.domain.user.dto.UserProfileResponse;
+import capstone.ai_meal_assistant_backend.domain.user.service.UserProfileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserProfileController {
+
+    private final UserProfileService userProfileService;
+
+    /**
+     * 사용자 프로필 저장 또는 수정
+     * - 인바디 정보
+     * - 음식 선호 정보
+     * - 알러지 정보
+     */
+    @PostMapping("/profile")
+    public ResponseEntity<UserProfileResponse> saveProfile(
+            @RequestParam Long userId,
+            @RequestBody UserProfileRequest request) {
+        UserProfileResponse response = userProfileService.saveOrUpdateProfile(userId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 사용자 프로필 수정 (PUT 방식)
+     */
+    @PutMapping("/profile")
+    public ResponseEntity<UserProfileResponse> updateProfile(
+            @RequestParam Long userId,
+            @RequestBody UserProfileRequest request) {
+        UserProfileResponse response = userProfileService.saveOrUpdateProfile(userId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 사용자 프로필 조회
+     */
+    @GetMapping("/profile")
+    public ResponseEntity<UserProfileResponse> getProfile(@RequestParam Long userId) {
+        UserProfileResponse response = userProfileService.getProfile(userId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/SignupRequest.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/SignupRequest.java
@@ -1,7 +1,9 @@
 package capstone.ai_meal_assistant_backend.domain.user.dto;
 
+import capstone.ai_meal_assistant_backend.domain.user.entity.Gender;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +23,9 @@ public class SignupRequest {
     @NotBlank(message = "닉네임은 필수입니다")
     @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하여야 합니다")
     private String nickname;
+
+    @NotNull(message = "성별은 필수입니다")
+    private Gender gender;
     
     // role은 백엔드에서 기본값 USER로 설정
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/UserProfileRequest.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/UserProfileRequest.java
@@ -1,5 +1,6 @@
 package capstone.ai_meal_assistant_backend.domain.user.dto;
 
+import capstone.ai_meal_assistant_backend.domain.user.entity.Gender;
 import capstone.ai_meal_assistant_backend.domain.user.entity.ProteinLevel;
 import capstone.ai_meal_assistant_backend.domain.user.entity.VegetarianType;
 import lombok.AllArgsConstructor;
@@ -13,6 +14,10 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserProfileRequest {
+    // 온보딩에서는 보내지 않고 마이페이지에서 수정할 때만 보내야됩니다
+    private String nickname;
+    private Gender gender;
+
     // 건강 정보 (인바디)
     private Double height;
     private Double weight;
@@ -31,4 +36,6 @@ public class UserProfileRequest {
 
     // 알러지 정보 (이름 리스트)
     private List<String> allergies;
+
+
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/UserProfileRequest.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/UserProfileRequest.java
@@ -1,0 +1,34 @@
+package capstone.ai_meal_assistant_backend.domain.user.dto;
+
+import capstone.ai_meal_assistant_backend.domain.user.entity.ProteinLevel;
+import capstone.ai_meal_assistant_backend.domain.user.entity.VegetarianType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileRequest {
+    // 건강 정보 (인바디)
+    private Double height;
+    private Double weight;
+    private Double skeletalMuscleMass;
+    private Double bodyFatPercentage;
+    private Double bmi;
+    private Integer bmr;
+    private Integer inbodyScore;
+    private LocalDate measurementDate;
+
+    // 선호 정보
+    private Integer mealBudget;
+    private VegetarianType vegetarianType;
+    private Integer spicyPreference;
+    private ProteinLevel proteinLevel;
+
+    // 알러지 정보 (이름 리스트)
+    private List<String> allergies;
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/UserProfileResponse.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/UserProfileResponse.java
@@ -1,5 +1,6 @@
 package capstone.ai_meal_assistant_backend.domain.user.dto;
 
+import capstone.ai_meal_assistant_backend.domain.user.entity.Gender;
 import capstone.ai_meal_assistant_backend.domain.user.entity.ProteinLevel;
 import capstone.ai_meal_assistant_backend.domain.user.entity.VegetarianType;
 import lombok.AllArgsConstructor;
@@ -15,6 +16,11 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class UserProfileResponse {
+    
+    // 유저 기본 정보 (마이페이지 화면 표시용)
+    private String nickname;
+    private Gender gender;
+
     // 건강 정보 (인바디)
     private Double height;
     private Double weight;

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/UserProfileResponse.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/UserProfileResponse.java
@@ -1,0 +1,36 @@
+package capstone.ai_meal_assistant_backend.domain.user.dto;
+
+import capstone.ai_meal_assistant_backend.domain.user.entity.ProteinLevel;
+import capstone.ai_meal_assistant_backend.domain.user.entity.VegetarianType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserProfileResponse {
+    // 건강 정보 (인바디)
+    private Double height;
+    private Double weight;
+    private Double skeletalMuscleMass;
+    private Double bodyFatPercentage;
+    private Double bmi;
+    private Integer bmr;
+    private Integer inbodyScore;
+    private LocalDate measurementDate;
+
+    // 선호 정보
+    private Integer mealBudget;
+    private VegetarianType vegetarianType;
+    private Integer spicyPreference;
+    private ProteinLevel proteinLevel;
+
+    // 알러지 정보 (이름 리스트)
+    private List<String> allergies;
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/Gender.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/Gender.java
@@ -1,0 +1,4 @@
+package capstone.ai_meal_assistant_backend.domain.user.entity;
+
+public enum Gender {
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/Gender.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/Gender.java
@@ -1,4 +1,30 @@
 package capstone.ai_meal_assistant_backend.domain.user.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.stream.Stream;
+
+@Getter
+@RequiredArgsConstructor
 public enum Gender {
+    MALE("남성"),
+    FEMALE("여성");
+
+    private final String description;
+
+    @JsonValue // 응답 나갈 때 "남성"으로 나감
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonCreator // 요청 들어올 때 "남성" 또는 "MALE"을 Gender.MALE로 바꿈
+    public static Gender from(String value) {
+        return Stream.of(Gender.values())
+                .filter(gender -> gender.description.equals(value) || gender.name().equalsIgnoreCase(value))
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/User.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/User.java
@@ -18,23 +18,31 @@ public class User extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String email;
 
-    private String password; // OAuth 가입자는 비밀번호가 없을 수 있으므로 nullable
+    private String password;
 
     @Column(nullable = false)
     private String nickname;
 
+    // --- 추가된 성별 필드 ---
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Role role; // enum Role { USER, ADMIN }
+    private Gender gender;
 
-    // --- OAuth 추가 부분 ---
-    private String provider; // 예: kakao, google
-    private String providerId; // 소셜 로그인 고유 식별자
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
 
-    // --- 양방향 매핑 (필요시 사용, 기본적으로는 단방향 추천) ---
+    private String provider;
+    private String providerId;
+
     @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private UserHealthProfile healthProfile;
 
     @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private UserPreference preference;
+
+    public void updateNicknameAndGender(String nickname, Gender gender) {
+        this.nickname = nickname;
+        this.gender = gender;
+    }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/UserHealthProfile.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/UserHealthProfile.java
@@ -2,11 +2,16 @@ package capstone.ai_meal_assistant_backend.domain.user.entity;
 
 import capstone.ai_meal_assistant_backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.*;
 
 import java.time.LocalDate;
 
 @Entity
 @Table(name = "user_health_profiles")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class UserHealthProfile extends BaseEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,4 +30,17 @@ public class UserHealthProfile extends BaseEntity{
     private Integer bmr; // 기초대사량
     private Integer inbodyScore; // 인바디 점수
     private LocalDate measurementDate; // 측정 날짜
+
+    public void updateProfile(Double height, Double weight, Double skeletalMuscleMass,
+                            Double bodyFatPercentage, Double bmi, Integer bmr,
+                            Integer inbodyScore, LocalDate measurementDate) {
+        this.height = height;
+        this.weight = weight;
+        this.skeletalMuscleMass = skeletalMuscleMass;
+        this.bodyFatPercentage = bodyFatPercentage;
+        this.bmi = bmi;
+        this.bmr = bmr;
+        this.inbodyScore = inbodyScore;
+        this.measurementDate = measurementDate;
+    }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/UserPreference.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/UserPreference.java
@@ -2,9 +2,14 @@ package capstone.ai_meal_assistant_backend.domain.user.entity;
 
 import capstone.ai_meal_assistant_backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Table(name = "user_preferences")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class UserPreference extends BaseEntity {
 
     @Id
@@ -25,4 +30,11 @@ public class UserPreference extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ProteinLevel proteinLevel; // enum { LOW, NORMAL, HIGH } (단백질 단계)
 
+    public void updatePreference(Integer mealBudget, VegetarianType vegetarianType,
+                               Integer spicyPreference, ProteinLevel proteinLevel) {
+        this.mealBudget = mealBudget;
+        this.vegetarianType = vegetarianType;
+        this.spicyPreference = spicyPreference;
+        this.proteinLevel = proteinLevel;
+    }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/repository/UserHealthProfileRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/repository/UserHealthProfileRepository.java
@@ -1,0 +1,14 @@
+package capstone.ai_meal_assistant_backend.domain.user.repository;
+
+import capstone.ai_meal_assistant_backend.domain.user.entity.User;
+import capstone.ai_meal_assistant_backend.domain.user.entity.UserHealthProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserHealthProfileRepository extends JpaRepository<UserHealthProfile, Long> {
+    Optional<UserHealthProfile> findByUser(User user);
+    void deleteByUser(User user);
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/repository/UserPreferenceRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/repository/UserPreferenceRepository.java
@@ -1,0 +1,14 @@
+package capstone.ai_meal_assistant_backend.domain.user.repository;
+
+import capstone.ai_meal_assistant_backend.domain.user.entity.User;
+import capstone.ai_meal_assistant_backend.domain.user.entity.UserPreference;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserPreferenceRepository extends JpaRepository<UserPreference, Long> {
+    Optional<UserPreference> findByUser(User user);
+    void deleteByUser(User user);
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthService.java
@@ -33,6 +33,7 @@ public class AuthService {
                     .email(request.getEmail())
                     .password(passwordEncoder.encode(request.getPassword()))
                     .nickname(request.getNickname())
+                    .gender(request.getGender())
                     .role(Role.USER) // 기본값 USER
                     .provider("local") // 직접 회원가입
                     .build();

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/UserProfileService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/UserProfileService.java
@@ -31,9 +31,15 @@ public class UserProfileService {
     private final UserAllergyRepository userAllergyRepository;
 
     @Transactional
-    public UserProfileResponse saveOrUpdateProfile(Long userId, UserProfileRequest request) {
-        User user = userRepository.findById(userId)
+    public UserProfileResponse saveOrUpdateProfile(String email, UserProfileRequest request) {
+        User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // 온보딩 때는 null이 들어오겠지만, 엔티티 내부에 방어막이 있어서 DB가 터지지 않음.
+        // 마이페이지 수정 때는 값이 들어오므로 정상적으로 업데이트됨
+        if (request.getNickname() != null || request.getGender() != null) {
+            user.updateNicknameAndGender(request.getNickname(), request.getGender());
+        } 
 
         // 1. 건강 정보 저장/수정
         UserHealthProfile healthProfile = healthProfileRepository.findByUser(user)
@@ -119,8 +125,8 @@ public class UserProfileService {
         return buildProfileResponse(user);
     }
 
-    public UserProfileResponse getProfile(Long userId) {
-        User user = userRepository.findById(userId)
+    public UserProfileResponse getProfile(String email) {
+        User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
         return buildProfileResponse(user);
@@ -140,6 +146,8 @@ public class UserProfileService {
                 .collect(Collectors.toList());
 
         return UserProfileResponse.builder()
+                .nickname(user.getNickname()) // 응답에는 유저의 기존 닉네임과 성별을 담아서 줌
+                .gender(user.getGender())
                 .height(healthProfile != null ? healthProfile.getHeight() : null)
                 .weight(healthProfile != null ? healthProfile.getWeight() : null)
                 .skeletalMuscleMass(healthProfile != null ? healthProfile.getSkeletalMuscleMass() : null)

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/UserProfileService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/UserProfileService.java
@@ -1,0 +1,158 @@
+package capstone.ai_meal_assistant_backend.domain.user.service;
+
+import capstone.ai_meal_assistant_backend.domain.menu.entity.Allergy;
+import capstone.ai_meal_assistant_backend.domain.menu.entity.UserAllergy;
+import capstone.ai_meal_assistant_backend.domain.menu.repository.AllergyRepository;
+import capstone.ai_meal_assistant_backend.domain.menu.repository.UserAllergyRepository;
+import capstone.ai_meal_assistant_backend.domain.user.dto.UserProfileRequest;
+import capstone.ai_meal_assistant_backend.domain.user.dto.UserProfileResponse;
+import capstone.ai_meal_assistant_backend.domain.user.entity.User;
+import capstone.ai_meal_assistant_backend.domain.user.entity.UserHealthProfile;
+import capstone.ai_meal_assistant_backend.domain.user.entity.UserPreference;
+import capstone.ai_meal_assistant_backend.domain.user.repository.UserHealthProfileRepository;
+import capstone.ai_meal_assistant_backend.domain.user.repository.UserPreferenceRepository;
+import capstone.ai_meal_assistant_backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserProfileService {
+
+    private final UserRepository userRepository;
+    private final UserHealthProfileRepository healthProfileRepository;
+    private final UserPreferenceRepository preferenceRepository;
+    private final AllergyRepository allergyRepository;
+    private final UserAllergyRepository userAllergyRepository;
+
+    @Transactional
+    public UserProfileResponse saveOrUpdateProfile(Long userId, UserProfileRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // 1. 건강 정보 저장/수정
+        UserHealthProfile healthProfile = healthProfileRepository.findByUser(user)
+                .orElse(null);
+
+        if (healthProfile == null) {
+            // 새로 생성
+            healthProfile = UserHealthProfile.builder()
+                    .user(user)
+                    .height(request.getHeight())
+                    .weight(request.getWeight())
+                    .skeletalMuscleMass(request.getSkeletalMuscleMass())
+                    .bodyFatPercentage(request.getBodyFatPercentage())
+                    .bmi(request.getBmi())
+                    .bmr(request.getBmr())
+                    .inbodyScore(request.getInbodyScore())
+                    .measurementDate(request.getMeasurementDate())
+                    .build();
+            healthProfileRepository.save(healthProfile);
+        } else {
+            // 기존 데이터 수정
+            healthProfile.updateProfile(
+                    request.getHeight(),
+                    request.getWeight(),
+                    request.getSkeletalMuscleMass(),
+                    request.getBodyFatPercentage(),
+                    request.getBmi(),
+                    request.getBmr(),
+                    request.getInbodyScore(),
+                    request.getMeasurementDate()
+            );
+        }
+
+        // 2. 선호 정보 저장/수정
+        UserPreference preference = preferenceRepository.findByUser(user)
+                .orElse(null);
+
+        if (preference == null) {
+            // 새로 생성
+            preference = UserPreference.builder()
+                    .user(user)
+                    .mealBudget(request.getMealBudget())
+                    .vegetarianType(request.getVegetarianType())
+                    .spicyPreference(request.getSpicyPreference())
+                    .proteinLevel(request.getProteinLevel())
+                    .build();
+            preferenceRepository.save(preference);
+        } else {
+            // 기존 데이터 수정
+            preference.updatePreference(
+                    request.getMealBudget(),
+                    request.getVegetarianType(),
+                    request.getSpicyPreference(),
+                    request.getProteinLevel()
+            );
+        }
+
+        // 3. 알러지 정보 저장/수정
+        // 기존 알러지 정보 삭제
+        userAllergyRepository.deleteByUser(user);
+
+        // 새로운 알러지 정보 저장
+        if (request.getAllergies() != null && !request.getAllergies().isEmpty()) {
+            for (String allergyName : request.getAllergies()) {
+                // 알러지가 DB에 없으면 생성, 있으면 조회
+                Allergy allergy = allergyRepository.findByName(allergyName)
+                        .orElseGet(() -> allergyRepository.save(
+                                Allergy.builder()
+                                        .name(allergyName)
+                                        .build()
+                        ));
+
+                // UserAllergy 생성
+                UserAllergy userAllergy = UserAllergy.builder()
+                        .user(user)
+                        .allergy(allergy)
+                        .build();
+                userAllergyRepository.save(userAllergy);
+            }
+        }
+
+        // 4. 응답 생성
+        return buildProfileResponse(user);
+    }
+
+    public UserProfileResponse getProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        return buildProfileResponse(user);
+    }
+
+    private UserProfileResponse buildProfileResponse(User user) {
+        // 건강 정보 조회
+        UserHealthProfile healthProfile = healthProfileRepository.findByUser(user).orElse(null);
+
+        // 선호 정보 조회
+        UserPreference preference = preferenceRepository.findByUser(user).orElse(null);
+
+        // 알러지 정보 조회
+        List<String> allergies = userAllergyRepository.findByUser(user)
+                .stream()
+                .map(userAllergy -> userAllergy.getAllergy().getName())
+                .collect(Collectors.toList());
+
+        return UserProfileResponse.builder()
+                .height(healthProfile != null ? healthProfile.getHeight() : null)
+                .weight(healthProfile != null ? healthProfile.getWeight() : null)
+                .skeletalMuscleMass(healthProfile != null ? healthProfile.getSkeletalMuscleMass() : null)
+                .bodyFatPercentage(healthProfile != null ? healthProfile.getBodyFatPercentage() : null)
+                .bmi(healthProfile != null ? healthProfile.getBmi() : null)
+                .bmr(healthProfile != null ? healthProfile.getBmr() : null)
+                .inbodyScore(healthProfile != null ? healthProfile.getInbodyScore() : null)
+                .measurementDate(healthProfile != null ? healthProfile.getMeasurementDate() : null)
+                .mealBudget(preference != null ? preference.getMealBudget() : null)
+                .vegetarianType(preference != null ? preference.getVegetarianType() : null)
+                .spicyPreference(preference != null ? preference.getSpicyPreference() : null)
+                .proteinLevel(preference != null ? preference.getProteinLevel() : null)
+                .allergies(allergies)
+                .build();
+    }
+}

--- a/flutter_app/lib/models/auth_models.dart
+++ b/flutter_app/lib/models/auth_models.dart
@@ -98,12 +98,14 @@ class User {
   final int? id;
   final String email;
   final String nickname;
+  final String? gender;
   final String? role;
 
   User({
     this.id,
     required this.email,
     required this.nickname,
+  this.gender,
     this.role,
   });
 
@@ -112,6 +114,7 @@ class User {
       id: json['id'],
       email: json['email'],
       nickname: json['nickname'],
+  gender: json['gender'],
       role: json['role'],
     );
   }

--- a/flutter_app/lib/models/user_profile_models.dart
+++ b/flutter_app/lib/models/user_profile_models.dart
@@ -1,0 +1,145 @@
+// 사용자 프로필(인바디/선호/알러지) 관련 모델
+
+class UserProfileRequest {
+  final String? nickname;
+  final String? gender;
+  final double? height;
+  final double? weight;
+  final double? skeletalMuscleMass;
+  final double? bodyFatPercentage;
+  final double? bmi;
+  final int? bmr;
+  final int? inbodyScore;
+  final String? measurementDate; // yyyy-MM-dd
+
+  final int? mealBudget;
+  final String? vegetarianType; // e.g. NONE, VEGAN...
+  final int? spicyPreference; // 1~5
+  final String? proteinLevel; // e.g. LOW, NORMAL, HIGH
+  final List<String>? allergies;
+
+  UserProfileRequest({
+    this.nickname,
+    this.gender,
+    this.height,
+    this.weight,
+    this.skeletalMuscleMass,
+    this.bodyFatPercentage,
+    this.bmi,
+    this.bmr,
+    this.inbodyScore,
+    this.measurementDate,
+    this.mealBudget,
+    this.vegetarianType,
+    this.spicyPreference,
+    this.proteinLevel,
+    this.allergies,
+  });
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = {};
+    if (nickname != null) data['nickname'] = nickname;
+    if (gender != null) data['gender'] = gender;
+    if (height != null) data['height'] = height;
+    if (weight != null) data['weight'] = weight;
+    if (skeletalMuscleMass != null) data['skeletalMuscleMass'] = skeletalMuscleMass;
+    if (bodyFatPercentage != null) data['bodyFatPercentage'] = bodyFatPercentage;
+    if (bmi != null) data['bmi'] = bmi;
+    if (bmr != null) data['bmr'] = bmr;
+    if (inbodyScore != null) data['inbodyScore'] = inbodyScore;
+    if (measurementDate != null) data['measurementDate'] = measurementDate;
+    if (mealBudget != null) data['mealBudget'] = mealBudget;
+    if (vegetarianType != null) data['vegetarianType'] = vegetarianType;
+    if (spicyPreference != null) data['spicyPreference'] = spicyPreference;
+    if (proteinLevel != null) data['proteinLevel'] = proteinLevel;
+    if (allergies != null) data['allergies'] = allergies;
+    return data;
+  }
+}
+
+class UserProfileResponse {
+  final bool success;
+  final String? message;
+  final UserProfileData? data;
+  final String? error;
+
+  const UserProfileResponse({
+    required this.success,
+    this.message,
+    this.data,
+    this.error,
+  });
+
+  factory UserProfileResponse.fromJson(Map<String, dynamic> json) {
+    return UserProfileResponse(
+      success: json['success'] ?? false,
+      message: json['message'],
+      data: json['data'] != null ? UserProfileData.fromJson(json['data']) : null,
+      error: json['error'],
+    );
+  }
+}
+
+class UserProfileData {
+  final int? userId;
+
+  // 기본 정보
+  final String? nickname;
+  final String? gender;
+
+  final double? height;
+  final double? weight;
+  final double? skeletalMuscleMass;
+  final double? bodyFatPercentage;
+  final double? bmi;
+  final int? bmr;
+  final int? inbodyScore;
+  final String? measurementDate;
+
+  final int? mealBudget;
+  final String? vegetarianType;
+  final int? spicyPreference;
+  final String? proteinLevel;
+
+  final List<String> allergies;
+
+  const UserProfileData({
+    this.userId,
+  this.nickname,
+  this.gender,
+    this.height,
+    this.weight,
+    this.skeletalMuscleMass,
+    this.bodyFatPercentage,
+    this.bmi,
+    this.bmr,
+    this.inbodyScore,
+    this.measurementDate,
+    this.mealBudget,
+    this.vegetarianType,
+    this.spicyPreference,
+    this.proteinLevel,
+    this.allergies = const [],
+  });
+
+  factory UserProfileData.fromJson(Map<String, dynamic> json) {
+    return UserProfileData(
+      userId: json['userId'],
+  nickname: json['nickname'],
+  gender: json['gender']?.toString(),
+      height: (json['height'] as num?)?.toDouble(),
+      weight: (json['weight'] as num?)?.toDouble(),
+      skeletalMuscleMass: (json['skeletalMuscleMass'] as num?)?.toDouble(),
+      bodyFatPercentage: (json['bodyFatPercentage'] as num?)?.toDouble(),
+      bmi: (json['bmi'] as num?)?.toDouble(),
+      bmr: json['bmr'],
+      inbodyScore: json['inbodyScore'],
+      measurementDate: json['measurementDate'],
+      mealBudget: json['mealBudget'],
+      vegetarianType: json['vegetarianType'],
+      spicyPreference: json['spicyPreference'],
+      proteinLevel: json['proteinLevel'],
+      allergies: (json['allergies'] as List?)?.map((e) => e.toString()).toList() ?? const [],
+    );
+  }
+}

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_app/models/user_profile_models.dart';
+import 'package:flutter_app/services/user_profile_service.dart';
+import 'package:flutter_app/services/token_storage.dart';
 
 class MyPageScreen extends StatefulWidget {
   const MyPageScreen({super.key});
@@ -10,43 +13,166 @@ class MyPageScreen extends StatefulWidget {
 class _MyPageScreenState extends State<MyPageScreen> {
   final _formKey = GlobalKey<FormState>();
   bool _isEditMode = false;
+  bool _isLoading = false;
 
   // 1. 기본 정보
-  final TextEditingController _nicknameController = TextEditingController(text: "김철수");
+  final TextEditingController _nicknameController = TextEditingController(
+    text: "김철수",
+  );
   String? _selectedGender = '남성';
 
   // 2. 인바디 정보
-  final TextEditingController _heightController = TextEditingController(text: "175");
-  final TextEditingController _weightController = TextEditingController(text: "70");
-  final TextEditingController _muscleController = TextEditingController(text: "35");
-  final TextEditingController _fatController = TextEditingController(text: "15");
-  final TextEditingController _bmrController = TextEditingController(text: "1600");
-  final TextEditingController _inbodyScoreController = TextEditingController(text: "80");
+  final TextEditingController _heightController = TextEditingController(
+    text: "175",
+  );
+  final TextEditingController _weightController = TextEditingController(
+    text: "70",
+  );
+  final TextEditingController _muscleController = TextEditingController(
+    text: "35",
+  );
+  final TextEditingController _fatController = TextEditingController(
+    text: "15",
+  );
+  final TextEditingController _bmrController = TextEditingController(
+    text: "1600",
+  );
+  final TextEditingController _inbodyScoreController = TextEditingController(
+    text: "80",
+  );
 
   // 3. 식습관 및 예산
-  final TextEditingController _budgetController = TextEditingController(text: "8000");
+  final TextEditingController _budgetController = TextEditingController(
+    text: "8000",
+  );
   String _selectedVegType = 'NONE';
   double _spicyLevel = 3;
 
   // 4. 알레르기 정보
   Set<String> _selectedAllergies = {'우유', '밀가루'};
-  
-  final List<String> _allergyOptions = ['땅콩', '갑각류', '대두', '우유', '밀가루', '계란', '견과류', '생선'];
+
+  final List<String> _allergyOptions = [
+    '땅콩',
+    '갑각류',
+    '대두',
+    '우유',
+    '밀가루',
+    '계란',
+    '견과류',
+    '생선',
+  ];
   final Map<String, String> _vegOptions = {
     'NONE': '해당 없음',
     'VEGAN': '비건 (완전 채식)',
     'LACTO': '락토 (우유 허용)',
     'OVO': '오보 (계란 허용)',
-    'PESCO': '페스코 (해산물 허용)'
+    'PESCO': '페스코 (해산물 허용)',
   };
 
   // 취소 버튼을 위한 데이터 백업 저장소
   late String _bkNickname;
   late String? _bkGender;
-  late String _bkHeight, _bkWeight, _bkMuscle, _bkFat, _bkBmr, _bkScore, _bkBudget;
+  late String _bkHeight,
+      _bkWeight,
+      _bkMuscle,
+      _bkFat,
+      _bkBmr,
+      _bkScore,
+      _bkBudget;
   late String _bkVegType;
   late double _bkSpicy;
   late Set<String> _bkAllergies;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadProfile();
+    _loadBasicUserInfoFromLocal();
+  }
+
+  Future<void> _loadBasicUserInfoFromLocal() async {
+    try {
+  final nickname = await TokenStorage.getUserNickname();
+      final gender = await TokenStorage.getGender();
+
+      if (!mounted) return;
+      setState(() {
+        if (nickname != null && nickname.isNotEmpty) {
+          _nicknameController.text = nickname;
+        }
+        final normalizedGender = _normalizeGender(gender);
+        if (normalizedGender != null) {
+          _selectedGender = normalizedGender;
+        }
+      });
+    } catch (_) {
+      // 로컬 저장소 접근 실패는 조용히 무시
+    }
+  }
+
+  String? _normalizeGender(String? raw) {
+    if (raw == null) return null;
+    final v = raw.trim();
+
+    // 서버/로컬 값이 다양하게 올 수 있어서 UI 드롭다운 값으로 정규화
+    if (v == '남성' || v == 'M' || v.toLowerCase() == 'male') return '남성';
+    if (v == '여성' || v == 'F' || v.toLowerCase() == 'female') return '여성';
+
+    // 이미 '남자/여자'로 저장된 케이스도 흡수
+    if (v == '남자') return '남성';
+    if (v == '여자') return '여성';
+
+    return null;
+  }
+
+  Future<void> _loadProfile() async {
+    setState(() => _isLoading = true);
+    try {
+      final result = await UserProfileService.getProfile();
+      if (!mounted) return;
+      if (!result.success || result.data == null) {
+        // 서버가 아직 준비 안 된 경우를 고려해서 조용히 유지
+        return;
+      }
+      _applyProfileToForm(result.data!);
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  void _applyProfileToForm(UserProfileData data) {
+    if (data.nickname != null && data.nickname!.isNotEmpty) {
+      _nicknameController.text = data.nickname!;
+      // 서버 값이 최신이면 로컬에도 동기화
+      // ignore: discarded_futures
+  TokenStorage.saveNickname(data.nickname!);
+    }
+    final normalizedGender = _normalizeGender(data.gender);
+    if (normalizedGender != null) {
+      _selectedGender = normalizedGender;
+      // ignore: discarded_futures
+      TokenStorage.saveGender(normalizedGender);
+    }
+
+    _heightController.text = data.height?.toString() ?? _heightController.text;
+    _weightController.text = data.weight?.toString() ?? _weightController.text;
+    _muscleController.text =
+        data.skeletalMuscleMass?.toString() ?? _muscleController.text;
+    _fatController.text =
+        data.bodyFatPercentage?.toString() ?? _fatController.text;
+    _bmrController.text = data.bmr?.toString() ?? _bmrController.text;
+    _inbodyScoreController.text =
+        data.inbodyScore?.toString() ?? _inbodyScoreController.text;
+    _budgetController.text =
+        data.mealBudget?.toString() ?? _budgetController.text;
+    if (data.vegetarianType != null) {
+      _selectedVegType = data.vegetarianType!;
+    }
+    if (data.spicyPreference != null) {
+      _spicyLevel = data.spicyPreference!.toDouble();
+    }
+    _selectedAllergies = data.allergies.toSet();
+  }
 
   @override
   void dispose() {
@@ -100,50 +226,75 @@ class _MyPageScreenState extends State<MyPageScreen> {
       _isEditMode = false;
     });
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('수정이 취소되었습니다.')),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('수정이 취소되었습니다.')));
   }
 
   // 변경사항 저장하기
-  void _saveProfile() {
-    if (_formKey.currentState!.validate()) {
-      setState(() {
-        _isEditMode = false;
-      });
+  Future<void> _saveProfile() async {
+    if (_isLoading) return;
+    if (!_formKey.currentState!.validate()) return;
 
-      final updatedData = {
-        'nickname': _nicknameController.text,
-        'gender': _selectedGender,
-        'health': {
-          'height': double.parse(_heightController.text),
-          'weight': double.parse(_weightController.text),
-          'muscle': double.parse(_muscleController.text),
-          'fat': double.parse(_fatController.text),
-          'bmr': int.parse(_bmrController.text),
-          'score': int.parse(_inbodyScoreController.text),
-        },
-        'preference': {
-          'budget': int.parse(_budgetController.text),
-          'vegType': _selectedVegType,
-          'spicy': _spicyLevel.toInt(),
-        },
-        'allergies': _selectedAllergies.toList(),
-      };
-
-      print('서버로 전송될 (수정된) 데이터: $updatedData');
-
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('프로필 정보가 성공적으로 업데이트되었습니다!')),
+    setState(() => _isLoading = true);
+    try {
+      final request = UserProfileRequest(
+        nickname: _nicknameController.text,
+        gender: _mapGenderToApiValue(_selectedGender),
+        height: double.tryParse(_heightController.text),
+        weight: double.tryParse(_weightController.text),
+        skeletalMuscleMass: double.tryParse(_muscleController.text),
+        bodyFatPercentage: double.tryParse(_fatController.text),
+        bmr: int.tryParse(_bmrController.text),
+        inbodyScore: int.tryParse(_inbodyScoreController.text),
+        measurementDate: DateTime.now().toIso8601String().substring(0, 10),
+        mealBudget: int.tryParse(_budgetController.text),
+        vegetarianType: _selectedVegType,
+        spicyPreference: _spicyLevel.toInt(),
+        proteinLevel: 'NORMAL',
+        allergies: _selectedAllergies.toList(),
       );
+
+      final result = await UserProfileService.updateProfile(request: request);
+      if (!mounted) return;
+
+      if (!result.success) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(result.error ?? '프로필 저장에 실패했습니다.')),
+        );
+        return;
+      }
+
+      setState(() => _isEditMode = false);
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('프로필 정보가 성공적으로 업데이트되었습니다!')));
+      
+      // 로컬 닉네임/성별 정보도 업데이트
+      await TokenStorage.saveNickname(_nicknameController.text);
+      if (_selectedGender != null) {
+        await TokenStorage.saveGender(_selectedGender!);
+      }
+
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
     }
+  }
+
+  String? _mapGenderToApiValue(String? gender) {
+    if (gender == '남성') return 'MALE';
+    if (gender == '여성') return 'FEMALE';
+    return null;
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('마이페이지', style: TextStyle(fontWeight: FontWeight.bold)),
+        title: const Text(
+          '마이페이지',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
         centerTitle: true,
         elevation: 0,
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
@@ -153,7 +304,11 @@ class _MyPageScreenState extends State<MyPageScreen> {
               onPressed: _enableEditMode,
               child: Text(
                 '수정',
-                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16, color: Theme.of(context).primaryColor),
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16,
+                  color: Theme.of(context).primaryColor,
+                ),
               ),
             ),
         ],
@@ -173,36 +328,78 @@ class _MyPageScreenState extends State<MyPageScreen> {
                   decoration: InputDecoration(
                     labelText: '성별',
                     filled: true,
-                    fillColor: _isEditMode ? Colors.white : Colors.grey.shade100, 
+                    fillColor: _isEditMode
+                        ? Colors.white
+                        : Colors.grey.shade100,
                   ),
                   value: _selectedGender,
-                  onChanged: _isEditMode ? (v) => setState(() => _selectedGender = v!) : null,
-                  items: ['남성', '여성'].map((s) => DropdownMenuItem(value: s, child: Text(s))).toList(),
+                  onChanged: _isEditMode
+                      ? (v) => setState(() => _selectedGender = v!)
+                      : null,
+                  items: ['남성', '여성']
+                      .map((s) => DropdownMenuItem(value: s, child: Text(s)))
+                      .toList(),
                 ),
                 const SizedBox(height: 32),
 
                 _buildSectionTitle('2. 체성분 (InBody) 정보'),
                 Row(
                   children: [
-                    Expanded(child: _buildTextField(_heightController, '키', suffix: 'cm')),
+                    Expanded(
+                      child: _buildTextField(
+                        _heightController,
+                        '키',
+                        suffix: 'cm',
+                      ),
+                    ),
                     const SizedBox(width: 12),
-                    Expanded(child: _buildTextField(_weightController, '몸무게', suffix: 'kg')),
+                    Expanded(
+                      child: _buildTextField(
+                        _weightController,
+                        '몸무게',
+                        suffix: 'kg',
+                      ),
+                    ),
                   ],
                 ),
                 const SizedBox(height: 12),
                 Row(
                   children: [
-                    Expanded(child: _buildTextField(_muscleController, '골격근량', suffix: 'kg')),
+                    Expanded(
+                      child: _buildTextField(
+                        _muscleController,
+                        '골격근량',
+                        suffix: 'kg',
+                      ),
+                    ),
                     const SizedBox(width: 12),
-                    Expanded(child: _buildTextField(_fatController, '체지방률', suffix: '%')),
+                    Expanded(
+                      child: _buildTextField(
+                        _fatController,
+                        '체지방률',
+                        suffix: '%',
+                      ),
+                    ),
                   ],
                 ),
                 const SizedBox(height: 12),
                 Row(
                   children: [
-                    Expanded(child: _buildTextField(_bmrController, '기초대사량', suffix: 'kcal')),
+                    Expanded(
+                      child: _buildTextField(
+                        _bmrController,
+                        '기초대사량',
+                        suffix: 'kcal',
+                      ),
+                    ),
                     const SizedBox(width: 12),
-                    Expanded(child: _buildTextField(_inbodyScoreController, '인바디 점수', suffix: '점')),
+                    Expanded(
+                      child: _buildTextField(
+                        _inbodyScoreController,
+                        '인바디 점수',
+                        suffix: '점',
+                      ),
+                    ),
                   ],
                 ),
                 const SizedBox(height: 32),
@@ -214,25 +411,43 @@ class _MyPageScreenState extends State<MyPageScreen> {
                   decoration: InputDecoration(
                     labelText: '채식 유형 선택',
                     filled: true,
-                    fillColor: _isEditMode ? Colors.white : Colors.grey.shade100,
+                    fillColor: _isEditMode
+                        ? Colors.white
+                        : Colors.grey.shade100,
                   ),
                   value: _selectedVegType,
-                  onChanged: _isEditMode ? (v) => setState(() => _selectedVegType = v!) : null,
-                  items: _vegOptions.entries.map((e) => DropdownMenuItem(value: e.key, child: Text(e.value))).toList(),
+                  onChanged: _isEditMode
+                      ? (v) => setState(() => _selectedVegType = v!)
+                      : null,
+                  items: _vegOptions.entries
+                      .map(
+                        (e) => DropdownMenuItem(
+                          value: e.key,
+                          child: Text(e.value),
+                        ),
+                      )
+                      .toList(),
                 ),
                 const SizedBox(height: 24),
-                
+
                 Opacity(
                   opacity: _isEditMode ? 1.0 : 0.5,
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text('매운맛 선호도 (${_spicyLevel.toInt()}단계)', style: const TextStyle(fontWeight: FontWeight.bold)),
+                      Text(
+                        '매운맛 선호도 (${_spicyLevel.toInt()}단계)',
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
                       Slider(
                         value: _spicyLevel,
-                        min: 1, max: 5, divisions: 4,
+                        min: 1,
+                        max: 5,
+                        divisions: 4,
                         activeColor: Theme.of(context).primaryColor,
-                        onChanged: _isEditMode ? (v) => setState(() => _spicyLevel = v) : null,
+                        onChanged: _isEditMode
+                            ? (v) => setState(() => _spicyLevel = v)
+                            : null,
                       ),
                     ],
                   ),
@@ -244,9 +459,13 @@ class _MyPageScreenState extends State<MyPageScreen> {
                   width: double.infinity,
                   padding: EdgeInsets.all(_isEditMode ? 0 : 16.0),
                   decoration: BoxDecoration(
-                    color: _isEditMode ? Colors.transparent : Colors.grey.shade100,
+                    color: _isEditMode
+                        ? Colors.transparent
+                        : Colors.grey.shade100,
                     borderRadius: BorderRadius.circular(12),
-                    border: _isEditMode ? null : Border.all(color: Colors.grey.shade300),
+                    border: _isEditMode
+                        ? null
+                        : Border.all(color: Colors.grey.shade300),
                   ),
                   child: IgnorePointer(
                     ignoring: !_isEditMode,
@@ -260,27 +479,35 @@ class _MyPageScreenState extends State<MyPageScreen> {
                             allergy,
                             style: TextStyle(
                               // 텍스트 색상도 읽기 전용일 땐 회색으로 변경
-                              color: _isEditMode ? Colors.black87 : Colors.grey.shade600,
+                              color: _isEditMode
+                                  ? Colors.black87
+                                  : Colors.grey.shade600,
                             ),
                           ),
                           selected: isSelected,
                           // 핵심 수정: 배경색과 선택된 색상 모두 음영 처리
-                          backgroundColor: _isEditMode ? Colors.white : Colors.grey.shade200,
-                          selectedColor: _isEditMode 
-                              ? Theme.of(context).primaryColor.withOpacity(0.2) 
+                          backgroundColor: _isEditMode
+                              ? Colors.white
+                              : Colors.grey.shade200,
+                          selectedColor: _isEditMode
+                              ? Theme.of(context).primaryColor.withOpacity(0.2)
                               : Colors.grey.shade300,
-                          checkmarkColor: _isEditMode 
-                              ? Theme.of(context).primaryColor 
+                          checkmarkColor: _isEditMode
+                              ? Theme.of(context).primaryColor
                               : Colors.grey.shade600,
                           shape: RoundedRectangleBorder(
                             side: BorderSide(
-                              color: _isEditMode ? Colors.grey.shade300 : Colors.transparent,
+                              color: _isEditMode
+                                  ? Colors.grey.shade300
+                                  : Colors.transparent,
                             ),
                             borderRadius: BorderRadius.circular(8),
                           ),
                           onSelected: (bool selected) {
                             setState(() {
-                              selected ? _selectedAllergies.add(allergy) : _selectedAllergies.remove(allergy);
+                              selected
+                                  ? _selectedAllergies.add(allergy)
+                                  : _selectedAllergies.remove(allergy);
                             });
                           },
                         );
@@ -299,16 +526,31 @@ class _MyPageScreenState extends State<MyPageScreen> {
                           style: OutlinedButton.styleFrom(
                             padding: const EdgeInsets.symmetric(vertical: 18),
                             side: BorderSide(color: Colors.grey.shade400),
-                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
                           ),
-                          child: const Text('취소', style: TextStyle(fontSize: 16, color: Colors.grey, fontWeight: FontWeight.bold)),
+                          child: const Text(
+                            '취소',
+                            style: TextStyle(
+                              fontSize: 16,
+                              color: Colors.grey,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
                         ),
                       ),
                       const SizedBox(width: 16),
                       Expanded(
                         child: ElevatedButton(
                           onPressed: _saveProfile,
-                          child: const Text('변경사항 저장', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                          child: const Text(
+                            '변경사항 저장',
+                            style: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
                         ),
                       ),
                     ],
@@ -327,16 +569,27 @@ class _MyPageScreenState extends State<MyPageScreen> {
       padding: const EdgeInsets.only(bottom: 12.0),
       child: Text(
         title,
-        style: TextStyle(fontSize: 18, fontWeight: FontWeight.w900, color: Theme.of(context).primaryColor),
+        style: TextStyle(
+          fontSize: 18,
+          fontWeight: FontWeight.w900,
+          color: Theme.of(context).primaryColor,
+        ),
       ),
     );
   }
 
-  Widget _buildTextField(TextEditingController controller, String label, {String? suffix, bool isNumber = true}) {
+  Widget _buildTextField(
+    TextEditingController controller,
+    String label, {
+    String? suffix,
+    bool isNumber = true,
+  }) {
     return TextFormField(
       controller: controller,
-      readOnly: !_isEditMode,
-      keyboardType: isNumber ? const TextInputType.numberWithOptions(decimal: true) : TextInputType.text,
+      readOnly: !_isEditMode || _isLoading,
+      keyboardType: isNumber
+          ? const TextInputType.numberWithOptions(decimal: true)
+          : TextInputType.text,
       decoration: InputDecoration(
         labelText: label,
         suffixText: suffix,

--- a/flutter_app/lib/screens/onboarding_screen.dart
+++ b/flutter_app/lib/screens/onboarding_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'main_screen.dart'; 
+import 'package:flutter_app/models/user_profile_models.dart';
+import 'package:flutter_app/services/user_profile_service.dart';
 
 class OnboardingScreen extends StatefulWidget {
   const OnboardingScreen({super.key});
@@ -11,11 +13,9 @@ class OnboardingScreen extends StatefulWidget {
 class _OnboardingScreenState extends State<OnboardingScreen> {
   final _formKey = GlobalKey<FormState>();
 
-  // 1. 기본 정보 컨트롤러
-  final TextEditingController _nicknameController = TextEditingController();
-  String _selectedGender = '남성';
+  bool _isLoading = false;
 
-  // 2. 인바디 정보 컨트롤러
+  // 1. 인바디 정보 컨트롤러
   final TextEditingController _heightController = TextEditingController();
   final TextEditingController _weightController = TextEditingController();
   final TextEditingController _muscleController = TextEditingController();
@@ -23,12 +23,12 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   final TextEditingController _bmrController = TextEditingController();
   final TextEditingController _inbodyScoreController = TextEditingController();
 
-  // 3. 식습관 및 예산 컨트롤러
+  // 2. 식습관 및 예산 컨트롤러
   final TextEditingController _budgetController = TextEditingController();
   String _selectedVegType = 'NONE';
   double _spicyLevel = 3;
 
-  // 4. 알레르기 정보
+  // 3. 알레르기 정보
   final Set<String> _selectedAllergies = {};
   
   final List<String> _allergyOptions = ['땅콩', '갑각류', '대두', '우유', '밀가루', '계란', '견과류', '생선'];
@@ -42,7 +42,6 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
 
   @override
   void dispose() {
-    _nicknameController.dispose();
     _heightController.dispose();
     _weightController.dispose();
     _muscleController.dispose();
@@ -54,40 +53,51 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   }
 
   // 💡 정보 저장 및 대시보드로 이동
-  void _finishOnboarding() {
-    if (_formKey.currentState!.validate()) {
-      // 1. 수집된 데이터를 백엔드로 보낼 JSON 형태로 정리 (마이페이지와 동일한 구조)
-      final initialData = {
-        'nickname': _nicknameController.text,
-        'gender': _selectedGender,
-        'health': {
-          'height': double.parse(_heightController.text),
-          'weight': double.parse(_weightController.text),
-          'muscle': double.parse(_muscleController.text),
-          'fat': double.parse(_fatController.text),
-          'bmr': int.parse(_bmrController.text),
-          'score': int.parse(_inbodyScoreController.text),
-        },
-        'preference': {
-          'budget': int.parse(_budgetController.text),
-          'vegType': _selectedVegType,
-          'spicy': _spicyLevel.toInt(),
-        },
-        'allergies': _selectedAllergies.toList(),
-      };
+  Future<void> _finishOnboarding() async {
+    if (_isLoading) return;
 
-      print('서버로 전송될 초기 가입 데이터: $initialData');
-      // TODO: 백엔드 API (POST /api/v1/users/profile) 호출 로직 추가
+    if (!_formKey.currentState!.validate()) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('입력하지 않은 필수 항목이 있습니다.')),
+      );
+      return;
+    }
 
-      // 2. 대시보드로 이동 (뒤로 가기 방지)
+    setState(() => _isLoading = true);
+    try {
+      final request = UserProfileRequest(
+        height: double.tryParse(_heightController.text),
+        weight: double.tryParse(_weightController.text),
+        skeletalMuscleMass: double.tryParse(_muscleController.text),
+        bodyFatPercentage: double.tryParse(_fatController.text),
+        bmr: int.tryParse(_bmrController.text),
+        inbodyScore: int.tryParse(_inbodyScoreController.text),
+        measurementDate: DateTime.now().toIso8601String().substring(0, 10),
+        mealBudget: int.tryParse(_budgetController.text),
+        vegetarianType: _selectedVegType,
+        spicyPreference: _spicyLevel.toInt(),
+        proteinLevel: 'NORMAL',
+        allergies: _selectedAllergies.toList(),
+      );
+
+      final result = await UserProfileService.saveProfile(request: request);
+      if (!mounted) return;
+
+      if (!result.success) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(result.error ?? '프로필 저장에 실패했습니다.')),
+        );
+        return;
+      }
+
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(builder: (context) => const MainScreen()),
       );
-    } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('입력하지 않은 필수 항목이 있습니다.')),
-      );
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
     }
   }
 
@@ -114,18 +124,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                 ),
                 const SizedBox(height: 32),
 
-                _buildSectionTitle('1. 기본 정보'),
-                _buildTextField(_nicknameController, '닉네임', hint: '예: 준용', isNumber: false),
-                const SizedBox(height: 16),
-                DropdownButtonFormField<String>(
-                  decoration: const InputDecoration(labelText: '성별', filled: true, fillColor: Colors.white),
-                  value: _selectedGender,
-                  onChanged: (v) => setState(() => _selectedGender = v!),
-                  items: ['남성', '여성'].map((s) => DropdownMenuItem(value: s, child: Text(s))).toList(),
-                ),
-                const SizedBox(height: 32),
-
-                _buildSectionTitle('2. 체성분 (InBody) 정보'),
+                // 💡 기본 정보 섹션 완전 삭제, 인바디 정보부터 시작
+                _buildSectionTitle('1. 체성분 (InBody) 정보'),
                 Row(
                   children: [
                     Expanded(child: _buildTextField(_heightController, '키', suffix: 'cm', hint: '175')),
@@ -151,7 +151,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                 ),
                 const SizedBox(height: 32),
 
-                _buildSectionTitle('3. 식습관 및 예산 설정'),
+                _buildSectionTitle('2. 식습관 및 예산 설정'),
                 _buildTextField(_budgetController, '끼니당 허용 예산', suffix: '원', hint: '8000'),
                 const SizedBox(height: 16),
                 DropdownButtonFormField<String>(
@@ -170,7 +170,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                 ),
                 const SizedBox(height: 32),
 
-                _buildSectionTitle('4. 알레르기 유발 물질 (해당 시 선택)'),
+                _buildSectionTitle('3. 알레르기 유발 물질 (해당 시 선택)'),
                 Wrap(
                   spacing: 8.0,
                   runSpacing: 8.0,
@@ -196,12 +196,18 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                 const SizedBox(height: 48),
 
                 ElevatedButton(
-                  onPressed: _finishOnboarding,
+                  onPressed: _isLoading ? null : _finishOnboarding,
                   style: ElevatedButton.styleFrom(
                     minimumSize: const Size(double.infinity, 56),
                     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
                   ),
-                  child: const Text('정보 저장하고 시작하기', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                  child: _isLoading
+                      ? const SizedBox(
+                          height: 22,
+                          width: 22,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('정보 저장하고 시작하기', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
                 ),
                 const SizedBox(height: 20),
               ],

--- a/flutter_app/lib/screens/signup_screen.dart
+++ b/flutter_app/lib/screens/signup_screen.dart
@@ -17,6 +17,7 @@ class _SignupScreenState extends State<SignupScreen> {
   final TextEditingController _passwordController = TextEditingController();
   final TextEditingController _passwordConfirmController = TextEditingController();
   final TextEditingController _nicknameController = TextEditingController();
+  String? _selectedGender = '남성';
   bool _isLoading = false;
 
   void _submitSignup() async {
@@ -29,6 +30,7 @@ class _SignupScreenState extends State<SignupScreen> {
         email: _emailController.text,
         password: _passwordController.text,
         nickname: _nicknameController.text,
+  gender: _mapGenderToApiValue(_selectedGender),
       );
 
   if (!mounted) return;
@@ -133,6 +135,37 @@ class _SignupScreenState extends State<SignupScreen> {
                     return null;
                   },
                 ),
+                const SizedBox(height: 20),
+
+                DropdownButtonFormField<String>(
+                  decoration: InputDecoration(
+                    labelText: '성별',
+                    hintText: '성별을 선택해 주세요',
+                    filled: true,
+                    fillColor: Colors.grey.shade100,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: const BorderSide(
+                        color: Color(0xFF8CA384),
+                        width: 2,
+                      ),
+                    ),
+                  ),
+                  value: _selectedGender,
+                  onChanged: (v) => setState(() => _selectedGender = v),
+                  items: const [
+                    DropdownMenuItem(value: '남성', child: Text('남성')),
+                    DropdownMenuItem(value: '여성', child: Text('여성')),
+                  ],
+                  validator: (v) {
+                    if (v == null || v.isEmpty) return '성별을 선택해 주세요.';
+                    return null;
+                  },
+                ),
                 const SizedBox(height: 40),
 
                 ElevatedButton(
@@ -183,5 +216,13 @@ class _SignupScreenState extends State<SignupScreen> {
       ),
       validator: validator,
     );
+  }
+
+  String? _mapGenderToApiValue(String? uiGender) {
+    // 서버 enum(Gender) 컨벤션 추정: MALE/FEMALE
+    if (uiGender == null) return null;
+    if (uiGender == '남성') return 'MALE';
+    if (uiGender == '여성') return 'FEMALE';
+    return null;
   }
 }

--- a/flutter_app/lib/services/auth_service.dart
+++ b/flutter_app/lib/services/auth_service.dart
@@ -37,6 +37,10 @@ class AuthService {
       final jsonResponse = jsonDecode(response.body);
       final authResponse = AuthResponse.fromJson(jsonResponse);
 
+  // 디버깅: 서버 응답에 user.id가 포함되는지 확인
+  // ignore: avoid_print
+  print('[AuthService.login] status=${response.statusCode} body=${response.body}');
+
       // 성공 시 토큰 저장
       if (authResponse.success && authResponse.data?.accessToken != null) {
         await TokenStorage.saveTokens(
@@ -47,6 +51,8 @@ class AuthService {
           await TokenStorage.saveUserInfo(
             email: authResponse.data!.user!.email,
             nickname: authResponse.data!.user!.nickname,
+            gender: authResponse.data!.user!.gender,
+            userId: authResponse.data!.user!.id,
           );
         }
       }
@@ -65,6 +71,7 @@ class AuthService {
     required String email,
     required String password,
     required String nickname,
+    required String? gender,
   }) async {
     try {
       final url = Uri.parse('${ApiConfig.baseUrl}${ApiConfig.apiVersion}/auth/signup');
@@ -78,6 +85,7 @@ class AuthService {
           'email': email,
           'password': password,
           'nickname': nickname,
+          'gender': gender,
           'role': 'USER',
           'provider': null,
           'providerId': null,
@@ -90,6 +98,10 @@ class AuthService {
       final jsonResponse = jsonDecode(response.body);
       final authResponse = AuthResponse.fromJson(jsonResponse);
 
+  // 디버깅: 서버 응답에 user.id가 포함되는지 확인
+  // ignore: avoid_print
+  print('[AuthService.signup] status=${response.statusCode} body=${response.body}');
+
       // 성공 시 토큰 저장
       if (authResponse.success && authResponse.data?.accessToken != null) {
         await TokenStorage.saveTokens(
@@ -100,6 +112,8 @@ class AuthService {
           await TokenStorage.saveUserInfo(
             email: authResponse.data!.user!.email,
             nickname: authResponse.data!.user!.nickname,
+            gender: authResponse.data!.user!.gender,
+            userId: authResponse.data!.user!.id,
           );
         }
       }

--- a/flutter_app/lib/services/token_storage.dart
+++ b/flutter_app/lib/services/token_storage.dart
@@ -6,6 +6,8 @@ class TokenStorage {
   static const String _refreshTokenKey = 'refresh_token';
   static const String _userEmailKey = 'user_email';
   static const String _userNicknameKey = 'user_nickname';
+  static const String _userGenderKey = 'user_gender';
+  static const String _userIdKey = 'user_id';
 
   // 토큰 저장
   static Future<void> saveTokens({
@@ -23,10 +25,39 @@ class TokenStorage {
   static Future<void> saveUserInfo({
     required String email,
     required String nickname,
+    String? gender,
+    int? userId,
   }) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_userEmailKey, email);
     await prefs.setString(_userNicknameKey, nickname);
+    if (gender != null) {
+      await prefs.setString(_userGenderKey, gender);
+    }
+    if (userId != null) {
+      await prefs.setInt(_userIdKey, userId);
+    }
+  }
+
+  static Future<void> saveGender(String gender) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_userGenderKey, gender);
+  }
+
+  static Future<void> saveNickname(String nickname) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_userNicknameKey, nickname);
+  }
+
+  static Future<String?> getGender() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_userGenderKey);
+  }
+
+  // 사용자 ID 조회
+  static Future<int?> getUserId() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_userIdKey);
   }
 
   // Access Token 조회
@@ -60,6 +91,8 @@ class TokenStorage {
     await prefs.remove(_refreshTokenKey);
     await prefs.remove(_userEmailKey);
     await prefs.remove(_userNicknameKey);
+  await prefs.remove(_userGenderKey);
+  await prefs.remove(_userIdKey);
   }
 
   // 토큰 존재 여부 확인

--- a/flutter_app/lib/services/user_profile_service.dart
+++ b/flutter_app/lib/services/user_profile_service.dart
@@ -1,0 +1,110 @@
+import 'dart:convert';
+
+import 'package:flutter_app/models/user_profile_models.dart';
+import 'package:http/http.dart' as http;
+
+import 'auth_service.dart';
+import 'token_storage.dart';
+
+class UserProfileService {
+  // auth는 /api/v1을 쓰지만, profile은 백엔드 매핑이 /api/users/profile인 경우가 많아서 분리
+  // 필요하면 여기만 /api/v1 로 바꾸면 됨.
+  static const String _profileApiBasePath = '/api';
+
+  static Future<Map<String, String>> _defaultHeaders() async {
+    final headers = <String, String>{
+      'Content-Type': 'application/json',
+    };
+
+    final accessToken = await TokenStorage.getAccessToken();
+    if (accessToken != null && accessToken.isNotEmpty) {
+      headers['Authorization'] = 'Bearer $accessToken';
+    }
+
+    return headers;
+  }
+
+  static Uri _profileUriWithoutUserId() {
+    return Uri.parse('${ApiConfig.baseUrl}$_profileApiBasePath/users/profile');
+  }
+
+  static Future<UserProfileResponse> getProfile() async {
+    try {
+      final response = await http
+          .get(
+            _profileUriWithoutUserId(),
+            headers: await _defaultHeaders(),
+          )
+          .timeout(
+            const Duration(seconds: 10),
+            onTimeout: () => throw Exception('요청 시간 초과'),
+          );
+
+      if (response.body.isEmpty) {
+        return UserProfileResponse(
+          success: false,
+          error: '빈 응답을 받았습니다. status=${response.statusCode}',
+        );
+      }
+
+      final jsonResponse = jsonDecode(response.body);
+      return UserProfileResponse.fromJson(jsonResponse);
+    } catch (e) {
+      return UserProfileResponse(success: false, error: '프로필 조회 중 오류: $e');
+    }
+  }
+
+  static Future<UserProfileResponse> saveProfile({
+    required UserProfileRequest request,
+  }) async {
+    // Spring 스펙: POST /api/users/profile
+    return _upsertProfile(method: 'POST', request: request);
+  }
+
+  static Future<UserProfileResponse> updateProfile({
+    required UserProfileRequest request,
+  }) async {
+    // Spring 스펙: PUT /api/users/profile
+    return _upsertProfile(method: 'PUT', request: request);
+  }
+
+  static Future<UserProfileResponse> _upsertProfile({
+    required String method,
+    required UserProfileRequest request,
+  }) async {
+    try {
+      final uri = _profileUriWithoutUserId();
+
+      final headers = await _defaultHeaders();
+      final body = jsonEncode(request.toJson());
+
+  // 디버깅: 실제 호출되는 URL/헤더 여부 확인
+  // ignore: avoid_print
+  print('[UserProfileService] $method $uri hasAuth=${headers.containsKey('Authorization')}');
+
+      late http.Response response;
+      if (method == 'POST') {
+        response = await http.post(uri, headers: headers, body: body);
+      } else if (method == 'PUT') {
+        response = await http.put(uri, headers: headers, body: body);
+      } else {
+        throw Exception('지원하지 않는 method: $method');
+      }
+
+  // ignore: avoid_print
+  print('[UserProfileService] response status=${response.statusCode} body=${response.body}');
+
+      if (response.body.isEmpty) {
+        return UserProfileResponse(
+          success: false,
+          error: '빈 응답을 받았습니다. status=${response.statusCode}',
+        );
+      }
+
+      final jsonResponse = jsonDecode(response.body);
+      return UserProfileResponse.fromJson(jsonResponse);
+    } catch (e) {
+      return UserProfileResponse(success: false, error: '프로필 저장/수정 중 오류: $e');
+    }
+  }
+}


### PR DESCRIPTION
해당 브랜치에서 플러터와 스프링 데이터베이스를 모두 연동하였습니다. 기존 54번 브랜치는 무시하셔도 됩니다.

회원가입 시 닉네임과 성별을 입력받도록 수정함에 따라, 기존 온보딩 페이지 내 해당 입력란을 삭제하였습니다.
이전에는 온보딩과 마이페이지를 함께 구현했어서 기능 수정 중 일시적으로 데이터 누락 이슈가 있었으나, 현재는 모두 정상적으로 해결되었습니다. 변경 사항을 확인하신 후, 문제가 없다면 머지 부탁드립니다.

Flutter (Client-Side)
1. user_profile_models.dart
    * UserProfileRequest 모델에 nickname과 gender 필드를 추가하여 서버로 전송할 수 있도록 데이터 구조를 확장했습니다.
2. mypage_screen.dart
    * 마이페이지의 '저장' 버튼을 누를 때, 사용자가 수정한 nickname과 gender 값을 UserProfileRequest에 담아 서버로 전송하도록 _saveProfile 함수를 수정했습니다.
    * 서버 API 명세에 맞게 성별 값을 '남성'/'여성'에서 'MALE'/'FEMALE'로 변환하는 _mapGenderToApiValue 함수를 추가했습니다.
    * 프로필 업데이트 성공 시, 앱의 로컬 저장소(SharedPreferences)에 저장된 닉네임과 성별 정보도 함께 업데이트하여 데이터 일관성을 유지하도록 보완했습니다.
 
Spring Boot (Server-Side)
1. UserProfileRequest.java
    * 클라이언트가 보내는 nickname과 gender를 수신할 수 있도록 해당 DTO에 필드를 추가했습니다.
2. UserProfileService.java
    * saveOrUpdateProfile 메소드 내부에 닉네임과 성별을 업데이트하는 로직을 추가했습니다.
    * request.getNickname() 또는 request.getGender() 값이 존재할 경우에만 user.updateNicknameAndGender()를 호출하여 사용자 정보를 갱신합니다.
3. User.java
    * updateNicknameAndGender 메소드를 추가하여 nickname과 gender 필드를 안전하게 변경할 수 있는 로직을 구현했습니다. 이 메소드는 null이 아닌 값으로만 필드를 업데이트하여 기존 데이터가 실수로 삭제되는 것을 방지합니다.
