### PR TITLE
feat: AI 추천용 서버사이드 메뉴 필터링 구현 (#70)

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/controller/MenuCandidateController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/controller/MenuCandidateController.java
@@ -1,0 +1,60 @@
+package capstone.ai_meal_assistant_backend.domain.menu.controller;
+
+import capstone.ai_meal_assistant_backend.domain.menu.dto.MenuCandidateDto;
+import capstone.ai_meal_assistant_backend.domain.menu.service.MenuCandidateService;
+import capstone.ai_meal_assistant_backend.global.security.JwtUtil;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/menus")
+@RequiredArgsConstructor
+public class MenuCandidateController {
+
+    private final MenuCandidateService menuCandidateService;
+    private final JwtUtil jwtUtil;
+
+    @Getter
+    @AllArgsConstructor
+    private static class ApiResponse<T> {
+        private boolean success;
+        private T data;
+        private String error;
+
+        static <T> ApiResponse<T> ok(T data) {
+            return new ApiResponse<>(true, data, null);
+        }
+
+        static <T> ApiResponse<T> fail(String error) {
+            return new ApiResponse<>(false, null, error);
+        }
+    }
+
+    /**
+     * AI 추천용 메뉴 후보 25개 반환
+     * - 알레르기 메뉴 제외
+     * - 예산 필터
+     * - 단백질 수준 필터
+     * - 이후 fitnessGoal / foodPreferences 필드 병합 시 확장 예정
+     */
+    @GetMapping("/candidates")
+    public ResponseEntity<ApiResponse<List<MenuCandidateDto>>> getCandidates(
+            @RequestHeader("Authorization") String authHeader) {
+
+        String email = extractEmail(authHeader);
+        List<MenuCandidateDto> candidates = menuCandidateService.getCandidates(email);
+        return ResponseEntity.ok(ApiResponse.ok(candidates));
+    }
+
+    private String extractEmail(String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new IllegalArgumentException("유효하지 않은 인증 헤더입니다.");
+        }
+        return jwtUtil.getEmailFromToken(authHeader.substring(7));
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/dto/MenuCandidateDto.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/dto/MenuCandidateDto.java
@@ -1,0 +1,32 @@
+package capstone.ai_meal_assistant_backend.domain.menu.dto;
+
+import capstone.ai_meal_assistant_backend.domain.menu.entity.Menu;
+import lombok.Getter;
+
+@Getter
+public class MenuCandidateDto {
+
+    private final Long id;
+    private final String name;
+    private final String category;
+    private final Integer calories;
+    private final Double protein;
+    private final Double fat;
+    private final Double carbs;
+    private final Integer basePrice;
+
+    private MenuCandidateDto(Menu menu) {
+        this.id        = menu.getId();
+        this.name      = menu.getName();
+        this.category  = menu.getCategory();
+        this.calories  = menu.getCalories();
+        this.protein   = menu.getProtein();
+        this.fat       = menu.getFat();
+        this.carbs     = menu.getCarbs();
+        this.basePrice = menu.getBasePrice();
+    }
+
+    public static MenuCandidateDto from(Menu menu) {
+        return new MenuCandidateDto(menu);
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/entity/Menu.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/entity/Menu.java
@@ -1,9 +1,13 @@
 package capstone.ai_meal_assistant_backend.domain.menu.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "menus")
+@Getter
+@NoArgsConstructor
 public class Menu {
 
     @Id

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/entity/MenuAllergy.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/entity/MenuAllergy.java
@@ -2,9 +2,11 @@ package capstone.ai_meal_assistant_backend.domain.menu.entity;
 
 import capstone.ai_meal_assistant_backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
-//깃허브 설명서 작성을 위한 주석 추가
+import lombok.Getter;
+
 @Entity
 @Table(name = "menu_allergies")
+@Getter
 public class MenuAllergy extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/MenuAllergyRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/MenuAllergyRepository.java
@@ -1,0 +1,18 @@
+package capstone.ai_meal_assistant_backend.domain.menu.repository;
+
+import capstone.ai_meal_assistant_backend.domain.menu.entity.Allergy;
+import capstone.ai_meal_assistant_backend.domain.menu.entity.MenuAllergy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Set;
+
+@Repository
+public interface MenuAllergyRepository extends JpaRepository<MenuAllergy, Long> {
+
+    @Query("SELECT DISTINCT ma.menu.id FROM MenuAllergy ma WHERE ma.allergy IN :allergies")
+    Set<Long> findMenuIdsByAllergyIn(@Param("allergies") List<Allergy> allergies);
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/MenuRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/MenuRepository.java
@@ -1,0 +1,31 @@
+package capstone.ai_meal_assistant_backend.domain.menu.repository;
+
+import capstone.ai_meal_assistant_backend.domain.menu.entity.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Set;
+
+@Repository
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+
+    @Query(value = """
+            SELECT * FROM menus m
+            WHERE (:excludeIds IS NULL OR m.id NOT IN (:excludeIds))
+              AND (:budget   IS NULL OR m.base_price IS NULL OR m.base_price <= :budget)
+              AND (:minPro   IS NULL OR m.protein >= :minPro)
+              AND (:maxCal   IS NULL OR m.calories <= :maxCal)
+            ORDER BY RAND()
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<Menu> findCandidates(
+            @Param("excludeIds") Set<Long> excludeIds,
+            @Param("budget")     Integer budget,
+            @Param("minPro")     Double minProtein,
+            @Param("maxCal")     Integer maxCalories,
+            @Param("limit")      int limit
+    );
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/service/MenuCandidateService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/service/MenuCandidateService.java
@@ -1,0 +1,76 @@
+package capstone.ai_meal_assistant_backend.domain.menu.service;
+
+import capstone.ai_meal_assistant_backend.domain.menu.dto.MenuCandidateDto;
+import capstone.ai_meal_assistant_backend.domain.menu.entity.Allergy;
+import capstone.ai_meal_assistant_backend.domain.menu.entity.UserAllergy;
+import capstone.ai_meal_assistant_backend.domain.menu.repository.MenuAllergyRepository;
+import capstone.ai_meal_assistant_backend.domain.menu.repository.MenuRepository;
+import capstone.ai_meal_assistant_backend.domain.menu.repository.UserAllergyRepository;
+import capstone.ai_meal_assistant_backend.domain.user.entity.ProteinLevel;
+import capstone.ai_meal_assistant_backend.domain.user.entity.User;
+import capstone.ai_meal_assistant_backend.domain.user.entity.UserPreference;
+import capstone.ai_meal_assistant_backend.domain.user.repository.UserPreferenceRepository;
+import capstone.ai_meal_assistant_backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MenuCandidateService {
+
+    private static final int CANDIDATE_LIMIT = 25;
+
+    private final UserRepository userRepository;
+    private final UserPreferenceRepository preferenceRepository;
+    private final UserAllergyRepository userAllergyRepository;
+    private final MenuAllergyRepository menuAllergyRepository;
+    private final MenuRepository menuRepository;
+
+    public List<MenuCandidateDto> getCandidates(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        UserPreference pref = preferenceRepository.findByUser(user).orElse(null);
+
+        // 1. 사용자 알레르기 메뉴 ID 수집
+        Set<Long> excludeMenuIds = getExcludeMenuIds(user);
+
+        // 2. 선호 조건 추출
+        Integer budget     = pref != null ? pref.getMealBudget() : null;
+        Double  minProtein = resolveMinProtein(pref);
+        Integer maxCal     = null; // fitnessGoal 병합 후 확장 예정
+
+        // 3. 후보 조회 (DB에서 RAND() + LIMIT)
+        // 빈 Set은 NOT IN () → SQL 오류 발생. -1L은 실제 메뉴 ID와 겹치지 않으므로 안전한 더미값
+        Set<Long> queryExclude = excludeMenuIds.isEmpty() ? Set.of(-1L) : excludeMenuIds;
+        return menuRepository
+                .findCandidates(queryExclude, budget, minProtein, maxCal, CANDIDATE_LIMIT)
+                .stream()
+                .map(MenuCandidateDto::from)
+                .collect(Collectors.toList());
+    }
+
+    private Set<Long> getExcludeMenuIds(User user) {
+        List<Allergy> userAllergies = userAllergyRepository.findByUser(user)
+                .stream()
+                .map(UserAllergy::getAllergy)
+                .collect(Collectors.toList());
+
+        if (userAllergies.isEmpty()) return Collections.emptySet();
+        return menuAllergyRepository.findMenuIdsByAllergyIn(userAllergies);
+    }
+
+    // proteinLevel → 최소 단백질(g) 변환
+    private Double resolveMinProtein(UserPreference pref) {
+        if (pref == null || pref.getProteinLevel() == null) return null;
+        if (pref.getProteinLevel() == ProteinLevel.HIGH) return 25.0;
+        return null;
+    }
+}

--- a/ai_agent_app/.env.example
+++ b/ai_agent_app/.env.example
@@ -1,0 +1,3 @@
+# AI Agent 환경변수 예시 — .env 파일로 복사 후 실제 값 입력
+OPENROUTER_API_KEY=sk-or-v1-...
+BACKEND_URL=http://localhost:8080

--- a/ai_agent_app/MenuFetcher.py
+++ b/ai_agent_app/MenuFetcher.py
@@ -1,0 +1,32 @@
+import requests
+from typing import List, Dict
+
+
+class MenuFetcher:
+    """Spring 백엔드에서 사용자 맞춤 메뉴 후보를 가져오는 클래스."""
+
+    def __init__(self, backend_url: str):
+        self.backend_url = backend_url.rstrip("/")
+
+    def fetch_candidate_names(self, jwt_token: str) -> set:
+        """
+        Spring GET /api/menus/candidates 호출 후 메뉴명 집합 반환.
+        실패 시 빈 set 반환 (호출자가 fallback 처리).
+        """
+        url = f"{self.backend_url}/api/menus/candidates"
+        headers = {"Authorization": f"Bearer {jwt_token}"}
+
+        try:
+            resp = requests.get(url, headers=headers, timeout=10)
+            resp.raise_for_status()
+            body = resp.json()
+            if body.get("success") and body.get("data"):
+                return {menu["name"] for menu in body["data"]}
+        except requests.exceptions.ConnectionError:
+            print("[MenuFetcher] Spring 백엔드에 연결할 수 없습니다.")
+        except requests.exceptions.Timeout:
+            print("[MenuFetcher] Spring 백엔드 응답 시간 초과.")
+        except Exception as e:
+            print(f"[MenuFetcher] 후보 조회 실패: {e}")
+
+        return set()

--- a/ai_agent_app/ProcessDynamicInputs.py
+++ b/ai_agent_app/ProcessDynamicInputs.py
@@ -116,16 +116,17 @@ class ProcessDynamicInputs:
         }
         return self.chain.invoke(llm_input)
     
-    def process_dynamic_inputs(self, user_query: Dict) -> Dict[str, Any]:
-        candidate_ids = self.select_candidates.select_candidates(self.recipes, user_query)
+    def process_dynamic_inputs(self, user_query: Dict, recipes: List[Dict] = None) -> Dict[str, Any]:
+        active_recipes = recipes if recipes is not None else self.recipes
+        candidate_ids = self.select_candidates.select_candidates(active_recipes, user_query)
 
         if not candidate_ids:
             raise ValueError("적합한 레시피 후보가 없습니다.")
-        
+
         enriched, price_cache = self._enrich_candidates(candidate_ids, user_query.get("location"))
         final_id    = self._select_final_id(user_query, enriched, candidate_ids)
-        print(f"최종 선정된 레시피 ID: {final_id}")  # 최종 선정된 ID 확인용
-        final_recipe = self.recipes[final_id]
+        print(f"최종 선정된 레시피 ID: {final_id}")
+        final_recipe = active_recipes[final_id]
         
         static_data = self._build_static_data(final_recipe)
         llm_data    = self._build_llm_data(final_recipe, price_cache[final_id], user_query)

--- a/ai_agent_app/server.py
+++ b/ai_agent_app/server.py
@@ -1,16 +1,16 @@
 # fastapi.py (파일명을 가급적 app_server.py 등으로 바꾸는 걸 추천해요!)
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
-from typing import List
+from typing import List, Optional
 import os
 from langchain_openai import ChatOpenAI
 from dotenv import load_dotenv
 import asyncio
-# 분리된 클래스들을 가져옵니다 (파일명에 맞춰 임포트 경로 수정 필요)
 from ai_agent_app.DataLoader import RecipeDataLoader
 from ai_agent_app.GetMarketPrices import GetMarketPrices
 from ai_agent_app.SelectCandidates import SelectCandidates
 from ai_agent_app.ProcessDynamicInputs import ProcessDynamicInputs
+from ai_agent_app.MenuFetcher import MenuFetcher
 
 load_dotenv()
 app = FastAPI(title="Recipe AI API")
@@ -22,18 +22,23 @@ class UserRequest(BaseModel):
     budget: float = Field(..., gt=0, example=8000)
 
     health_conditions: List[str] = Field(
-        default_factory=list, 
-        example=["고혈압"], 
+        default_factory=list,
+        example=["고혈압"],
         description="사용자의 지병이나 주의가 필요한 건강 상태"
     )
     fitness_goal: str = Field(
-        default="일반식단", 
-        example="근력운동", 
+        default="일반식단",
+        example="근력운동",
         description="운동 목적: 다이어트, 근력운동, 유지 등"
     )
 
     allergies: List[str] = Field(default_factory=list, example=["견과류", "메밀"])
     preferences: List[str] = Field(default_factory=list, example=["매운맛"])
+
+    jwt_token: Optional[str] = Field(
+        default=None,
+        description="Spring 백엔드 JWT. 제공 시 서버 사이드 필터링 후보 사용"
+    )
     
 
 recipe_path = "ai_agent_app/all_recipe_nutrition_data.json"
@@ -41,6 +46,12 @@ price_path = "ai_agent_app/seoul_prices_weekly_2026-04-05.json"
 
 recipes = RecipeDataLoader.load_json(recipe_path)
 price_list = RecipeDataLoader.load_json(price_path)
+
+# 메뉴명 → 레시피 데이터 빠른 조회용 인덱스
+recipe_index: dict = {r["RCP_NM"]: r for r in recipes}
+
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8080")
+menu_fetcher = MenuFetcher(BACKEND_URL)
 
 model = ChatOpenAI(
             # OpenRouter 공식 엔드포인트
@@ -67,11 +78,36 @@ orchestrator = ProcessDynamicInputs(
     model=model
 )
 
+def _resolve_recipes(jwt_token: Optional[str]) -> list:
+    """
+    jwt_token 있으면 Spring 후보 25개 기준으로 로컬 JSON 필터링.
+    없거나 실패하면 전체 레시피 반환 (기존 동작 유지).
+    """
+    if not jwt_token:
+        return recipes
+
+    candidate_names = menu_fetcher.fetch_candidate_names(jwt_token)
+    if not candidate_names:
+        print("[server] Spring 후보 조회 실패 → 전체 레시피 사용")
+        return recipes
+
+    filtered = [recipe_index[name] for name in candidate_names if name in recipe_index]
+    if not filtered:
+        print("[server] 로컬 JSON 매칭 결과 없음 → 전체 레시피 사용")
+        return recipes
+
+    print(f"[server] Spring 후보 {len(candidate_names)}개 중 로컬 매칭 {len(filtered)}개 사용")
+    return filtered
+
+
 @app.post("/recommend")
 async def get_recommendation(user_input: UserRequest):
     try:
+        active_recipes = _resolve_recipes(user_input.jwt_token)
+        user_query = user_input.dict(exclude={"jwt_token"})
+
         final_result: dict = await asyncio.get_running_loop().run_in_executor(
-            None, orchestrator.process_dynamic_inputs, user_input.dict()
+            None, orchestrator.process_dynamic_inputs, user_query, active_recipes
         )
 
         if "market_prices" in final_result and isinstance(final_result["market_prices"], list):

--- a/scripts/tag_menu_cuisine.py
+++ b/scripts/tag_menu_cuisine.py
@@ -1,0 +1,182 @@
+"""
+menus 테이블의 category 컬럼을 한식/중식/일식/양식/동남아식/기타 로 재태깅하는 스크립트.
+
+실행 방법:
+  # 결과만 확인 (DB 변경 없음)
+  python3 scripts/tag_menu_cuisine.py
+
+  # 실제 DB에 반영
+  python3 scripts/tag_menu_cuisine.py --apply
+
+환경변수:
+  OPENROUTER_API_KEY  (LLM 2차 분류에 필요)
+"""
+
+import os
+import sys
+import json
+import re
+from collections import Counter
+from typing import Optional
+
+import pymysql
+
+# ── DB 연결 설정 ──────────────────────────────────────────────
+DB_CONFIG = {
+    "host": "localhost",
+    "port": 3306,
+    "user": "root",
+    "password": "ai_meal_assistant_123!",
+    "database": "meal_assistant",
+    "charset": "utf8mb4",
+}
+
+# ── 1차 규칙 기반 키워드 매핑 ──────────────────────────────────
+# 메뉴명에 해당 키워드가 포함되면 해당 카테고리로 분류
+# 순서가 중요: 앞에서 매칭되면 뒤는 보지 않음
+CUISINE_RULES: list[tuple[str, list[str]]] = [
+    ("중식", [
+        "짜장", "짬뽕", "탕수육", "마파두부", "볶음밥", "깐풍", "유린기",
+        "팔보채", "고추잡채", "동파육", "마라", "훠궈", "딤섬",
+    ]),
+    ("일식", [
+        "초밥", "스시", "라멘", "우동", "소바", "돈가스", "가츠",
+        "오야코", "가라아게", "규동", "텐동", "치라시", "미소",
+        "덴푸라", "야키토리", "타코야키",
+    ]),
+    ("양식", [
+        "파스타", "스테이크", "피자", "리조또", "오믈렛", "그라탕",
+        "카르보나라", "뇨끼", "펜네", "라자냐", "함박", "크림수프",
+        "비프스튜", "포크찹", "샌드위치", "바게트", "프렌치토스트",
+    ]),
+    ("동남아식", [
+        "팟타이", "쌀국수", "커리", "카레", "볶음면", "분짜", "반미",
+        "나시고렝", "똠얌", "월남쌈", "가오팟", "아도보",
+    ]),
+    # 한식은 마지막 — 위에서 매칭 안 된 것은 대부분 한식
+    ("한식", [
+        "김치", "된장", "불고기", "비빔", "제육", "삼겹", "갈비", "찌개",
+        "국밥", "나물", "잡채", "떡볶이", "부침", "전", "조림", "무침",
+        "냉면", "국수", "수제비", "설렁탕", "삼계탕", "곰탕", "순대",
+        "떡국", "쌈밥", "청국장", "도토리묵", "오징어", "낙지", "꼴뚜기",
+        "갈치", "고등어", "삼치", "북어", "황태", "동태", "홍합", "바지락",
+        "해물", "새우", "굴", "감자", "고구마", "호박", "시금치", "깻잎",
+        "두부", "계란", "닭볶음", "닭갈비", "대구", "명태", "아귀",
+        "육개장", "추어탕", "선지", "뼈다귀", "갈비탕", "미역", "콩나물",
+        "만두", "떡만두",
+    ]),
+]
+
+
+def classify_by_rule(name: str) -> Optional[str]:
+    for cuisine, keywords in CUISINE_RULES:
+        for kw in keywords:
+            if kw in name:
+                return cuisine
+    return None
+
+
+def classify_batch_by_llm(names: list[str]) -> dict[str, str]:
+    """메뉴명 리스트를 LLM으로 분류. 실패 시 빈 dict 반환."""
+    try:
+        from langchain_openai import ChatOpenAI
+    except ImportError:
+        print("  [경고] langchain-openai 미설치 → LLM 분류 건너뜀")
+        return {}
+
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        print("  [경고] OPENROUTER_API_KEY 환경변수 없음 → LLM 분류 건너뜀")
+        return {}
+
+    model = ChatOpenAI(
+        base_url="https://openrouter.ai/api/v1",
+        model="openai/gpt-4o-mini",
+        temperature=0,
+        openai_api_key=api_key,
+        default_headers={
+            "HTTP-Referer": "http://localhost",
+            "X-Title": "NutriAgent Menu Tagger",
+        },
+    )
+
+    menu_list = "\n".join(f"{i + 1}. {n}" for i, n in enumerate(names))
+    prompt = (
+        "다음은 요리 메뉴명 목록이야. 각 메뉴를 한식/중식/일식/양식/동남아식/기타 중 하나로 분류해줘.\n"
+        "반드시 아래 JSON 형식으로만 응답해 (설명 없이):\n"
+        '{"메뉴명": "분류", ...}\n\n'
+        f"메뉴 목록:\n{menu_list}"
+    )
+
+    try:
+        response = model.invoke(prompt)
+        content = response.content
+        match = re.search(r"\{.*\}", content, re.DOTALL)
+        if match:
+            return json.loads(match.group())
+    except Exception as e:
+        print(f"  [LLM 오류] {e}")
+    return {}
+
+
+def main(apply: bool) -> None:
+    conn = pymysql.connect(**DB_CONFIG)
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT id, name FROM menus ORDER BY id")
+    menus: list[tuple[int, str]] = cursor.fetchall()
+    print(f"총 메뉴: {len(menus)}개\n")
+
+    # ── 1차: 규칙 기반 ───────────────────────────────────────
+    updates: dict[int, tuple[str, str]] = {}  # id → (name, cuisine)
+    unclassified: list[tuple[int, str]] = []
+
+    for menu_id, name in menus:
+        cuisine = classify_by_rule(name)
+        if cuisine:
+            updates[menu_id] = (name, cuisine)
+        else:
+            unclassified.append((menu_id, name))
+
+    print(f"[1차 규칙 기반]  분류 완료: {len(updates)}개  /  미분류: {len(unclassified)}개")
+
+    # ── 2차: LLM (미분류만) ──────────────────────────────────
+    if unclassified:
+        print(f"\n[2차 LLM 분류] 미분류 {len(unclassified)}개 처리 중...")
+        BATCH = 50
+        for i in range(0, len(unclassified), BATCH):
+            chunk = unclassified[i: i + BATCH]
+            names_only = [n for _, n in chunk]
+            end = min(i + BATCH, len(unclassified))
+            print(f"  배치 {i + 1}~{end} / {len(unclassified)}")
+
+            result = classify_batch_by_llm(names_only)
+            for menu_id, name in chunk:
+                cuisine = result.get(name) or "기타"
+                updates[menu_id] = (name, cuisine)
+
+    # ── 결과 요약 ────────────────────────────────────────────
+    counter = Counter(v[1] for v in updates.values())
+    print("\n[분류 결과]")
+    for cuisine, count in sorted(counter.items(), key=lambda x: -x[1]):
+        print(f"  {cuisine:8s}: {count:4d}개")
+
+    if not apply:
+        print("\n[DRY RUN] DB 변경 없음. 실제 반영하려면 --apply 옵션을 붙여서 실행하세요.")
+        cursor.close()
+        conn.close()
+        return
+
+    # ── DB 업데이트 ──────────────────────────────────────────
+    print(f"\n[DB 업데이트] {len(updates)}개 메뉴 category 컬럼 갱신 중...")
+    for menu_id, (_, cuisine) in updates.items():
+        cursor.execute("UPDATE menus SET category = %s WHERE id = %s", (cuisine, menu_id))
+
+    conn.commit()
+    print("완료!")
+    cursor.close()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main(apply="--apply" in sys.argv)


### PR DESCRIPTION
플러터 앱이 JWT와 사용자 정보를 Python AI 서버(/recommend)로 전송하면, AI 서버는 JWT로 Spring 백엔드(/api/menus/candidates)에서 필터링된 25개 후보를 받아 로컬 레시피 JSON과 매핑한 뒤 LLM으로 최종 1개 메뉴를 추천해 반환한다.

Spring 백엔드는 JWT에서 이메일을 추출해 해당 유저의 알레르기·예산·단백질 수준을 조회하고, 조건에 맞는 메뉴 25개를 DB에서 랜덤 샘플링해 AI 서버에 넘긴다.

---

Summary

- Spring GET /api/menus/candidates 엔드포인트 추가 — 알레르기 제외·예산·단백질 수준 필터 후 25개 랜덤 반환
- Python AI Agent JWT 전달 시 Spring 후보 기준으로 로컬 JSON 필터링, Spring 미응답 시 전체 레시피 fallback
- scripts/tag_menu_cuisine.py 규칙 기반 + LLM(gpt-4o-mini) 하이브리드로 1143개 메뉴에 cuisine 카테고리 태깅

변경 파일

Spring Backend
- MenuCandidateController.java — GET /api/menus/candidates 엔드포인트
- MenuCandidateService.java — 알레르기·예산·단백질 필터 로직
- MenuRepository.java — native query (RAND() LIMIT 25)
- MenuAllergyRepository.java — 알레르기 메뉴 ID 조회
- MenuCandidateDto.java — 응답 DTO
- Menu.java, MenuAllergy.java — @Getter / @NoArgsConstructor 추가

Python AI Agent
- MenuFetcher.py (NEW) — Spring API 호출 클래스
- server.py — jwt_token 옵션 수신, _resolve_recipes() 헬퍼 추가
- ProcessDynamicInputs.py  사용

기타
- scripts/tag_menu_cuisine.py — 메뉴 카테고리 태깅 스크립트
- ai_agent_app/.env.exampl화

Test plan

- GET /api/menus/candidate
- 알레르기 등록 유저 요청 시 해당 메뉴 제외 확인
- jwt_token 없이 AI /recomback 확인
- jwt_token 포함 시 Spring 후보 기반 레시피 사용 확인
- Spring 서버 다운 상태에서 AI 요청 시 fallback 동작 확인