### PR TITLE
feat: AI 추천 결과 플러터 연동 및 후보 목록 표시 (#75)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,14 @@ build/
 # OS / temp
 *.tmp
 *.swp
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+*.egg-info/
+
+# Environment secrets
+.env
+!.env.example

--- a/README.md
+++ b/README.md
@@ -1,0 +1,220 @@
+# NUTRIAgent
+
+AI 기반 맞춤형 식단 추천 서비스. 사용자의 신체 정보, 건강 목표, 예산, 알러지를 바탕으로 레시피를 추천하고 실시간 시장 가격으로 재료비를 산출합니다.
+
+---
+
+## 시스템 구성
+
+```
+Flutter App (클라이언트)
+    │
+    ├── Spring Boot API (포트 8080)  ← 인증, 사용자 정보, 메뉴 후보 제공
+    │       │
+    │       └── MySQL DB
+    │
+    ├── Python AI 서버 (포트 8000)   ← 메뉴 선정 + 레시피 분석
+    │
+    └── Spring Boot 배치 서버         ← KAMIS 물가 수집 (스케줄러)
+```
+
+---
+
+## 데이터 흐름
+
+### 추천 요청 흐름
+
+```
+[Flutter] 추천 버튼 클릭
+    │
+    ├── 1. GET /api/menus/candidates  →  [Spring API]
+    │         JWT 있으면 사용자 알러지·선호 기반 필터링
+    │         없으면 랜덤 100개 반환
+    │         응답: 메뉴 ID·이름·영양정보·재료 텍스트
+    │
+    ▼
+[Flutter] 후보 목록 즉시 화면 표시 (빠름)
+    │
+    └── 2. POST /recommend  →  [Python AI 서버]
+              요청: 신체정보·예산·목표·알러지·선호·JWT
+                │
+                ├── /api/menus/candidates 재조회 (AI 포맷 변환)
+                ├── SelectCandidates: LLM이 후보 중 10개 추림
+                ├── GetMarketPrices: 재료별 물가 조회 (현재 미연결)
+                ├── ProcessDynamicInputs: LLM이 최종 1개 선정
+                └── Prompts chain: 선정 이유 + 재료비 계산 생성
+              응답: 메뉴명·영양정보·조리법·선정 이유·재료비 내역
+
+[Flutter] AI 1픽 결과를 후보 목록 상단에 표시
+```
+
+### KAMIS 물가 수집 흐름 (배치)
+
+```
+[KamisPriceScheduler] 매일 cron 실행
+    │
+    ├── KamisNaturePriceListClient: KAMIS API XML 요청
+    ├── KamisNaturePriceListXmlParser: XML → 가격 항목 파싱
+    ├── KamisIngredientMapLoader: 재료명 ↔ KAMIS 품목코드 매핑
+    └── KamisPriceUpdateService: ingredient_prices 테이블 upsert
+                                  (1g당 가격으로 표준화 저장)
+```
+
+### 레시피 데이터 적재 흐름 (배치)
+
+```
+[MfdsRecipeImportCommand] 1회성 실행
+    │
+    ├── FoodSafetyApiFetcher: 식품의약품안전처 API 호출
+    ├── RecipeDataParser: JSON → 레시피 파싱
+    └── RecipeDataSyncService: menus · menu_ingredients 테이블 적재
+```
+
+---
+
+## 모듈별 역할
+
+### `ai-meal-assistant-backend/` — Spring Boot API 서버
+
+| 도메인 | 주요 기능 |
+|---|---|
+| `user` | 회원가입·로그인·JWT 발급, 신체 정보(키·몸무게·인바디), 식단 선호(목표·예산·채식·매운맛) |
+| `menu` | 메뉴 후보 목록 제공 (`/api/menus/candidates`), 사용자 알러지·선호 기반 필터링 |
+| `history` | 추천 이력 저장 (`recommendation_logs`) |
+
+### `ai-meal-assistant-batch/` — Spring Boot 배치 서버
+
+| 잡 | 주요 기능 |
+|---|---|
+| `kamis` | KAMIS API에서 전통시장 농수산물 시세 수집 → `ingredient_prices` 저장 |
+| `mfds` | 식품의약품안전처 레시피 API → `menus`, `menu_ingredients` 적재 |
+| `seed` | 재료 시드 데이터 초기 적재 |
+
+### `ai_agent_app/` — Python AI 서버 (FastAPI)
+
+| 파일 | 역할 |
+|---|---|
+| `server.py` | FastAPI 엔드포인트 (`POST /recommend`), Spring API에서 레시피 조회 |
+| `MenuFetcher.py` | Spring `/api/menus/candidates` 호출 → AI 내부 포맷(`RCP_NM`, `INFO_ENG` 등)으로 변환 |
+| `SelectCandidates.py` | LLM으로 후보 100개 → 상위 10개 추림 |
+| `GetMarketPrices.py` | 재료 텍스트에서 키워드 추출 → 물가 데이터에서 가격 조회 |
+| `ProcessDynamicInputs.py` | 전체 AI 파이프라인 오케스트레이션 |
+| `Prompts.py` | 레시피 분석 + 재료비 계산 LLM 프롬프트 |
+
+### `flutter_app/` — Flutter 클라이언트
+
+| 화면 | 기능 |
+|---|---|
+| `LoginScreen` | 이메일·소셜 로그인 선택 |
+| `SignupScreen` | 회원가입 |
+| `OnboardingScreen` | 최초 프로필 입력 (신체정보·목표·선호) |
+| `DashboardScreen` | 날씨 브리핑·예산 표시, 추천 버튼 |
+| `RecommendationScreen` | 후보 목록 즉시 표시 + AI 1픽 비동기 로딩 |
+| `MypageScreen` | 프로필 조회·수정 |
+
+---
+
+## DB 테이블 구조 (주요)
+
+```
+menus                  레시피 (이름·카테고리·영양정보·이미지·건강팁)
+menu_ingredients       메뉴 ↔ 재료 연결 (사용량 텍스트 포함)
+ingredients            재료 마스터 (이름·단위)
+ingredient_prices      재료별 시세 (1g당 가격, 날짜, 출처)
+users                  회원
+user_health_profiles   신체 정보 (키·몸무게·BMI·기초대사량 등)
+user_preferences       식단 선호 (예산·채식 타입·단백질 수준·운동 목표)
+user_allergies         알러지 정보
+user_food_preferences  음식 선호 키워드
+recommendation_logs    추천 이력
+```
+
+---
+
+## 환경 변수
+
+### AI 서버 (`ai_agent_app/.env`)
+```
+OPENROUTER_API_KEY=sk-or-v1-...   # OpenRouter API 키 (gpt-4o-mini 사용)
+BACKEND_URL=http://localhost:8080  # Spring API 주소
+```
+
+### 배치 서버 (`application.yml` 또는 환경변수)
+```
+KAMIS_API_KEY=...       # KAMIS API 인증키
+```
+
+---
+
+## 실행 방법
+
+```bash
+# Spring API 서버
+cd ai-meal-assistant-backend
+./gradlew bootRun
+
+# Spring 배치 서버
+cd ai-meal-assistant-batch
+./gradlew bootRun
+
+# Python AI 서버
+cd ai_agent_app
+pip install -r requirements.txt
+uvicorn ai_agent_app.server:app --reload --port 8000
+
+# Flutter 앱
+cd flutter_app
+flutter run
+```
+
+---
+
+## 현재 미구현 / 향후 작업
+
+### 높은 우선순위
+
+- [ ] **KAMIS 물가 → AI 서버 연동**
+  - 현재: `GetMarketPrices([])` 빈 리스트로 초기화 → LLM이 가격 추정
+  - 필요: Spring API에 `/api/ingredients/prices` 엔드포인트 추가 → AI 서버가 실시간 시세 조회
+  - 관련 파일: `GetMarketPrices.py`, `server.py`, `IngredientPriceRepository.java`
+
+- [ ] **레시피 조리 단계 DB 저장**
+  - 현재: `menu_steps` 테이블 없음 → `MenuCandidateDto.steps` 항상 빈 리스트 반환
+  - 필요: 배치 서버에서 MFDS 데이터의 `MANUAL01~MANUAL20` 필드 파싱 → `menu_steps` 테이블 적재
+  - 관련 파일: `MfdsRecipeImportService.java`, `MenuCandidateDto.java`, `MenuFetcher.py`
+
+- [ ] **건강 상태(지병) 필드 추가**
+  - 현재: `health_conditions` 빈 리스트로 고정 (`UserHealthProfile`에 해당 필드 없음)
+  - 필요: `UserHealthProfile`에 당뇨·고혈압 등 지병 필드 추가, 온보딩·마이페이지 UI 연결
+  - 관련 파일: `UserHealthProfile.java`, `UserProfileRequest.java`, `onboarding_screen.dart`, `mypage_screen.dart`
+
+### 중간 우선순위
+
+- [ ] **추천 이력 저장**
+  - `recommendation_logs` 테이블은 존재하나 AI 추천 결과를 실제로 저장하는 로직 미구현
+  - AI 서버 응답 성공 시 Spring API로 이력 저장 호출 필요
+
+- [ ] **대시보드 날씨 실시간 연동**
+  - 현재: "서울시 맑음 22°C" 하드코딩
+  - 필요: 날씨 API(기상청 or OpenWeatherMap) 연동, 날씨 기반 브리핑 문구 동적 생성
+
+- [ ] **대시보드 예산 카드 수정 기능**
+  - 수정 버튼 UI는 있으나 동작 미구현 (`IconButton(onPressed: () {}`)
+
+- [ ] **사용자 위치 정보**
+  - 현재: `location`은 "서울"로 하드코딩
+  - 필요: `UserPreference`에 지역 필드 추가, 물가 조회 지역화에 활용
+
+### 낮은 우선순위
+
+- [ ] **소셜 로그인 (카카오/구글)**
+  - `LoginScreen`에 버튼만 존재, OAuth 연동 미구현
+
+- [ ] **인바디 연동 온보딩**
+  - `UserHealthProfile`에 `skeletalMuscleMass`, `inbodyScore` 등 인바디 필드는 있으나 입력 UI 없음
+
+- [ ] **AI 추천 재시도 / 다른 메뉴 보기**
+  - 현재 추천 화면에서 한 번만 호출, 재추천 기능 없음
+
+- [ ] **오프라인 / 에러 처리 고도화**
+  - AI 서버 타임아웃(120초) 시 사용자 피드백 개선 필요

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/controller/MenuCandidateController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/controller/MenuCandidateController.java
@@ -44,17 +44,15 @@ public class MenuCandidateController {
      */
     @GetMapping("/candidates")
     public ResponseEntity<ApiResponse<List<MenuCandidateDto>>> getCandidates(
-            @RequestHeader("Authorization") String authHeader) {
+            @RequestHeader(value = "Authorization", required = false) String authHeader) {
 
-        String email = extractEmail(authHeader);
-        List<MenuCandidateDto> candidates = menuCandidateService.getCandidates(email);
-        return ResponseEntity.ok(ApiResponse.ok(candidates));
-    }
-
-    private String extractEmail(String authHeader) {
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            throw new IllegalArgumentException("유효하지 않은 인증 헤더입니다.");
+        List<MenuCandidateDto> candidates;
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String email = jwtUtil.getEmailFromToken(authHeader.substring(7));
+            candidates = menuCandidateService.getCandidates(email);
+        } else {
+            candidates = menuCandidateService.getRandomCandidates();
         }
-        return jwtUtil.getEmailFromToken(authHeader.substring(7));
+        return ResponseEntity.ok(ApiResponse.ok(candidates));
     }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/dto/MenuCandidateDto.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/dto/MenuCandidateDto.java
@@ -3,30 +3,57 @@ package capstone.ai_meal_assistant_backend.domain.menu.dto;
 import capstone.ai_meal_assistant_backend.domain.menu.entity.Menu;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 public class MenuCandidateDto {
 
     private final Long id;
     private final String name;
     private final String category;
-    private final Integer calories;
+    private final String cookingMethod;
+    private final Double calories;
     private final Double protein;
     private final Double fat;
     private final Double carbs;
+    private final Double sodium;
     private final Integer basePrice;
+    private final String mainImageUrl;
+    private final String healthTip;
+    private final String ingredientsText;
+    private final List<StepDto> steps;
 
-    private MenuCandidateDto(Menu menu) {
-        this.id        = menu.getId();
-        this.name      = menu.getName();
-        this.category  = menu.getCategory();
-        this.calories  = menu.getCalories();
-        this.protein   = menu.getProtein();
-        this.fat       = menu.getFat();
-        this.carbs     = menu.getCarbs();
-        this.basePrice = menu.getBasePrice();
+    private MenuCandidateDto(Menu menu, String ingredientsText, List<StepDto> steps) {
+        this.id              = menu.getId();
+        this.name            = menu.getName();
+        this.category        = menu.getCategory();
+        this.cookingMethod   = menu.getCookingMethod();
+        this.calories        = menu.getCalories();
+        this.protein         = menu.getProtein();
+        this.fat             = menu.getFat();
+        this.carbs           = menu.getCarbs();
+        this.sodium          = menu.getSodium();
+        this.basePrice       = menu.getBasePrice();
+        this.mainImageUrl    = menu.getMainImageUrl();
+        this.healthTip       = menu.getHealthTip();
+        this.ingredientsText = ingredientsText;
+        this.steps           = steps;
     }
 
-    public static MenuCandidateDto from(Menu menu) {
-        return new MenuCandidateDto(menu);
+    public static MenuCandidateDto from(Menu menu, String ingredientsText, List<StepDto> steps) {
+        return new MenuCandidateDto(menu, ingredientsText, steps);
+    }
+
+    @Getter
+    public static class StepDto {
+        private final int stepNo;
+        private final String content;
+        private final String imageUrl;
+
+        public StepDto(int stepNo, String content, String imageUrl) {
+            this.stepNo  = stepNo;
+            this.content = content;
+            this.imageUrl = imageUrl;
+        }
     }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/entity/Menu.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/entity/Menu.java
@@ -14,13 +14,23 @@ public class Menu {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String foodCode;
+
     @Column(nullable = false)
     private String name;
 
     private String category;
-    private Integer calories;
+    private String cookingMethod;
+    private Double calories;
     private Double protein;
     private Double fat;
     private Double carbs;
+    private Double sodium;
     private Integer basePrice;
+
+    @Column(length = 500)
+    private String mainImageUrl;
+
+    @Column(length = 1000)
+    private String healthTip;
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/MenuRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/MenuRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -28,4 +29,15 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
             @Param("maxCal")     Integer maxCalories,
             @Param("limit")      int limit
     );
+
+    @Query(value = """
+            SELECT mi.menu_id,
+                   GROUP_CONCAT(CONCAT(i.name, ' ', COALESCE(mi.amount_text, ''))
+                                ORDER BY i.name SEPARATOR ', ') AS ingredients_text
+            FROM menu_ingredients mi
+            JOIN ingredients i ON mi.ingredient_id = i.id
+            WHERE mi.menu_id IN (:menuIds)
+            GROUP BY mi.menu_id
+            """, nativeQuery = true)
+    List<Object[]> findIngredientsTextByMenuIds(@Param("menuIds") Collection<Long> menuIds);
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/service/MenuCandidateService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/service/MenuCandidateService.java
@@ -2,6 +2,7 @@ package capstone.ai_meal_assistant_backend.domain.menu.service;
 
 import capstone.ai_meal_assistant_backend.domain.menu.dto.MenuCandidateDto;
 import capstone.ai_meal_assistant_backend.domain.menu.entity.Allergy;
+import capstone.ai_meal_assistant_backend.domain.menu.entity.Menu;
 import capstone.ai_meal_assistant_backend.domain.menu.entity.UserAllergy;
 import capstone.ai_meal_assistant_backend.domain.menu.repository.MenuAllergyRepository;
 import capstone.ai_meal_assistant_backend.domain.menu.repository.MenuRepository;
@@ -15,9 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -39,21 +38,38 @@ public class MenuCandidateService {
 
         UserPreference pref = preferenceRepository.findByUser(user).orElse(null);
 
-        // 1. 사용자 알레르기 메뉴 ID 수집
         Set<Long> excludeMenuIds = getExcludeMenuIds(user);
-
-        // 2. 선호 조건 추출
         Integer budget     = pref != null ? pref.getMealBudget() : null;
         Double  minProtein = resolveMinProtein(pref);
-        Integer maxCal     = null; // fitnessGoal 병합 후 확장 예정
 
-        // 3. 후보 조회 (DB에서 RAND() + LIMIT)
-        // 빈 Set은 NOT IN () → SQL 오류 발생. -1L은 실제 메뉴 ID와 겹치지 않으므로 안전한 더미값
         Set<Long> queryExclude = excludeMenuIds.isEmpty() ? Set.of(-1L) : excludeMenuIds;
-        return menuRepository
-                .findCandidates(queryExclude, budget, minProtein, maxCal, CANDIDATE_LIMIT)
-                .stream()
-                .map(MenuCandidateDto::from)
+        List<Menu> menus = menuRepository.findCandidates(queryExclude, budget, minProtein, null, CANDIDATE_LIMIT);
+        return buildDtos(menus);
+    }
+
+    public List<MenuCandidateDto> getRandomCandidates() {
+        List<Menu> menus = menuRepository.findCandidates(Set.of(-1L), null, null, null, CANDIDATE_LIMIT);
+        return buildDtos(menus);
+    }
+
+    private List<MenuCandidateDto> buildDtos(List<Menu> menus) {
+        if (menus.isEmpty()) return Collections.emptyList();
+
+        List<Long> menuIds = menus.stream().map(Menu::getId).collect(Collectors.toList());
+
+        // 재료 텍스트 일괄 조회 (쿼리 1번)
+        Map<Long, String> ingredientsMap = new HashMap<>();
+        for (Object[] row : menuRepository.findIngredientsTextByMenuIds(menuIds)) {
+            Long menuId = ((Number) row[0]).longValue();
+            ingredientsMap.put(menuId, (String) row[1]);
+        }
+
+        return menus.stream()
+                .map(m -> MenuCandidateDto.from(
+                        m,
+                        ingredientsMap.getOrDefault(m.getId(), ""),
+                        Collections.emptyList() // TODO: menu_steps 테이블 추가 후 연결
+                ))
                 .collect(Collectors.toList());
     }
 
@@ -67,7 +83,6 @@ public class MenuCandidateService {
         return menuAllergyRepository.findMenuIdsByAllergyIn(userAllergies);
     }
 
-    // proteinLevel → 최소 단백질(g) 변환
     private Double resolveMinProtein(UserPreference pref) {
         if (pref == null || pref.getProteinLevel() == null) return null;
         if (pref.getProteinLevel() == ProteinLevel.HIGH) return 25.0;

--- a/ai_agent_app/.env.example
+++ b/ai_agent_app/.env.example
@@ -1,3 +1,2 @@
-# AI Agent 환경변수 예시 — .env 파일로 복사 후 실제 값 입력
 OPENROUTER_API_KEY=sk-or-v1-...
 BACKEND_URL=http://localhost:8080

--- a/ai_agent_app/DataLoader.py
+++ b/ai_agent_app/DataLoader.py
@@ -1,0 +1,9 @@
+import json
+from typing import List, Dict, Any
+
+
+class RecipeDataLoader:
+    @staticmethod
+    def load_json(path: str) -> Any:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)

--- a/ai_agent_app/GetMarketPrices.py
+++ b/ai_agent_app/GetMarketPrices.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Optional
 from collections import defaultdict
 
 class GetMarketPrices:
@@ -42,7 +42,7 @@ class GetMarketPrices:
                 )
             return self._national_pool, self._national_index
         
-    def _match_item(self, word: str, pool: List[Dict], index: Dict[str, Dict]) -> Dict | None:
+    def _match_item(self, word: str, pool: List[Dict], index: Dict[str, Dict]) -> Optional[Dict]:
         """정확히 일치 → 부분 일치 순으로 탐색."""
         if exact := index.get(word):
             return exact

--- a/ai_agent_app/MenuFetcher.py
+++ b/ai_agent_app/MenuFetcher.py
@@ -1,5 +1,5 @@
 import requests
-from typing import List, Dict
+from typing import List, Optional
 
 
 class MenuFetcher:
@@ -8,20 +8,23 @@ class MenuFetcher:
     def __init__(self, backend_url: str):
         self.backend_url = backend_url.rstrip("/")
 
-    def fetch_candidate_names(self, jwt_token: str) -> set:
+    def fetch_candidates_full(self, jwt_token: Optional[str]) -> List[dict]:
         """
-        Spring GET /api/menus/candidates 호출 후 메뉴명 집합 반환.
-        실패 시 빈 set 반환 (호출자가 fallback 처리).
+        Spring GET /api/menus/candidates 호출 후
+        AI 내부 포맷(RCP_NM, INFO_ENG, ...) 의 dict 리스트 반환.
+        실패 시 빈 리스트 반환.
         """
         url = f"{self.backend_url}/api/menus/candidates"
-        headers = {"Authorization": f"Bearer {jwt_token}"}
+        headers = {}
+        if jwt_token:
+            headers["Authorization"] = f"Bearer {jwt_token}"
 
         try:
             resp = requests.get(url, headers=headers, timeout=10)
             resp.raise_for_status()
             body = resp.json()
             if body.get("success") and body.get("data"):
-                return {menu["name"] for menu in body["data"]}
+                return [self._to_ai_format(m) for m in body["data"]]
         except requests.exceptions.ConnectionError:
             print("[MenuFetcher] Spring 백엔드에 연결할 수 없습니다.")
         except requests.exceptions.Timeout:
@@ -29,4 +32,24 @@ class MenuFetcher:
         except Exception as e:
             print(f"[MenuFetcher] 후보 조회 실패: {e}")
 
-        return set()
+        return []
+
+    def _to_ai_format(self, dto: dict) -> dict:
+        """Spring MenuCandidateDto → AI 내부 JSON 포맷 변환."""
+        recipe = {
+            "RCP_NM":         dto.get("name", ""),
+            "RCP_PARTS_DTLS": dto.get("ingredientsText", ""),
+            "INFO_ENG":        str(dto.get("calories") or 0),
+            "INFO_PRO":        str(dto.get("protein") or 0),
+            "INFO_FAT":        str(dto.get("fat") or 0),
+            "INFO_CAR":        str(dto.get("carbs") or 0),
+            "INFO_NA":         str(dto.get("sodium") or 0),
+            "ATT_FILE_NO_MAIN": dto.get("mainImageUrl", ""),
+            "RCP_NA_TIP":      dto.get("healthTip", ""),
+        }
+        # 조리 단계 (steps 테이블 연결 후 채워짐)
+        for step in dto.get("steps", []):
+            num = str(step.get("stepNo", 0)).zfill(2)
+            recipe[f"MANUAL{num}"]     = step.get("content", "")
+            recipe[f"MANUAL_IMG{num}"] = step.get("imageUrl", "")
+        return recipe

--- a/ai_agent_app/ProcessDynamicInputs.py
+++ b/ai_agent_app/ProcessDynamicInputs.py
@@ -14,12 +14,12 @@ class ProcessDynamicInputs:
         self.model = model
         self.chain = get_recipe_prompt() | self.model | JsonOutputParser()
         
-    def _enrich_candidates(self, candidate_ids, user_location) -> tuple[list[str], dict]:
+    def _enrich_candidates(self, candidate_ids, user_location, active_recipes) -> tuple[list[str], dict]:
         """후보별 물가 조회 + enriched 문자열 생성"""
         price_cache: Dict[int, str] = {}
         enriched: List[str] = []
         for cid in candidate_ids:
-            r = self.recipes[cid]
+            r = active_recipes[cid]
             try:
                 p_info = self.get_market_prices.get_market_prices(
                     r['RCP_PARTS_DTLS'], 
@@ -123,7 +123,7 @@ class ProcessDynamicInputs:
         if not candidate_ids:
             raise ValueError("적합한 레시피 후보가 없습니다.")
 
-        enriched, price_cache = self._enrich_candidates(candidate_ids, user_query.get("location"))
+        enriched, price_cache = self._enrich_candidates(candidate_ids, user_query.get("location"), active_recipes)
         final_id    = self._select_final_id(user_query, enriched, candidate_ids)
         print(f"최종 선정된 레시피 ID: {final_id}")
         final_recipe = active_recipes[final_id]

--- a/ai_agent_app/SelectCandidates.py
+++ b/ai_agent_app/SelectCandidates.py
@@ -1,16 +1,14 @@
-from typing import List, Dict
+from typing import Any, Dict, List
+
 from langchain_openai import ChatOpenAI
-from langchain.output_parsers import ResponseSchema, StructuredOutputParser
-from langchain.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.prompts import ChatPromptTemplate
 
 class SelectCandidates:
     def __init__(self, model: ChatOpenAI):
-        response_schemas = [
-            ResponseSchema(name="candidate_ids", description="선택된 레시피의 ID 리스트 (최대 10개)", type="list[int]")
-        ]
-        self.parser = StructuredOutputParser.from_response_schemas(response_schemas)
         self.model = model
-    
+        self.parser = JsonOutputParser()
+
     def _build_context(self, recipes: List[Dict]) -> str:
         return "\n".join([
             f"ID:{i}|메뉴:{r['RCP_NM']}|열량:{r['INFO_ENG']}kcal|"
@@ -18,12 +16,16 @@ class SelectCandidates:
             f"나트륨:{r['INFO_NA']}mg|재료:{r['RCP_PARTS_DTLS']}"
             for i, r in enumerate(recipes[:100])
         ])
-        
+
     def select_candidates(self, recipes: List[Dict], query: Dict) -> List[int]:
         context = self._build_context(recipes)
 
         prompt = ChatPromptTemplate.from_messages([
-            ("system", "당신은 전문 영양사입니다. 사용자의 프로필을 분석하여 최적의 식단 ID를 선정하세요.\n{format_instructions}"),
+            (
+                "system",
+                "당신은 전문 영양사입니다. 사용자의 프로필을 분석하여 최적의 식단 ID를 선정하세요. "
+                "반드시 JSON으로만 답하세요. 형식: {{\"candidate_ids\": [0, 1, 2]}} (최대 10개)"
+            ),
             ("human", (
                 "[사용자 정보]\n"
                 "신체 정보: {height}cm, {weight}kg\n"
@@ -34,11 +36,10 @@ class SelectCandidates:
                 "[레시피 목록]\n{context}"
             ))
         ])
-        
+
         chain = prompt | self.model | self.parser
         try:
             response = chain.invoke({
-                "format_instructions": self.parser.get_format_instructions(),
                 "height": query.get('height_cm'),
                 "weight": query.get('weight_kg'),
                 "health": ", ".join(query.get('health_conditions', [])) or "없음",
@@ -47,9 +48,20 @@ class SelectCandidates:
                 "goal": query.get('fitness_goal'),
                 "context": context
             })
-            print(response.get('candidate_ids', [])) # 모델이 어떤 응답을 주는지 확인용
-            return response.get('candidate_ids', [])[:10]
-            
+            if not isinstance(response, dict):
+                return []
+            candidate_ids: Any = response.get('candidate_ids', [])
+            if not isinstance(candidate_ids, list):
+                return []
+
+            out: List[int] = []
+            for x in candidate_ids:
+                try:
+                    out.append(int(x))
+                except Exception:
+                    continue
+            print(out)  # 모델이 어떤 응답을 주는지 확인용
+            return out[:10]
         except Exception as e:
             print(f"Error in select_candidates: {e}")
             return []

--- a/ai_agent_app/server.py
+++ b/ai_agent_app/server.py
@@ -1,4 +1,3 @@
-# fastapi.py (파일명을 가급적 app_server.py 등으로 바꾸는 걸 추천해요!)
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 from typing import List, Optional
@@ -6,7 +5,6 @@ import os
 from langchain_openai import ChatOpenAI
 from dotenv import load_dotenv
 import asyncio
-from ai_agent_app.DataLoader import RecipeDataLoader
 from ai_agent_app.GetMarketPrices import GetMarketPrices
 from ai_agent_app.SelectCandidates import SelectCandidates
 from ai_agent_app.ProcessDynamicInputs import ProcessDynamicInputs
@@ -15,10 +13,11 @@ from ai_agent_app.MenuFetcher import MenuFetcher
 load_dotenv()
 app = FastAPI(title="Recipe AI API")
 
+
 class UserRequest(BaseModel):
     height_cm: float = Field(..., gt=0, example=180.5)
     weight_kg: float = Field(..., gt=0, example=85.0)
-    location: str = Field(..., example="관악구")
+    location: str = Field(..., example="서울")
     budget: float = Field(..., gt=0, example=8000)
 
     health_conditions: List[str] = Field(
@@ -39,71 +38,48 @@ class UserRequest(BaseModel):
         default=None,
         description="Spring 백엔드 JWT. 제공 시 서버 사이드 필터링 후보 사용"
     )
-    
 
-recipe_path = "ai_agent_app/all_recipe_nutrition_data.json"
-price_path = "ai_agent_app/seoul_prices_weekly_2026-04-05.json"
-
-recipes = RecipeDataLoader.load_json(recipe_path)
-price_list = RecipeDataLoader.load_json(price_path)
-
-# 메뉴명 → 레시피 데이터 빠른 조회용 인덱스
-recipe_index: dict = {r["RCP_NM"]: r for r in recipes}
 
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8080")
 menu_fetcher = MenuFetcher(BACKEND_URL)
 
 model = ChatOpenAI(
-            # OpenRouter 공식 엔드포인트
-            base_url="https://openrouter.ai/api/v1", 
-            # OpenRouter에서 제공하는 모델 식별자 (예: gpt-4o, claude-3.5-sonnet 등)
-            model="openai/gpt-4o", 
-            temperature=0, 
-            openai_api_key=os.getenv("OPENROUTER_API_KEY"),
-            # OpenRouter 권장 필수 헤더 (선택 사항이지만 넣는 것이 좋습니다)
-            default_headers={
-                "HTTP-Referer": "http://localhost:3000", # 앱의 URL
-                "X-Title": "Recipe Analyst App"          # 앱 이름
-            }
-        )
+    base_url="https://openrouter.ai/api/v1",
+    model="openai/gpt-4o-mini",   # gpt-4o → gpt-4o-mini: 속도 개선
+    temperature=0,
+    openai_api_key=os.getenv("OPENROUTER_API_KEY"),
+    default_headers={
+        "HTTP-Referer": "http://localhost:3000",
+        "X-Title": "Recipe Analyst App"
+    }
+)
 
-get_market_prices = GetMarketPrices(price_list)
+get_market_prices = GetMarketPrices([])  # 가격 데이터는 추후 DB 연결
 select_candidates = SelectCandidates(model)
 
-# 메인 오케스트레이터 생성
 orchestrator = ProcessDynamicInputs(
-    recipes=recipes,
+    recipes=[],  # 런타임에 항상 주입되므로 빈 리스트
     get_market_prices=get_market_prices,
     select_candidates=select_candidates,
     model=model
 )
 
+
 def _resolve_recipes(jwt_token: Optional[str]) -> list:
-    """
-    jwt_token 있으면 Spring 후보 25개 기준으로 로컬 JSON 필터링.
-    없거나 실패하면 전체 레시피 반환 (기존 동작 유지).
-    """
-    if not jwt_token:
-        return recipes
-
-    candidate_names = menu_fetcher.fetch_candidate_names(jwt_token)
-    if not candidate_names:
-        print("[server] Spring 후보 조회 실패 → 전체 레시피 사용")
-        return recipes
-
-    filtered = [recipe_index[name] for name in candidate_names if name in recipe_index]
-    if not filtered:
-        print("[server] 로컬 JSON 매칭 결과 없음 → 전체 레시피 사용")
-        return recipes
-
-    print(f"[server] Spring 후보 {len(candidate_names)}개 중 로컬 매칭 {len(filtered)}개 사용")
-    return filtered
+    """Spring /api/menus/candidates 에서 AI 포맷 후보 리스트 반환."""
+    candidates = menu_fetcher.fetch_candidates_full(jwt_token)
+    if not candidates:
+        print("[server] Spring 후보 조회 실패")
+    return candidates
 
 
 @app.post("/recommend")
 async def get_recommendation(user_input: UserRequest):
     try:
         active_recipes = _resolve_recipes(user_input.jwt_token)
+        if not active_recipes:
+            raise ValueError("메뉴 후보를 가져올 수 없습니다. Spring 백엔드 연결을 확인하세요.")
+
         user_query = user_input.dict(exclude={"jwt_token"})
 
         final_result: dict = await asyncio.get_running_loop().run_in_executor(
@@ -111,16 +87,14 @@ async def get_recommendation(user_input: UserRequest):
         )
 
         if "market_prices" in final_result and isinstance(final_result["market_prices"], list):
-            # 각 항목의 calculated_cost를 정수로 변환하여 합산
             total_cost = sum(
-                float(item.get("calculated_cost", 0)) 
+                float(item.get("calculated_cost", 0))
                 for item in final_result["market_prices"]
             )
-            # 최종 필드 업데이트
             final_result["total_estimated_cost"] = total_cost
-        return final_result 
+
+        return final_result
     except ValueError as e:
-        # ID 범위 오류, JSON 파싱 실패 등 orchestrator 내부에서 명시적으로 던진 오류
         raise HTTPException(status_code=422, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"AI 에이전트 실행 중 오류 발생: {str(e)}")

--- a/flutter_app/lib/models/recommendation_models.dart
+++ b/flutter_app/lib/models/recommendation_models.dart
@@ -1,0 +1,174 @@
+class RecommendationRequest {
+  final double heightCm;
+  final double weightKg;
+  final String location;
+  final double budget;
+  final List<String> healthConditions;
+  final String fitnessGoal;
+  final List<String> allergies;
+  final List<String> preferences;
+  final String? jwtToken;
+
+  const RecommendationRequest({
+    required this.heightCm,
+    required this.weightKg,
+    required this.location,
+    required this.budget,
+    required this.fitnessGoal,
+    this.healthConditions = const [],
+    this.allergies = const [],
+    this.preferences = const [],
+    this.jwtToken,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'height_cm': heightCm,
+        'weight_kg': weightKg,
+        'location': location,
+        'budget': budget,
+        'health_conditions': healthConditions,
+        'fitness_goal': fitnessGoal,
+        'allergies': allergies,
+        'preferences': preferences,
+        if (jwtToken != null) 'jwt_token': jwtToken,
+      };
+}
+
+class MenuCandidate {
+  final int id;
+  final String name;
+  final String? category;
+  final double? calories;
+  final double? protein;
+  final double? sodium;
+  final int? basePrice;
+  final String? mainImageUrl;
+
+  const MenuCandidate({
+    required this.id,
+    required this.name,
+    this.category,
+    this.calories,
+    this.protein,
+    this.sodium,
+    this.basePrice,
+    this.mainImageUrl,
+  });
+
+  factory MenuCandidate.fromJson(Map<String, dynamic> json) => MenuCandidate(
+        id: json['id'] ?? 0,
+        name: json['name'] ?? '',
+        category: json['category'],
+        calories: (json['calories'] as num?)?.toDouble(),
+        protein: (json['protein'] as num?)?.toDouble(),
+        sodium: (json['sodium'] as num?)?.toDouble(),
+        basePrice: json['basePrice'],
+        mainImageUrl: json['mainImageUrl'],
+      );
+}
+
+class NutritionInfo {
+  final String energy;
+  final String protein;
+  final String fat;
+  final String carbs;
+  final String sodium;
+
+  const NutritionInfo({
+    required this.energy,
+    required this.protein,
+    required this.fat,
+    required this.carbs,
+    required this.sodium,
+  });
+
+  factory NutritionInfo.fromJson(Map<String, dynamic> json) => NutritionInfo(
+        energy: json['energy'] ?? '-',
+        protein: json['protein'] ?? '-',
+        fat: json['fat'] ?? '-',
+        carbs: json['carbs'] ?? '-',
+        sodium: json['sodium'] ?? '-',
+      );
+}
+
+class RecipeStep {
+  final int stepNo;
+  final String content;
+  final String image;
+
+  const RecipeStep({
+    required this.stepNo,
+    required this.content,
+    required this.image,
+  });
+
+  factory RecipeStep.fromJson(Map<String, dynamic> json) => RecipeStep(
+        stepNo: json['step_no'] ?? 0,
+        content: json['content'] ?? '',
+        image: json['image'] ?? '',
+      );
+}
+
+class MarketPriceItem {
+  final String name;
+  final String recipeAmount;
+  final String marketUnit;
+  final num marketPrice;
+  final String calculationReasoning;
+  final num calculatedCost;
+
+  const MarketPriceItem({
+    required this.name,
+    required this.recipeAmount,
+    required this.marketUnit,
+    required this.marketPrice,
+    required this.calculationReasoning,
+    required this.calculatedCost,
+  });
+
+  factory MarketPriceItem.fromJson(Map<String, dynamic> json) => MarketPriceItem(
+        name: json['name'] ?? '',
+        recipeAmount: json['recipe_amount'] ?? '',
+        marketUnit: json['market_unit'] ?? '',
+        marketPrice: json['market_price'] ?? 0,
+        calculationReasoning: json['calculation_reasoning'] ?? '',
+        calculatedCost: json['calculated_cost'] ?? 0,
+      );
+}
+
+class RecommendationResult {
+  final String menuName;
+  final String mainImg;
+  final NutritionInfo nutritionInfo;
+  final List<RecipeStep> recipeSteps;
+  final String naTip;
+  final String selectionReason;
+  final num totalEstimatedCost;
+  final List<MarketPriceItem> marketPrices;
+
+  const RecommendationResult({
+    required this.menuName,
+    required this.mainImg,
+    required this.nutritionInfo,
+    required this.recipeSteps,
+    required this.naTip,
+    required this.selectionReason,
+    required this.totalEstimatedCost,
+    required this.marketPrices,
+  });
+
+  factory RecommendationResult.fromJson(Map<String, dynamic> json) => RecommendationResult(
+        menuName: json['menu_name'] ?? '',
+        mainImg: json['main_img'] ?? '',
+        nutritionInfo: NutritionInfo.fromJson(json['nutrition_info'] ?? {}),
+        recipeSteps: (json['recipe_steps'] as List? ?? [])
+            .map((e) => RecipeStep.fromJson(e))
+            .toList(),
+        naTip: json['na_tip'] ?? '',
+        selectionReason: json['selection_reason'] ?? '',
+        totalEstimatedCost: json['total_estimated_cost'] ?? 0,
+        marketPrices: (json['market_prices'] as List? ?? [])
+            .map((e) => MarketPriceItem.fromJson(e))
+            .toList(),
+      );
+}

--- a/flutter_app/lib/screens/dashboard_screen.dart
+++ b/flutter_app/lib/screens/dashboard_screen.dart
@@ -1,9 +1,90 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_app/models/recommendation_models.dart';
+import 'package:flutter_app/models/user_profile_models.dart';
+import 'package:flutter_app/services/recommendation_service.dart';
+import 'package:flutter_app/services/token_storage.dart';
+import 'package:flutter_app/services/user_profile_service.dart';
 import 'recommendation_screen.dart';
 import 'package:flutter_app/theme.dart';
 
-class DashboardScreen extends StatelessWidget {
+class DashboardScreen extends StatefulWidget {
   const DashboardScreen({super.key});
+
+  @override
+  State<DashboardScreen> createState() => _DashboardScreenState();
+}
+
+class _DashboardScreenState extends State<DashboardScreen> {
+  bool _isLoading = false;
+
+  static const Map<String, String> _fitnessGoalMap = {
+    'DIET': '다이어트',
+    'MUSCLE_GAIN': '근력운동',
+    'MAINTAIN': '체중유지',
+    'GENERAL': '일반식단',
+  };
+
+  Future<void> _requestRecommendation() async {
+    setState(() => _isLoading = true);
+
+    try {
+      final profileResp = await UserProfileService.getProfile();
+      if (!profileResp.success || profileResp.data == null) {
+        _showError('프로필 정보를 불러오지 못했습니다.\n마이페이지에서 프로필을 먼저 입력해주세요.');
+        return;
+      }
+      final UserProfileData profile = profileResp.data!;
+      final jwt = await TokenStorage.getAccessToken();
+
+      final request = RecommendationRequest(
+        heightCm: profile.height ?? 170.0,
+        weightKg: profile.weight ?? 65.0,
+        location: '서울', // TODO: 사용자 위치 필드 추가 시 교체
+        budget: (profile.mealBudget ?? 8000).toDouble(),
+        fitnessGoal: _fitnessGoalMap[profile.fitnessGoal] ?? '일반식단',
+        healthConditions: const [], // TODO: health_conditions 필드 추가 시 연결
+        allergies: profile.allergies,
+        preferences: profile.foodPreferences,
+        jwtToken: jwt,
+      );
+
+      // 후보 목록 먼저 가져오고 (빠름), AI 추천은 화면에서 처리
+      final candidates = await RecommendationService.fetchCandidates(jwt);
+
+      if (!mounted) return;
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => RecommendationScreen(
+            candidates: candidates,
+            request: request,
+          ),
+        ),
+      );
+    } catch (e) {
+      _showError('추천 중 오류가 발생했습니다.\n$e');
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  void _showError(String message) {
+    if (!mounted) return;
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        title: const Text('오류', style: TextStyle(fontWeight: FontWeight.bold)),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('확인'),
+          ),
+        ],
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -13,23 +94,17 @@ class DashboardScreen extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            // 상단: 앱 타이틀 (💡 ShaderMask를 이용해 텍스트에 그라데이션 적용)
             ShaderMask(
               blendMode: BlendMode.srcIn,
-              shaderCallback: (Rect bounds) {
-                return AppTheme.aiGradient.createShader(bounds);
-              },
+              shaderCallback: (Rect bounds) => AppTheme.aiGradient.createShader(bounds),
               child: const Text(
                 'NUTRI Agent',
-                style: TextStyle(
-                  fontSize: 28, // 로고 느낌을 주기 위해 폰트 사이즈 살짝 증가
-                  fontWeight: FontWeight.w900,
-                ),
+                style: TextStyle(fontSize: 28, fontWeight: FontWeight.w900),
               ),
             ),
             const SizedBox(height: 24),
 
-            // 상단: 날씨 및 브리핑 카드
+            // 날씨 및 브리핑 카드
             Container(
               padding: const EdgeInsets.all(20),
               decoration: BoxDecoration(
@@ -72,19 +147,15 @@ class DashboardScreen extends StatelessWidget {
                   const SizedBox(height: 8),
                   Text(
                     '상쾌한 날씨입니다. 매일 하시는 5km 러닝 후 근손실 방지를 위해 오늘은 단백질이 풍부하고 예산에 맞는 메뉴를 추천해 드릴 준비가 되었습니다.',
-                    style: TextStyle(
-                      fontSize: 15,
-                      color: Colors.grey[700],
-                      height: 1.5,
-                    ),
+                    style: TextStyle(fontSize: 15, color: Colors.grey[700], height: 1.5),
                   ),
                 ],
               ),
             ),
-            
+
             const SizedBox(height: 16),
 
-            // 중앙: 예산 카드
+            // 예산 카드
             Container(
               padding: const EdgeInsets.all(20),
               decoration: BoxDecoration(
@@ -150,46 +221,70 @@ class DashboardScreen extends StatelessWidget {
 
             const Spacer(),
 
-            // 하단: 메뉴 추천 바로가기 버튼 (💡 Container를 이용해 그라데이션 적용)
+            // 메뉴 추천 버튼
             Container(
               width: double.infinity,
-              height: 56, // 통일된 캡슐 형태의 높이
+              height: 56,
               decoration: BoxDecoration(
-                gradient: AppTheme.aiGradient,
+                gradient: _isLoading ? null : AppTheme.aiGradient,
+                color: _isLoading ? Colors.grey[300] : null,
                 borderRadius: BorderRadius.circular(30),
-                boxShadow: [
-                  BoxShadow(
-                    color: AppTheme.primaryColor.withOpacity(0.3),
-                    blurRadius: 10,
-                    offset: const Offset(0, 4),
-                  ),
-                ],
+                boxShadow: _isLoading
+                    ? null
+                    : [
+                        BoxShadow(
+                          color: AppTheme.primaryColor.withOpacity(0.3),
+                          blurRadius: 10,
+                          offset: const Offset(0, 4),
+                        ),
+                      ],
               ),
               child: ElevatedButton(
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (context) => const RecommendationScreen()),
-                  );
-                  // TODO: 메뉴 추천 API 호출 및 로직 연결
-                },
+                onPressed: _isLoading ? null : _requestRecommendation,
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.transparent, // 배경 투명 처리 (그라데이션 노출)
-                  shadowColor: Colors.transparent,     // 기본 그림자 제거
+                  backgroundColor: Colors.transparent,
+                  shadowColor: Colors.transparent,
                   shape: const StadiumBorder(),
-                  padding: EdgeInsets.zero,            // Container 제어 따름
+                  padding: EdgeInsets.zero,
                 ),
-                child: const Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(Icons.restaurant_menu, size: 24, color: Colors.white),
-                    SizedBox(width: 12),
-                    Text(
-                      '맞춤 메뉴 추천 받기',
-                      style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Colors.white),
-                    ),
-                  ],
-                ),
+                child: _isLoading
+                    ? const Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(
+                              color: Colors.white,
+                              strokeWidth: 2.5,
+                            ),
+                          ),
+                          SizedBox(width: 12),
+                          Text(
+                            'AI가 메뉴를 분석 중...',
+                            style: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
+                              color: Colors.white,
+                            ),
+                          ),
+                        ],
+                      )
+                    : const Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(Icons.restaurant_menu, size: 24, color: Colors.white),
+                          SizedBox(width: 12),
+                          Text(
+                            '맞춤 메뉴 추천 받기',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                              color: Colors.white,
+                            ),
+                          ),
+                        ],
+                      ),
               ),
             ),
             const SizedBox(height: 20),

