### PR TITLE
fix: 회원가입 직후 로그인 없이 앱 내부로 접근하는 로직 수정 (#62)

### DIFF
--- a/flutter_app/lib/screens/email_login_screen.dart
+++ b/flutter_app/lib/screens/email_login_screen.dart
@@ -2,9 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_app/services/auth_service.dart';
 import 'main_screen.dart';
 import 'package:flutter_app/theme.dart';
+import 'package:flutter_app/services/user_profile_service.dart';
+import 'onboarding_screen.dart';
 
 // 직접 로그인을 진행하는 페이지입니다. (소셜로그인X)
-
 class EmailLoginScreen extends StatefulWidget {
   const EmailLoginScreen({super.key});
 
@@ -18,12 +19,13 @@ class _EmailLoginScreenState extends State<EmailLoginScreen> {
   final TextEditingController _passwordController = TextEditingController();
   bool _isLoading = false;
 
-  void _submitLogin() async {
+    void _submitLogin() async {
     if (_formKey.currentState!.validate()) {
       setState(() {
         _isLoading = true;
       });
 
+      // 1. 로그인 API 호출 (이 안에서 토큰이 로컬에 저장됨)
       final response = await AuthService.login(
         email: _emailController.text,
         password: _passwordController.text,
@@ -31,21 +33,48 @@ class _EmailLoginScreenState extends State<EmailLoginScreen> {
 
       if (!mounted) return;
 
-      setState(() {
-        _isLoading = false;
-      });
-
       if (response.success) {
+        // 💡 2. 토큰이 저장되었으니, 프로필 정보를 찔러서 온보딩 필요 여부 확인
+        final profileResponse = await UserProfileService.getProfile();
+        
+        if (!mounted) return;
+        
+        setState(() {
+          _isLoading = false;
+        });
+
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('로그인 성공!')),
         );
-        // 로그인 성공 시 온보딩을 건너뛰고 바로 대시보드로 이동
-        Navigator.pushAndRemoveUntil(
-          context,
-          MaterialPageRoute(builder: (context) => const MainScreen()),
-          (route) => false, // 이전 로그인/가입 화면 라우팅 스택 모두 제거
-        );
+
+        // 💡 3. 필수 데이터(예: 키, 몸무게)가 없으면 온보딩 대상으로 간주
+        // 백엔드에서 아직 프로필이 안 만들어졌거나, height가 null인 경우
+        // 💡 키 값이 null이거나, 백엔드 초기값인 999(또는 999.0)인 경우 온보딩으로 보냅니다
+        bool needsOnboarding = profileResponse.data == null || 
+                              profileResponse.data?.height == null || 
+                              profileResponse.data?.height == 999 || 
+                              profileResponse.data?.height == 999.0;
+
+        if (needsOnboarding) {
+          // 첫 로그인 유저 -> 온보딩 화면으로 이동 (뒤로 가기 방지)
+          Navigator.pushAndRemoveUntil(
+            context,
+            MaterialPageRoute(builder: (context) => const OnboardingScreen()),
+            (route) => false,
+          );
+        } else {
+          // 기존 유저 -> 메인 대시보드로 이동 (뒤로 가기 방지)
+          Navigator.pushAndRemoveUntil(
+            context,
+            MaterialPageRoute(builder: (context) => const MainScreen()),
+            (route) => false,
+          );
+        }
       } else {
+        // 로그인 실패 시
+        setState(() {
+          _isLoading = false;
+        });
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(response.error ?? '로그인 실패했습니다.')),
         );

--- a/flutter_app/lib/screens/login_screen.dart
+++ b/flutter_app/lib/screens/login_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'signup_screen.dart';
 import 'email_login_screen.dart';
-import 'package:flutter_app/theme.dart'; // 💡 AppTheme 임포트 추가
+import 'package:flutter_app/theme.dart';
 
 // 직접 가입 or 소셜 로그인을 선택할 수 있는 페이지 입니다.
 class LoginScreen extends StatelessWidget {

--- a/flutter_app/lib/screens/signup_screen.dart
+++ b/flutter_app/lib/screens/signup_screen.dart
@@ -42,14 +42,18 @@ class _SignupScreenState extends State<SignupScreen> {
 
       if (response.success) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('회원가입 성공! 추가 정보를 입력해주세요.')),
+          const SnackBar(content: Text('회원가입 성공! 로그인을 진행해 주세요.')), // 문구 수정
         );
 
-        // 가입 성공 시 온보딩(기초 정보 입력) 페이지로 이동
+        // 가입 성공 시 로그인 화면으로
+        Navigator.pop(context); 
+        
+        /* 만약 pop()으로 안 되는 라우팅 구조라면 명시적으로 이동
         Navigator.pushReplacement(
           context,
-          MaterialPageRoute(builder: (context) => const OnboardingScreen()),
+          MaterialPageRoute(builder: (context) => const LoginScreen()),
         );
+        */
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(response.error ?? '회원가입 실패했습니다.')),


### PR DESCRIPTION
로그인이 스킵된 기존 로직을 수정하였습니다.

기존 로직 : 회원가입 -> 온보딩 페이지 -> 대시보드로 접근
변경 로직 : 회원가입 -> 초기 페이지(login page) -> 로그인 페이지(email_login_page) -> 온보딩 정보가 없는 첫 로그인인지 체크 -> 첫로그인이면 온보딩 페이지로 이동 -> 정보 입력 완료 시 대시보드로 접근