--- a/flutter_app/lib/screens/recommendation_screen.dart
+++ b/flutter_app/lib/screens/recommendation_screen.dart
@@ -1,40 +1,35 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_app/models/recommendation_models.dart';
+import 'package:flutter_app/services/recommendation_service.dart';
 import 'package:flutter_app/theme.dart';
 
 class RecommendationScreen extends StatefulWidget {
-  const RecommendationScreen({super.key});
+  final List<MenuCandidate> candidates;
+  final RecommendationRequest request;
+
+  const RecommendationScreen({
+    super.key,
+    required this.candidates,
+    required this.request,
+  });
 
   @override
   State<RecommendationScreen> createState() => _RecommendationScreenState();
 }
 
 class _RecommendationScreenState extends State<RecommendationScreen> {
+  RecommendationResult? _aiResult;
+  bool _aiLoading = true;
+  String? _aiError;
+
   int _rating = 0;
   final TextEditingController _feedbackController = TextEditingController();
 
-  final List<Map<String, dynamic>> _recommendedMenus = [
-    {
-      "id": 15,
-      "name": "연어 포케",
-      "price": 9500,
-      "calories": 550,
-      "reason": "예산 범위 내이며, 러닝 후 근손실 방지를 위한 고단백 메뉴입니다."
-    },
-    {
-      "id": 42,
-      "name": "닭가슴살 샐러드와 호밀빵",
-      "price": 8000,
-      "calories": 480,
-      "reason": "현재 물가가 저렴한 양상추를 듬뿍 활용한 가성비 식단입니다."
-    },
-    {
-      "id": 8,
-      "name": "소고기 버섯 덮밥",
-      "price": 9000,
-      "calories": 620,
-      "reason": "철분 보충에 좋으며 매운맛을 선호하지 않는 취향을 반영했습니다."
-    }
-  ];
+  @override
+  void initState() {
+    super.initState();
+    _fetchAiResult();
+  }
 
   @override
   void dispose() {
@@ -42,171 +37,99 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
     super.dispose();
   }
 
-  // 메뉴 상세 팝업
-  void _showMenuDetailDialog(Map<String, dynamic> menu) {
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return AlertDialog(
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)), // 💡 팝업 모서리 20px 라운딩
-          title: Text(menu['name'], style: const TextStyle(fontWeight: FontWeight.bold)),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text('💰 가격: ${menu['price']}원', style: const TextStyle(fontSize: 16)),
-              const SizedBox(height: 8),
-              Text('🔥 칼로리: ${menu['calories']} kcal', style: const TextStyle(fontSize: 16)),
-              const SizedBox(height: 16),
-              const Text('🤖 AI 추천 사유:', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
-              const SizedBox(height: 4),
-              Text(menu['reason'], style: TextStyle(color: Colors.grey[700], height: 1.4, fontSize: 15)),
-            ],
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context), 
-              child: const Text('닫기', style: TextStyle(color: Colors.grey, fontWeight: FontWeight.bold))
-            ),
-            // 💡 선택 버튼에 그라데이션 캡슐 디자인 적용
-            Container(
-              decoration: BoxDecoration(
-                gradient: AppTheme.aiGradient,
-                borderRadius: BorderRadius.circular(30),
-              ),
-              child: ElevatedButton(
-                onPressed: () {
-                  Navigator.pop(context);
-                  ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('${menu['name']} 선택 완료!')));
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.transparent,
-                  shadowColor: Colors.transparent,
-                  shape: const StadiumBorder(),
-                  padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-                ),
-                child: const Text('선택', style: TextStyle(fontWeight: FontWeight.bold, color: Colors.white)),
-              ),
-            ),
-          ],
-        );
-      },
-    );
+  Future<void> _fetchAiResult() async {
+    try {
+      final result = await RecommendationService.recommend(widget.request);
+      if (mounted) setState(() { _aiResult = result; _aiLoading = false; });
+    } catch (e) {
+      if (mounted) setState(() { _aiError = e.toString(); _aiLoading = false; });
+    }
   }
 
-  // 피드백 입력창 (바텀 시트)
   void _showFeedbackBottomSheet() {
-    // 시트를 열 때 별점 초기화
     _rating = 0;
     _feedbackController.clear();
-
     showModalBottomSheet(
       context: context,
-      isScrollControlled: true, 
+      isScrollControlled: true,
       backgroundColor: Colors.transparent,
-      builder: (context) {
-        return StatefulBuilder( 
-          builder: (BuildContext context, StateSetter setModalState) {
-            return Container(
-              padding: EdgeInsets.only(
-                left: 24, right: 24, top: 32,
-                bottom: MediaQuery.of(context).viewInsets.bottom + 24, 
+      builder: (context) => StatefulBuilder(
+        builder: (ctx, setModal) => Container(
+          padding: EdgeInsets.only(
+            left: 24, right: 24, top: 32,
+            bottom: MediaQuery.of(context).viewInsets.bottom + 24,
+          ),
+          decoration: const BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Text('이번 추천은 어떠셨나요?',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+              const SizedBox(height: 20),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: List.generate(5, (i) => IconButton(
+                  icon: Icon(
+                    i < _rating ? Icons.star_rounded : Icons.star_outline_rounded,
+                    size: 48,
+                    color: i < _rating ? Colors.amber : Colors.grey[300],
+                  ),
+                  onPressed: () => setModal(() => _rating = i + 1),
+                )),
               ),
-              decoration: const BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.vertical(top: Radius.circular(28)), // 💡 시트 상단 부드러운 라운딩
+              const SizedBox(height: 20),
+              TextField(
+                controller: _feedbackController,
+                maxLines: 3,
+                decoration: InputDecoration(
+                  hintText: '아쉬운 점이 있다면 알려주세요...',
+                  filled: true,
+                  fillColor: Colors.grey.shade100,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(16),
+                    borderSide: BorderSide.none,
+                  ),
+                ),
               ),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  const Text(
-                    '이번 추천은 어떠셨나요?',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              const SizedBox(height: 24),
+              Container(
+                height: 56,
+                decoration: BoxDecoration(
+                  gradient: AppTheme.aiGradient,
+                  borderRadius: BorderRadius.circular(30),
+                ),
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.pop(context);
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('소중한 피드백 감사합니다!')),
+                    );
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.transparent,
+                    shadowColor: Colors.transparent,
+                    shape: const StadiumBorder(),
                   ),
-                  const SizedBox(height: 20),
-                  
-                  // 별점 선택
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: List.generate(5, (index) {
-                      return IconButton(
-                        icon: Icon(
-                          index < _rating ? Icons.star_rounded : Icons.star_outline_rounded,
-                          size: 48, // 별 크기 약간 증가
-                          color: index < _rating ? Colors.amber : Colors.grey[300],
-                        ),
-                        onPressed: () {
-                          setModalState(() => _rating = index + 1);
-                        },
-                      );
-                    }),
-                  ),
-                  const SizedBox(height: 20),
-                  
-                  // 💡 피드백 텍스트 필드 디자인 적용 (16px 라운딩)
-                  TextField(
-                    controller: _feedbackController,
-                    maxLines: 3,
-                    decoration: InputDecoration(
-                      hintText: '아쉬운 점이 있다면 알려주세요...',
-                      filled: true,
-                      fillColor: Colors.grey.shade100,
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(16),
-                        borderSide: BorderSide.none,
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(16),
-                        borderSide: const BorderSide(color: AppTheme.primaryColor, width: 2),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 32),
-                  
-                  // 💡 피드백 제출 버튼 그라데이션 적용
-                  Container(
-                    height: 56,
-                    decoration: BoxDecoration(
-                      gradient: AppTheme.aiGradient,
-                      borderRadius: BorderRadius.circular(30),
-                      boxShadow: [
-                        BoxShadow(
-                          color: AppTheme.primaryColor.withOpacity(0.3),
-                          blurRadius: 10,
-                          offset: const Offset(0, 4),
-                        ),
-                      ],
-                    ),
-                    child: ElevatedButton(
-                      onPressed: () {
-                        // ignore: avoid_print
-                        print('피드백: $_rating점, ${_feedbackController.text}');
-                        Navigator.pop(context); 
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(content: Text('소중한 피드백 감사합니다!')),
-                        );
-                      },
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.transparent,
-                        shadowColor: Colors.transparent,
-                        shape: const StadiumBorder(),
-                      ),
-                      child: const Text('피드백 제출하기', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white)),
-                    ),
-                  ),
-                ],
+                  child: const Text('피드백 제출하기',
+                      style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white)),
+                ),
               ),
-            );
-          }
-        );
-      },
+            ],
+          ),
+        ),
+      ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
+    final aiPickName = _aiResult?.menuName;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('맞춤 메뉴 추천', style: TextStyle(fontWeight: FontWeight.bold)),
@@ -214,70 +137,166 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
         elevation: 0,
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       ),
-      body: SafeArea(
-        child: Column(
-          children: [
-            // 1. 추천 메뉴 리스트
-            Expanded(
-              child: ListView.builder(
-                padding: const EdgeInsets.all(20.0),
-                itemCount: _recommendedMenus.length,
-                itemBuilder: (context, index) {
-                  final menu = _recommendedMenus[index];
-                  return Card(
-                    margin: const EdgeInsets.only(bottom: 16),
-                    // 💡 글로벌 테마가 적용되지만 혹시 몰라 명시적 처리
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-                    child: InkWell(
-                      borderRadius: BorderRadius.circular(20), // 💡 클릭 시 물결 효과 라운딩 통일
-                      onTap: () => _showMenuDetailDialog(menu),
-                      child: Padding(
-                        padding: const EdgeInsets.all(20.0),
-                        child: Row(
-                          children: [
-                            Container(
-                              width: 56, height: 56,
-                              decoration: BoxDecoration(
-                                color: AppTheme.primaryColor.withOpacity(0.1), // 💡 AppTheme 색상 적용
-                                borderRadius: BorderRadius.circular(16),
-                              ),
-                              child: const Icon(Icons.restaurant, color: AppTheme.primaryColor, size: 28),
-                            ),
-                            const SizedBox(width: 16),
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(menu['name'], style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                                  const SizedBox(height: 4),
-                                  Text('${menu['price']}원', style: TextStyle(color: Colors.grey[600], fontSize: 15)),
-                                ],
-                              ),
-                            ),
-                            const Icon(Icons.chevron_right, color: Colors.grey),
-                          ],
+      body: Column(
+        children: [
+          Expanded(
+            child: CustomScrollView(
+              slivers: [
+                // ── AI 추천 1픽 섹션 ──────────────────────────
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                    child: _AiPickSection(
+                      loading: _aiLoading,
+                      result: _aiResult,
+                      error: _aiError,
+                      onRetry: () {
+                        setState(() { _aiLoading = true; _aiError = null; });
+                        _fetchAiResult();
+                      },
+                    ),
+                  ),
+                ),
+
+                // ── 후보 메뉴 헤더 ────────────────────────────
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                    child: Row(
+                      children: [
+                        const Icon(Icons.list_alt, size: 18, color: AppTheme.primaryColor),
+                        const SizedBox(width: 6),
+                        Text(
+                          '후보 메뉴 ${widget.candidates.length}개',
+                          style: const TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+                // ── 후보 메뉴 목록 ────────────────────────────
+                widget.candidates.isEmpty
+                    ? SliverToBoxAdapter(
+                        child: Padding(
+                          padding: const EdgeInsets.all(32),
+                          child: Center(
+                            child: Text('후보 메뉴를 불러오지 못했습니다.',
+                                style: TextStyle(color: Colors.grey[500])),
+                          ),
+                        ),
+                      )
+                    : SliverList(
+                        delegate: SliverChildBuilderDelegate(
+                          (ctx, i) => _CandidateCard(
+                            candidate: widget.candidates[i],
+                            isAiPick: aiPickName != null &&
+                                widget.candidates[i].name == aiPickName,
+                          ),
+                          childCount: widget.candidates.length,
                         ),
                       ),
-                    ),
-                  );
-                },
-              ),
+
+                const SliverToBoxAdapter(child: SizedBox(height: 16)),
+              ],
             ),
-            
-            // 2. 하단 고정 버튼 (피드백)
-            Padding(
-              padding: const EdgeInsets.all(20.0),
-              child: OutlinedButton(
-                onPressed: _showFeedbackBottomSheet, 
-                style: OutlinedButton.styleFrom(
-                  side: const BorderSide(color: AppTheme.primaryColor, width: 1.5), // 💡 AppTheme 색상
-                  minimumSize: const Size(double.infinity, 56),
-                  shape: const StadiumBorder(), // 💡 캡슐 모양으로 통일
-                ),
-                child: const Text(
-                  '메뉴 추천 결과 피드백 남기기',
-                  style: TextStyle(color: AppTheme.primaryColor, fontSize: 16, fontWeight: FontWeight.bold),
-                ),
+          ),
+
+          // ── 피드백 버튼 ───────────────────────────────────
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 20),
+            child: OutlinedButton(
+              onPressed: _showFeedbackBottomSheet,
+              style: OutlinedButton.styleFrom(
+                side: const BorderSide(color: AppTheme.primaryColor, width: 1.5),
+                minimumSize: const Size(double.infinity, 52),
+                shape: const StadiumBorder(),
+              ),
+              child: const Text('추천 결과 피드백 남기기',
+                  style: TextStyle(
+                      color: AppTheme.primaryColor,
+                      fontSize: 15,
+                      fontWeight: FontWeight.bold)),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── AI 추천 1픽 섹션 ─────────────────────────────────────────
+class _AiPickSection extends StatelessWidget {
+  final bool loading;
+  final RecommendationResult? result;
+  final String? error;
+  final VoidCallback onRetry;
+
+  const _AiPickSection({
+    required this.loading,
+    required this.result,
+    required this.error,
+    required this.onRetry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            ShaderMask(
+              blendMode: BlendMode.srcIn,
+              shaderCallback: (b) => AppTheme.aiGradient.createShader(b),
+              child: const Icon(Icons.auto_awesome, size: 20),
+            ),
+            const SizedBox(width: 6),
+            ShaderMask(
+              blendMode: BlendMode.srcIn,
+              shaderCallback: (b) => AppTheme.aiGradient.createShader(b),
+              child: const Text('AI 추천 1픽',
+                  style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold)),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        if (loading)
+          _LoadingCard()
+        else if (error != null)
+          _ErrorCard(error: error!, onRetry: onRetry)
+        else if (result != null)
+          _ResultCard(result: result!),
+      ],
+    );
+  }
+}
+
+class _LoadingCard extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          children: [
+            const SizedBox(
+              width: 24, height: 24,
+              child: CircularProgressIndicator(
+                  color: AppTheme.primaryColor, strokeWidth: 2.5),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('AI가 최적 메뉴를 분석 중입니다...',
+                      style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14)),
+                  const SizedBox(height: 4),
+                  Text('후보 목록을 먼저 확인해보세요.',
+                      style: TextStyle(fontSize: 12, color: Colors.grey[600])),
+                ],
               ),
             ),
           ],
@@ -285,4 +304,244 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
       ),
     );
   }
+}
+
+class _ErrorCard extends StatelessWidget {
+  final String error;
+  final VoidCallback onRetry;
+  const _ErrorCard({required this.error, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            const Icon(Icons.error_outline, color: Colors.red),
+            const SizedBox(width: 10),
+            const Expanded(
+                child: Text('AI 추천을 불러오지 못했습니다.',
+                    style: TextStyle(fontSize: 13))),
+            TextButton(onPressed: onRetry, child: const Text('재시도')),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ResultCard extends StatelessWidget {
+  final RecommendationResult result;
+  const _ResultCard({required this.result});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // 이미지
+          if (result.mainImg.isNotEmpty)
+            Image.network(
+              result.mainImg,
+              height: 160,
+              fit: BoxFit.cover,
+              errorBuilder: (_, _, _) => Container(
+                height: 160,
+                color: AppTheme.primaryColor.withValues(alpha: 0.1),
+                child: const Icon(Icons.restaurant, size: 48, color: AppTheme.primaryColor),
+              ),
+            ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // 메뉴명
+                Text(result.menuName,
+                    style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 8),
+                // 추천 이유
+                Text(result.selectionReason,
+                    style: TextStyle(fontSize: 13, color: Colors.grey[700], height: 1.5)),
+                const SizedBox(height: 12),
+                // 영양 정보 칩
+                _NutritionRow(info: result.nutritionInfo),
+                // 예상 비용
+                if (result.totalEstimatedCost > 0) ...[
+                  const SizedBox(height: 10),
+                  Row(children: [
+                    const Icon(Icons.receipt_long_outlined,
+                        size: 15, color: AppTheme.primaryColor),
+                    const SizedBox(width: 4),
+                    Text('예상 재료비 약 ${result.totalEstimatedCost.toInt()}원',
+                        style: const TextStyle(
+                            fontSize: 13, fontWeight: FontWeight.w600)),
+                  ]),
+                ],
+                // 레시피 단계 (있는 경우)
+                if (result.recipeSteps.isNotEmpty) ...[
+                  const Divider(height: 24),
+                  const Text('조리 방법',
+                      style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14)),
+                  const SizedBox(height: 8),
+                  ...result.recipeSteps.map((s) => Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Container(
+                          width: 22, height: 22,
+                          decoration: const BoxDecoration(
+                              color: AppTheme.primaryColor, shape: BoxShape.circle),
+                          child: Center(
+                            child: Text('${s.stepNo}',
+                                style: const TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 11,
+                                    fontWeight: FontWeight.bold)),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(s.content,
+                              style: TextStyle(
+                                  fontSize: 13, color: Colors.grey[800], height: 1.4)),
+                        ),
+                      ],
+                    ),
+                  )),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── 영양 정보 칩 행 ───────────────────────────────────────────
+class _NutritionRow extends StatelessWidget {
+  final NutritionInfo info;
+  const _NutritionRow({required this.info});
+
+  @override
+  Widget build(BuildContext context) {
+    final items = [
+      ('열량', info.energy),
+      ('단백질', info.protein),
+      ('지방', info.fat),
+      ('탄수화물', info.carbs),
+      ('나트륨', info.sodium),
+    ];
+    return Wrap(
+      spacing: 6,
+      runSpacing: 4,
+      children: items.map((item) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: AppTheme.primaryColor.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Text('${item.$1} ${item.$2}',
+            style: const TextStyle(fontSize: 11, fontWeight: FontWeight.w500)),
+      )).toList(),
+    );
+  }
+}
+
+// ── 후보 메뉴 카드 ────────────────────────────────────────────
+class _CandidateCard extends StatelessWidget {
+  final MenuCandidate candidate;
+  final bool isAiPick;
+
+  const _CandidateCard({required this.candidate, required this.isAiPick});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(14),
+        border: isAiPick
+            ? Border.all(color: AppTheme.primaryColor, width: 2)
+            : null,
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.04),
+            blurRadius: 6,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        child: Row(
+          children: [
+            // 썸네일
+            ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: candidate.mainImageUrl != null &&
+                      candidate.mainImageUrl!.isNotEmpty
+                  ? Image.network(
+                      candidate.mainImageUrl!,
+                      width: 52, height: 52, fit: BoxFit.cover,
+                      errorBuilder: (_, _, _) => _placeholder(),
+                    )
+                  : _placeholder(),
+            ),
+            const SizedBox(width: 12),
+            // 이름 + 칼로리
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(candidate.name,
+                      style: const TextStyle(
+                          fontWeight: FontWeight.w600, fontSize: 14)),
+                  const SizedBox(height: 3),
+                  Text(
+                    [
+                      if (candidate.calories != null)
+                        '${candidate.calories!.toInt()} kcal',
+                      if (candidate.protein != null)
+                        '단백질 ${candidate.protein!.toStringAsFixed(1)}g',
+                    ].join('  ·  '),
+                    style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+                  ),
+                ],
+              ),
+            ),
+            // AI 픽 뱃지
+            if (isAiPick)
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  gradient: AppTheme.aiGradient,
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: const Text('AI 픽',
+                    style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 11,
+                        fontWeight: FontWeight.bold)),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _placeholder() => Container(
+        width: 52, height: 52,
+        color: AppTheme.primaryColor.withValues(alpha: 0.08),
+        child: const Icon(Icons.restaurant,
+            size: 24, color: AppTheme.primaryColor),
+      );
 }

--- a/flutter_app/lib/services/auth_service.dart
+++ b/flutter_app/lib/services/auth_service.dart
@@ -8,6 +8,7 @@ class ApiConfig {
   // TODO: 실제 서버 주소로 변경
   static const String baseUrl = 'http://localhost:8080';
   static const String apiVersion = '/api/v1';
+  static const String aiBaseUrl = 'http://localhost:8000';
 }
 
 // 인증 관련 API 서비스

--- a/flutter_app/lib/services/recommendation_service.dart
+++ b/flutter_app/lib/services/recommendation_service.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter_app/models/recommendation_models.dart';
+import 'auth_service.dart';
+
+class RecommendationService {
+  static Future<List<MenuCandidate>> fetchCandidates(String? jwt) async {
+    final uri = Uri.parse('${ApiConfig.baseUrl}/api/menus/candidates');
+    final headers = <String, String>{};
+    if (jwt != null && jwt.isNotEmpty) {
+      headers['Authorization'] = 'Bearer $jwt';
+    }
+
+    final response = await http
+        .get(uri, headers: headers)
+        .timeout(const Duration(seconds: 10));
+
+    if (response.statusCode != 200) return [];
+
+    final json = jsonDecode(utf8.decode(response.bodyBytes));
+    if (json['success'] != true || json['data'] == null) return [];
+    return (json['data'] as List)
+        .map((e) => MenuCandidate.fromJson(e))
+        .toList();
+  }
+
+  static Future<RecommendationResult> recommend(RecommendationRequest request) async {
+    final uri = Uri.parse('${ApiConfig.aiBaseUrl}/recommend');
+
+    final response = await http
+        .post(
+          uri,
+          headers: {'Content-Type': 'application/json'},
+          body: jsonEncode(request.toJson()),
+        )
+        .timeout(
+          const Duration(seconds: 120),
+          onTimeout: () => throw Exception('AI 서버 응답 시간 초과 (120초)'),
+        );
+
+    if (response.statusCode != 200) {
+      final body = jsonDecode(response.body);
+      throw Exception(body['detail'] ?? 'AI 추천 실패 (${response.statusCode})');
+    }
+
+    final json = jsonDecode(utf8.decode(response.bodyBytes));
+    return RecommendationResult.fromJson(json);
+  }
+}


### PR DESCRIPTION
## 개요

AI 서버의 추천 결과를 Flutter 앱에 실제로 연결하고,
추천 화면을 후보 목록(빠름) + AI 1픽(느림) 2단계 구조로 재구성했습니다.
JSON 파일 의존성을 제거하고 Spring DB에서 레시피 데이터를 직접 조회합니다.

## 주요 변경 사항

### Flutter
- `RecommendationScreen` 전면 재작성: 후보 목록 즉시 표시 → AI 1픽 비동기 로딩
- `DashboardScreen`: AI 응답 대기 없이 후보 목록 받는 즉시 화면 전환
- `recommendation_models.dart` 추가: `MenuCandidate`, `RecommendationResult` 등 모델 정의
- `recommendation_service.dart` 추가: `fetchCandidates()`, `recommend()` API 호출 (타임아웃 120초)

### Spring Backend
- `Menu` 엔티티에 `healthTip` 필드 추가
- `MenuCandidateDto`에 `ingredientsText`, `healthTip`, `steps` 필드 추가
- `MenuRepository`에 재료
- `MenuCandidateService`에 `getRandomCandidates()` 추가 (JWT 없을 때 폴백)
- `MenuCandidateControlleruired = false`)

### Python AI 서버
- `server.py`: JSON 파일 로딩 제거 → 런타임에 Spring `/api/menus/candidates` 직접 조회
- `MenuFetcher.py`: Spring DTO → AI 내부 포맷(`RCP_NM`, `INFO_ENG` 등) 변환 로직 추가
- `ProcessDynamicInputs.py`: `_enrich_candidates()`가 `active_recipes`를 직접받도록 버그 수정
- `SelectCandidates.py`: `JsonOutputParser` 적용, LangChain 프롬프트 중괄호 이스케이프 수정
- `GetMarketPrices.py`: Python 3.9 호환 타입 힌트 수정 (`X | None` → `Optional[X]`)

### 기타
- `README.md` 추가: 전체 시스템 워크플로우, 모듈 역할, DB 구조, 향후 작업 목록
- `.gitignore` 업데이트

## 미연결 항목 (향후 작업)

- KAMIS 실시간 물가 → AI  서버 연동 (현재는 ai 생성만 사용)
- 레시피 조리 단계(`menu_steps` 테이블) 미구현으로 단계 목록 빈 리스트 반환
- `health_conditions 빈리스트 고정 -> 사용자에게 질병 입력받아야함