### PR TITLE
feat: 메뉴 추천 피드백 및 추천 메뉴 상세페이지 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ __pycache__/
 # Environment secrets
 .env
 !.env.example
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
@@ -1,0 +1,43 @@
+package capstone.ai_meal_assistant_backend.domain.history.controller;
+
+import capstone.ai_meal_assistant_backend.domain.history.service.RecommendationLogService;
+import capstone.ai_meal_assistant_backend.global.security.JwtUtil;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/recommendation-logs")
+@RequiredArgsConstructor
+public class RecommendationLogController {
+
+    private final RecommendationLogService recommendationLogService;
+    private final JwtUtil jwtUtil;
+
+    @PostMapping
+    public ResponseEntity<?> saveFeedback(
+            @RequestHeader(value = "Authorization", required = false) String authHeader,
+            @RequestBody FeedbackRequest request) {
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return ResponseEntity.status(401).body(Map.of("success", false, "error", "인증이 필요합니다."));
+        }
+
+        String email = jwtUtil.getEmailFromToken(authHeader.substring(7));
+        recommendationLogService.saveFeedback(email, request.getMenuId(), request.getFeedbackScore());
+        return ResponseEntity.ok(Map.of("success", true));
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    static class FeedbackRequest {
+        private Long menuId;
+        private int feedbackScore;
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
@@ -29,7 +29,8 @@ public class RecommendationLogController {
         }
 
         String email = jwtUtil.getEmailFromToken(authHeader.substring(7));
-        recommendationLogService.saveFeedback(email, request.getMenuId(), request.getFeedbackScore());
+        recommendationLogService.saveFeedback(email, request.getMenuId(),
+                request.getFeedbackScore(), request.getStarRating(), request.getFeedbackReason());
         return ResponseEntity.ok(Map.of("success", true));
     }
 
@@ -38,6 +39,8 @@ public class RecommendationLogController {
     @NoArgsConstructor
     static class FeedbackRequest {
         private Long menuId;
-        private int feedbackScore;
+        private Integer feedbackScore;  // 후보 좋아요/싫어요: 1 or -1
+        private Integer starRating;     // AI 픽 별점: 1~5
+        private String feedbackReason;
     }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/entity/RecommendationLog.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/entity/RecommendationLog.java
@@ -38,9 +38,11 @@ public class RecommendationLog extends BaseEntity {
     @JoinColumn(name = "selected_menu_id", nullable = false)
     private Menu selectedMenu;
 
-    // 1 = 긍정, -1 = 부정
-    @Column(nullable = false)
+    // 1 = 긍정, -1 = 부정 (후보 메뉴 좋아요/싫어요 — 다음 추천 필터링에 사용)
     private Integer feedbackScore;
+
+    // 1~5 별점 (AI 픽 만족도 — 추후 RAG/분석용)
+    private Integer starRating;
 
     @Column(columnDefinition = "TEXT")
     private String feedbackReason;

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/entity/RecommendationLog.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/entity/RecommendationLog.java
@@ -4,13 +4,22 @@ import capstone.ai_meal_assistant_backend.domain.menu.entity.Menu;
 import capstone.ai_meal_assistant_backend.domain.user.entity.User;
 import capstone.ai_meal_assistant_backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 import java.util.List;
 
 @Entity
-@Table(name = "recommendation_logs")
+@Table(
+    name = "recommendation_logs",
+    indexes = @Index(name = "idx_rec_log_user_score", columnList = "user_id, feedback_score")
+)
+@Getter
+@Setter
+@NoArgsConstructor
 public class RecommendationLog extends BaseEntity {
 
     @Id
@@ -18,20 +27,21 @@ public class RecommendationLog extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    // ★ 최신 하이버네이트 6 (스프링 부트 3.x) JSON 컬럼 매핑 방식 ★
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "json")
-    private List<Long> recommendedMenuIds; // AI가 추천했던 메뉴 ID 리스트를 JSON 배열로 저장
+    private List<Long> recommendedMenuIds;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "selected_menu_id")
+    @JoinColumn(name = "selected_menu_id", nullable = false)
     private Menu selectedMenu;
 
+    // 1 = 긍정, -1 = 부정
+    @Column(nullable = false)
     private Integer feedbackScore;
 
     @Column(columnDefinition = "TEXT")
-    private String feedbackReason; // RAG 검색 재료용
+    private String feedbackReason;
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/repository/RecommendationLogRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/repository/RecommendationLogRepository.java
@@ -1,0 +1,17 @@
+package capstone.ai_meal_assistant_backend.domain.history.repository;
+
+import capstone.ai_meal_assistant_backend.domain.history.entity.RecommendationLog;
+import capstone.ai_meal_assistant_backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+
+@Repository
+public interface RecommendationLogRepository extends JpaRepository<RecommendationLog, Long> {
+
+    @Query("SELECT r.selectedMenu.id FROM RecommendationLog r WHERE r.user = :user AND r.feedbackScore < 0")
+    Set<Long> findNegativeMenuIdsByUser(@Param("user") User user);
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
@@ -21,7 +21,7 @@ public class RecommendationLogService {
     private final MenuRepository menuRepository;
 
     @Transactional
-    public void saveFeedback(String email, Long menuId, int feedbackScore) {
+    public void saveFeedback(String email, Long menuId, Integer feedbackScore, Integer starRating, String feedbackReason) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
         Menu menu = menuRepository.findById(menuId)
@@ -31,6 +31,8 @@ public class RecommendationLogService {
         log.setUser(user);
         log.setSelectedMenu(menu);
         log.setFeedbackScore(feedbackScore);
+        log.setStarRating(starRating);
+        log.setFeedbackReason(feedbackReason);
         recommendationLogRepository.save(log);
     }
 

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
@@ -1,0 +1,41 @@
+package capstone.ai_meal_assistant_backend.domain.history.service;
+
+import capstone.ai_meal_assistant_backend.domain.history.entity.RecommendationLog;
+import capstone.ai_meal_assistant_backend.domain.history.repository.RecommendationLogRepository;
+import capstone.ai_meal_assistant_backend.domain.menu.entity.Menu;
+import capstone.ai_meal_assistant_backend.domain.menu.repository.MenuRepository;
+import capstone.ai_meal_assistant_backend.domain.user.entity.User;
+import capstone.ai_meal_assistant_backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendationLogService {
+
+    private final RecommendationLogRepository recommendationLogRepository;
+    private final UserRepository userRepository;
+    private final MenuRepository menuRepository;
+
+    @Transactional
+    public void saveFeedback(String email, Long menuId, int feedbackScore) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        Menu menu = menuRepository.findById(menuId)
+                .orElseThrow(() -> new IllegalArgumentException("메뉴를 찾을 수 없습니다."));
+
+        RecommendationLog log = new RecommendationLog();
+        log.setUser(user);
+        log.setSelectedMenu(menu);
+        log.setFeedbackScore(feedbackScore);
+        recommendationLogRepository.save(log);
+    }
+
+    @Transactional(readOnly = true)
+    public Set<Long> getNegativeMenuIds(User user) {
+        return recommendationLogRepository.findNegativeMenuIdsByUser(user);
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/controller/MenuCandidateController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/controller/MenuCandidateController.java
@@ -35,6 +35,11 @@ public class MenuCandidateController {
         }
     }
 
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<MenuCandidateDto>> getMenuById(@PathVariable("id") Long id) {
+        return ResponseEntity.ok(ApiResponse.ok(menuCandidateService.getMenuById(id)));
+    }
+
     /**
      * AI 추천용 메뉴 후보 반환
      * - ids 파라미터 제공 시: 해당 ID 목록의 메뉴만 반환 (AI agent 전용)

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/controller/MenuCandidateController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/controller/MenuCandidateController.java
@@ -36,15 +36,19 @@ public class MenuCandidateController {
     }
 
     /**
-     * AI 추천용 메뉴 후보 25개 반환
-     * - 알레르기 메뉴 제외
-     * - 예산 필터
-     * - 단백질 수준 필터
-     * - 이후 fitnessGoal / foodPreferences 필드 병합 시 확장 예정
+     * AI 추천용 메뉴 후보 반환
+     * - ids 파라미터 제공 시: 해당 ID 목록의 메뉴만 반환 (AI agent 전용)
+     * - ids 없고 JWT 있을 시: 사용자 조건 필터링 후 랜덤 25개
+     * - ids 없고 JWT 없을 시: 랜덤 25개
      */
     @GetMapping("/candidates")
     public ResponseEntity<ApiResponse<List<MenuCandidateDto>>> getCandidates(
-            @RequestHeader(value = "Authorization", required = false) String authHeader) {
+            @RequestHeader(value = "Authorization", required = false) String authHeader,
+            @RequestParam(value = "ids", required = false) List<Long> ids) {
+
+        if (ids != null && !ids.isEmpty()) {
+            return ResponseEntity.ok(ApiResponse.ok(menuCandidateService.getCandidatesByIds(ids)));
+        }
 
         List<MenuCandidateDto> candidates;
         if (authHeader != null && authHeader.startsWith("Bearer ")) {

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/MenuRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/MenuRepository.java
@@ -15,10 +15,10 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     @Query(value = """
             SELECT * FROM menus m
-            WHERE (:excludeIds IS NULL OR m.id NOT IN (:excludeIds))
-              AND (:budget   IS NULL OR m.base_price IS NULL OR m.base_price <= :budget)
-              AND (:minPro   IS NULL OR m.protein >= :minPro)
-              AND (:maxCal   IS NULL OR m.calories <= :maxCal)
+            WHERE m.id NOT IN (:excludeIds)
+              AND (:budget IS NULL OR m.base_price IS NULL OR m.base_price <= :budget)
+              AND (:minPro IS NULL OR m.protein >= :minPro)
+              AND (:maxCal IS NULL OR m.calories <= :maxCal)
             ORDER BY RAND()
             LIMIT :limit
             """, nativeQuery = true)

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/MenuRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/MenuRepository.java
@@ -32,7 +32,7 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     @Query(value = """
             SELECT mi.menu_id,
-                   GROUP_CONCAT(CONCAT(i.name, ' ', COALESCE(mi.amount_text, ''))
+                   GROUP_CONCAT(DISTINCT CONCAT(i.name, ' ', COALESCE(mi.amount_text, ''))
                                 ORDER BY i.name SEPARATOR ', ') AS ingredients_text
             FROM menu_ingredients mi
             JOIN ingredients i ON mi.ingredient_id = i.id

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/service/MenuCandidateService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/service/MenuCandidateService.java
@@ -1,5 +1,6 @@
 package capstone.ai_meal_assistant_backend.domain.menu.service;
 
+import capstone.ai_meal_assistant_backend.domain.history.repository.RecommendationLogRepository;
 import capstone.ai_meal_assistant_backend.domain.menu.dto.MenuCandidateDto;
 import capstone.ai_meal_assistant_backend.domain.menu.entity.Allergy;
 import capstone.ai_meal_assistant_backend.domain.menu.entity.Menu;
@@ -31,6 +32,7 @@ public class MenuCandidateService {
     private final UserAllergyRepository userAllergyRepository;
     private final MenuAllergyRepository menuAllergyRepository;
     private final MenuRepository menuRepository;
+    private final RecommendationLogRepository recommendationLogRepository;
 
     public List<MenuCandidateDto> getCandidates(String email) {
         User user = userRepository.findByEmail(email)
@@ -38,7 +40,9 @@ public class MenuCandidateService {
 
         UserPreference pref = preferenceRepository.findByUser(user).orElse(null);
 
-        Set<Long> excludeMenuIds = getExcludeMenuIds(user);
+        Set<Long> excludeMenuIds = new HashSet<>(getExcludeMenuIds(user));
+        excludeMenuIds.addAll(recommendationLogRepository.findNegativeMenuIdsByUser(user));
+
         Integer budget     = pref != null ? pref.getMealBudget() : null;
         Double  minProtein = resolveMinProtein(pref);
 
@@ -52,12 +56,16 @@ public class MenuCandidateService {
         return buildDtos(menus);
     }
 
+    public List<MenuCandidateDto> getCandidatesByIds(List<Long> ids) {
+        List<Menu> menus = menuRepository.findAllById(ids);
+        return buildDtos(menus);
+    }
+
     private List<MenuCandidateDto> buildDtos(List<Menu> menus) {
         if (menus.isEmpty()) return Collections.emptyList();
 
         List<Long> menuIds = menus.stream().map(Menu::getId).collect(Collectors.toList());
 
-        // 재료 텍스트 일괄 조회 (쿼리 1번)
         Map<Long, String> ingredientsMap = new HashMap<>();
         for (Object[] row : menuRepository.findIngredientsTextByMenuIds(menuIds)) {
             Long menuId = ((Number) row[0]).longValue();
@@ -68,7 +76,7 @@ public class MenuCandidateService {
                 .map(m -> MenuCandidateDto.from(
                         m,
                         ingredientsMap.getOrDefault(m.getId(), ""),
-                        Collections.emptyList() // TODO: menu_steps 테이블 추가 후 연결
+                        Collections.emptyList()
                 ))
                 .collect(Collectors.toList());
     }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/service/MenuCandidateService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/service/MenuCandidateService.java
@@ -69,6 +69,14 @@ public class MenuCandidateService {
         return buildDtos(menus);
     }
 
+    public MenuCandidateDto getMenuById(Long id) {
+        Menu menu = menuRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("메뉴를 찾을 수 없습니다. id=" + id));
+        List<Object[]> rows = menuRepository.findIngredientsTextByMenuIds(List.of(id));
+        String ingredientsText = rows.isEmpty() ? "" : (String) rows.get(0)[1];
+        return MenuCandidateDto.from(menu, ingredientsText, Collections.emptyList());
+    }
+
     private List<MenuCandidateDto> buildDtos(List<Menu> menus) {
         if (menus.isEmpty()) return Collections.emptyList();
 

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/service/MenuCandidateService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/service/MenuCandidateService.java
@@ -14,12 +14,14 @@ import capstone.ai_meal_assistant_backend.domain.user.entity.UserPreference;
 import capstone.ai_meal_assistant_backend.domain.user.repository.UserPreferenceRepository;
 import capstone.ai_meal_assistant_backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -41,7 +43,13 @@ public class MenuCandidateService {
         UserPreference pref = preferenceRepository.findByUser(user).orElse(null);
 
         Set<Long> excludeMenuIds = new HashSet<>(getExcludeMenuIds(user));
-        excludeMenuIds.addAll(recommendationLogRepository.findNegativeMenuIdsByUser(user));
+        try {
+            Set<Long> negativeIds = recommendationLogRepository.findNegativeMenuIdsByUser(user);
+            log.debug("[MenuCandidateService] 부정 피드백 제외 메뉴 {}개", negativeIds.size());
+            excludeMenuIds.addAll(negativeIds);
+        } catch (Exception e) {
+            log.error("[MenuCandidateService] 부정 피드백 조회 실패 (필터링 없이 진행): {}", e.getMessage(), e);
+        }
 
         Integer budget     = pref != null ? pref.getMealBudget() : null;
         Double  minProtein = resolveMinProtein(pref);

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/UserProfileRequest.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/UserProfileRequest.java
@@ -7,11 +7,13 @@ import capstone.ai_meal_assistant_backend.domain.user.entity.VegetarianType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDate;
 import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserProfileRequest {
@@ -39,4 +41,7 @@ public class UserProfileRequest {
 
     // 알러지 정보 (이름 리스트)
     private List<String> allergies;
+
+    // 건강 상태 (예: 고혈압, 당뇨 등)
+    private List<String> healthConditions;
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/UserProfileResponse.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/UserProfileResponse.java
@@ -42,4 +42,7 @@ public class UserProfileResponse {
 
     // 알러지 정보 (이름 리스트)
     private List<String> allergies;
+
+    // 건강 상태 (예: 고혈압, 당뇨 등)
+    private List<String> healthConditions;
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/UserPreference.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/UserPreference.java
@@ -44,9 +44,16 @@ public class UserPreference extends BaseEntity {
     @Builder.Default
     private List<String> foodPreferences = new ArrayList<>();
 
+    @ElementCollection
+    @CollectionTable(name = "user_health_conditions", joinColumns = @JoinColumn(name = "user_preference_id"))
+    @Column(name = "health_condition")
+    @Builder.Default
+    private List<String> healthConditions = new ArrayList<>();
+
     public void updatePreference(Integer mealBudget, VegetarianType vegetarianType,
                                  Integer spicyPreference, ProteinLevel proteinLevel,
-                                 FitnessGoal fitnessGoal, List<String> foodPreferences) {
+                                 FitnessGoal fitnessGoal, List<String> foodPreferences,
+                                 List<String> healthConditions) {
         this.mealBudget = mealBudget;
         this.vegetarianType = vegetarianType;
         this.spicyPreference = spicyPreference;
@@ -55,6 +62,10 @@ public class UserPreference extends BaseEntity {
         if (foodPreferences != null) {
             this.foodPreferences.clear();
             this.foodPreferences.addAll(foodPreferences);
+        }
+        if (healthConditions != null) {
+            this.healthConditions.clear();
+            this.healthConditions.addAll(healthConditions);
         }
     }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/UserProfileService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/UserProfileService.java
@@ -88,6 +88,7 @@ public class UserProfileService {
                     .proteinLevel(request.getProteinLevel())
                     .fitnessGoal(request.getFitnessGoal() != null ? request.getFitnessGoal() : FitnessGoal.GENERAL)
                     .foodPreferences(request.getFoodPreferences() != null ? request.getFoodPreferences() : new java.util.ArrayList<>())
+                    .healthConditions(request.getHealthConditions() != null ? request.getHealthConditions() : new java.util.ArrayList<>())
                     .build();
             preferenceRepository.save(preference);
         } else {
@@ -98,7 +99,8 @@ public class UserProfileService {
                     request.getSpicyPreference(),
                     request.getProteinLevel(),
                     request.getFitnessGoal(),
-                    request.getFoodPreferences()
+                    request.getFoodPreferences(),
+                    request.getHealthConditions()
             );
         }
 
@@ -168,6 +170,7 @@ public class UserProfileService {
                 .fitnessGoal(preference != null ? preference.getFitnessGoal() : null)
                 .foodPreferences(preference != null ? preference.getFoodPreferences() : List.of())
                 .allergies(allergies)
+                .healthConditions(preference != null ? preference.getHealthConditions() : List.of())
                 .build();
     }
 }

--- a/ai_agent_app/MenuFetcher.py
+++ b/ai_agent_app/MenuFetcher.py
@@ -34,20 +34,49 @@ class MenuFetcher:
 
         return []
 
+    def fetch_candidates_by_ids(self, ids: List[int], jwt_token: Optional[str]) -> List[dict]:
+        """
+        Flutter가 미리 조회한 후보 ID 목록으로 Spring GET /api/menus/candidates?ids=... 호출.
+        Flutter와 AI agent가 동일한 후보 풀을 사용하도록 보장.
+        """
+        if not ids:
+            return []
+
+        url = f"{self.backend_url}/api/menus/candidates"
+        headers = {}
+        if jwt_token:
+            headers["Authorization"] = f"Bearer {jwt_token}"
+        params = [("ids", i) for i in ids]
+
+        try:
+            resp = requests.get(url, params=params, headers=headers, timeout=10)
+            resp.raise_for_status()
+            body = resp.json()
+            if body.get("success") and body.get("data"):
+                return [self._to_ai_format(m) for m in body["data"]]
+        except requests.exceptions.ConnectionError:
+            print("[MenuFetcher] Spring 백엔드에 연결할 수 없습니다.")
+        except requests.exceptions.Timeout:
+            print("[MenuFetcher] Spring 백엔드 응답 시간 초과.")
+        except Exception as e:
+            print(f"[MenuFetcher] ID 기반 후보 조회 실패: {e}")
+
+        return []
+
     def _to_ai_format(self, dto: dict) -> dict:
         """Spring MenuCandidateDto → AI 내부 JSON 포맷 변환."""
         recipe = {
-            "RCP_NM":         dto.get("name", ""),
-            "RCP_PARTS_DTLS": dto.get("ingredientsText", ""),
-            "INFO_ENG":        str(dto.get("calories") or 0),
-            "INFO_PRO":        str(dto.get("protein") or 0),
-            "INFO_FAT":        str(dto.get("fat") or 0),
-            "INFO_CAR":        str(dto.get("carbs") or 0),
-            "INFO_NA":         str(dto.get("sodium") or 0),
-            "ATT_FILE_NO_MAIN": dto.get("mainImageUrl", ""),
-            "RCP_NA_TIP":      dto.get("healthTip", ""),
+            "MENU_ID":          dto.get("id"),
+            "RCP_NM":           dto.get("name", ""),
+            "RCP_PARTS_DTLS":   dto.get("ingredientsText", ""),
+            "INFO_ENG":          str(dto.get("calories") or 0),
+            "INFO_PRO":          str(dto.get("protein") or 0),
+            "INFO_FAT":          str(dto.get("fat") or 0),
+            "INFO_CAR":          str(dto.get("carbs") or 0),
+            "INFO_NA":           str(dto.get("sodium") or 0),
+            "ATT_FILE_NO_MAIN":  dto.get("mainImageUrl", ""),
+            "RCP_NA_TIP":        dto.get("healthTip", ""),
         }
-        # 조리 단계 (steps 테이블 연결 후 채워짐)
         for step in dto.get("steps", []):
             num = str(step.get("stepNo", 0)).zfill(2)
             recipe[f"MANUAL{num}"]     = step.get("content", "")

--- a/ai_agent_app/ProcessDynamicInputs.py
+++ b/ai_agent_app/ProcessDynamicInputs.py
@@ -108,12 +108,15 @@ class ProcessDynamicInputs:
             "user_profile": (
                 f"키 {user_query.get('height_cm')}cm, "
                 f"체중 {user_query.get('weight_kg')}kg, "
-                f"목표: {user_query.get('fitness_goal')}"
+                f"운동 목표: {user_query.get('fitness_goal', '일반식단')}, "
+                f"건강 상태: {', '.join(user_query.get('health_conditions', []) or []) or '없음'}, "
+                f"선호 음식: {', '.join(user_query.get('preferences', []) or []) or '없음'}"
             ),
             "user_restrictions": (
                 f"알러지: {', '.join(user_query.get('allergies', []) or [])}, "
                 f"선호: {', '.join(user_query.get('preferences', []) or [])}"
             ),
+            "health_conditions": ', '.join(user_query.get('health_conditions', []) or []) or '없음',
         }
         return self.chain.invoke(llm_input)
     

--- a/ai_agent_app/ProcessDynamicInputs.py
+++ b/ai_agent_app/ProcessDynamicInputs.py
@@ -85,6 +85,7 @@ class ProcessDynamicInputs:
     def _build_static_data(self, final_recipe) -> dict:
         """정적 레시피 데이터 조립"""
         return {
+            "menu_id": final_recipe.get("MENU_ID"),
             "menu_name": final_recipe["RCP_NM"],
             "main_img": final_recipe["ATT_FILE_NO_MAIN"],
             "nutrition_info": {

--- a/ai_agent_app/Prompts.py
+++ b/ai_agent_app/Prompts.py
@@ -3,7 +3,7 @@ from langchain_core.prompts import ChatPromptTemplate
 
 RECIPE_ANALYST_TEMPLATE = """
 # Role: 영양 및 물가 기반 맞춤형 레시피 분석가
-# Task: 
+# Task:
 1. 아래 데이터를 바탕으로 분석을 수행하고 반드시 지정된 JSON 형식으로만 답변하세요.
 2. 제공된 [실시간 물가 정보]를 참고하여 [메뉴 및 재료]에 적힌 각 재료의 비용을 계산하세요.
 3. 마트 판매 단위(예: 1망, 1팩)를 레시피 사용량(예: 1/2개, 100g)으로 환산하여 '실제 소요 비용'을 산출하세요.
@@ -15,11 +15,13 @@ RECIPE_ANALYST_TEMPLATE = """
 - 실시간 물가 정보: {price_info}
 - 프로필: {user_profile}
 - 제한사항: {user_restrictions}
+- 건강 상태: {health_conditions}
 
 
 # 반드시 아래 JSON 구조를 지키세요:
 {{
     "selection_reason": "이 메뉴를 추천한 이유를 사용자 프로필과 제한사항을 근거로 2~3문장으로 서술",
+    "personalized_recipe_tip": "사용자의 건강 상태({health_conditions})와 운동 목표를 고려하여 이 레시피에서 개선하거나 변주할 수 있는 2~3가지 구체적인 방법을 서술. 예: 특정 영양소 보충을 위한 재료 추가, 건강 상태에 따른 재료 대체, 조리법 변경 등. 건강 상태가 없음이면 운동 목표 기반으로만 작성.",
     "total_estimated_cost": 0,
     "market_prices": [
         {{

--- a/ai_agent_app/server.py
+++ b/ai_agent_app/server.py
@@ -38,6 +38,10 @@ class UserRequest(BaseModel):
         default=None,
         description="Spring 백엔드 JWT. 제공 시 서버 사이드 필터링 후보 사용"
     )
+    candidate_menu_ids: Optional[List[int]] = Field(
+        default=None,
+        description="Flutter가 미리 조회한 후보 메뉴 ID 목록. 제공 시 해당 후보만 사용하여 Flutter와 동일한 후보 풀 보장"
+    )
 
 
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8080")
@@ -45,7 +49,7 @@ menu_fetcher = MenuFetcher(BACKEND_URL)
 
 model = ChatOpenAI(
     base_url="https://openrouter.ai/api/v1",
-    model="openai/gpt-4o-mini",   # gpt-4o → gpt-4o-mini: 속도 개선
+    model="openai/gpt-4o-mini",
     temperature=0,
     openai_api_key=os.getenv("OPENROUTER_API_KEY"),
     default_headers={
@@ -54,19 +58,24 @@ model = ChatOpenAI(
     }
 )
 
-get_market_prices = GetMarketPrices([])  # 가격 데이터는 추후 DB 연결
+get_market_prices = GetMarketPrices([])
 select_candidates = SelectCandidates(model)
 
 orchestrator = ProcessDynamicInputs(
-    recipes=[],  # 런타임에 항상 주입되므로 빈 리스트
+    recipes=[],
     get_market_prices=get_market_prices,
     select_candidates=select_candidates,
     model=model
 )
 
 
-def _resolve_recipes(jwt_token: Optional[str]) -> list:
-    """Spring /api/menus/candidates 에서 AI 포맷 후보 리스트 반환."""
+def _resolve_recipes(jwt_token: Optional[str], candidate_menu_ids: Optional[List[int]] = None) -> list:
+    """후보 메뉴 목록 반환. candidate_menu_ids 제공 시 해당 IDs로 조회하여 Flutter와 동일한 풀 사용."""
+    if candidate_menu_ids:
+        candidates = menu_fetcher.fetch_candidates_by_ids(candidate_menu_ids, jwt_token)
+        if candidates:
+            return candidates
+        print("[server] ID 기반 후보 조회 실패, 전체 후보로 대체")
     candidates = menu_fetcher.fetch_candidates_full(jwt_token)
     if not candidates:
         print("[server] Spring 후보 조회 실패")
@@ -76,11 +85,11 @@ def _resolve_recipes(jwt_token: Optional[str]) -> list:
 @app.post("/recommend")
 async def get_recommendation(user_input: UserRequest):
     try:
-        active_recipes = _resolve_recipes(user_input.jwt_token)
+        active_recipes = _resolve_recipes(user_input.jwt_token, user_input.candidate_menu_ids)
         if not active_recipes:
             raise ValueError("메뉴 후보를 가져올 수 없습니다. Spring 백엔드 연결을 확인하세요.")
 
-        user_query = user_input.dict(exclude={"jwt_token"})
+        user_query = user_input.dict(exclude={"jwt_token", "candidate_menu_ids"})
 
         final_result: dict = await asyncio.get_running_loop().run_in_executor(
             None, orchestrator.process_dynamic_inputs, user_query, active_recipes

--- a/flutter_app/lib/models/recommendation_models.dart
+++ b/flutter_app/lib/models/recommendation_models.dart
@@ -8,6 +8,7 @@ class RecommendationRequest {
   final List<String> allergies;
   final List<String> preferences;
   final String? jwtToken;
+  final List<int> candidateMenuIds;
 
   const RecommendationRequest({
     required this.heightCm,
@@ -19,7 +20,23 @@ class RecommendationRequest {
     this.allergies = const [],
     this.preferences = const [],
     this.jwtToken,
+    this.candidateMenuIds = const [],
   });
+
+  RecommendationRequest copyWith({List<int>? candidateMenuIds}) {
+    return RecommendationRequest(
+      heightCm: heightCm,
+      weightKg: weightKg,
+      location: location,
+      budget: budget,
+      fitnessGoal: fitnessGoal,
+      healthConditions: healthConditions,
+      allergies: allergies,
+      preferences: preferences,
+      jwtToken: jwtToken,
+      candidateMenuIds: candidateMenuIds ?? this.candidateMenuIds,
+    );
+  }
 
   Map<String, dynamic> toJson() => {
         'height_cm': heightCm,
@@ -31,6 +48,7 @@ class RecommendationRequest {
         'allergies': allergies,
         'preferences': preferences,
         if (jwtToken != null) 'jwt_token': jwtToken,
+        if (candidateMenuIds.isNotEmpty) 'candidate_menu_ids': candidateMenuIds,
       };
 }
 
@@ -137,6 +155,7 @@ class MarketPriceItem {
 }
 
 class RecommendationResult {
+  final int menuId;
   final String menuName;
   final String mainImg;
   final NutritionInfo nutritionInfo;
@@ -147,6 +166,7 @@ class RecommendationResult {
   final List<MarketPriceItem> marketPrices;
 
   const RecommendationResult({
+    required this.menuId,
     required this.menuName,
     required this.mainImg,
     required this.nutritionInfo,
@@ -158,6 +178,7 @@ class RecommendationResult {
   });
 
   factory RecommendationResult.fromJson(Map<String, dynamic> json) => RecommendationResult(
+        menuId: json['menu_id'] ?? 0,
         menuName: json['menu_name'] ?? '',
         mainImg: json['main_img'] ?? '',
         nutritionInfo: NutritionInfo.fromJson(json['nutrition_info'] ?? {}),

--- a/flutter_app/lib/models/recommendation_models.dart
+++ b/flutter_app/lib/models/recommendation_models.dart
@@ -162,6 +162,7 @@ class RecommendationResult {
   final List<RecipeStep> recipeSteps;
   final String naTip;
   final String selectionReason;
+  final String personalizedRecipeTip;
   final num totalEstimatedCost;
   final List<MarketPriceItem> marketPrices;
 
@@ -173,6 +174,7 @@ class RecommendationResult {
     required this.recipeSteps,
     required this.naTip,
     required this.selectionReason,
+    this.personalizedRecipeTip = '',
     required this.totalEstimatedCost,
     required this.marketPrices,
   });
@@ -187,9 +189,58 @@ class RecommendationResult {
             .toList(),
         naTip: json['na_tip'] ?? '',
         selectionReason: json['selection_reason'] ?? '',
+        personalizedRecipeTip: json['personalized_recipe_tip'] ?? '',
         totalEstimatedCost: json['total_estimated_cost'] ?? 0,
         marketPrices: (json['market_prices'] as List? ?? [])
             .map((e) => MarketPriceItem.fromJson(e))
             .toList(),
+      );
+}
+
+class MenuDetail {
+  final int id;
+  final String name;
+  final String? category;
+  final String? cookingMethod;
+  final double? calories;
+  final double? protein;
+  final double? fat;
+  final double? carbs;
+  final double? sodium;
+  final int? basePrice;
+  final String? mainImageUrl;
+  final String? healthTip;
+  final String? ingredientsText;
+
+  const MenuDetail({
+    required this.id,
+    required this.name,
+    this.category,
+    this.cookingMethod,
+    this.calories,
+    this.protein,
+    this.fat,
+    this.carbs,
+    this.sodium,
+    this.basePrice,
+    this.mainImageUrl,
+    this.healthTip,
+    this.ingredientsText,
+  });
+
+  factory MenuDetail.fromJson(Map<String, dynamic> json) => MenuDetail(
+        id: (json['id'] as num?)?.toInt() ?? 0,
+        name: json['name'] ?? '',
+        category: json['category'],
+        cookingMethod: json['cookingMethod'],
+        calories: (json['calories'] as num?)?.toDouble(),
+        protein: (json['protein'] as num?)?.toDouble(),
+        fat: (json['fat'] as num?)?.toDouble(),
+        carbs: (json['carbs'] as num?)?.toDouble(),
+        sodium: (json['sodium'] as num?)?.toDouble(),
+        basePrice: (json['basePrice'] as num?)?.toInt(),
+        mainImageUrl: json['mainImageUrl'],
+        healthTip: json['healthTip'],
+        ingredientsText: json['ingredientsText'],
       );
 }

--- a/flutter_app/lib/models/user_profile_models.dart
+++ b/flutter_app/lib/models/user_profile_models.dart
@@ -19,6 +19,7 @@ class UserProfileRequest {
   final String? fitnessGoal; // e.g. DIET, MUSCLE_GAIN, MAINTAIN, GENERAL
   final List<String>? foodPreferences;
   final List<String>? allergies;
+  final List<String>? healthConditions;
 
   UserProfileRequest({
     this.nickname,
@@ -38,6 +39,7 @@ class UserProfileRequest {
     this.fitnessGoal,
     this.foodPreferences,
     this.allergies,
+    this.healthConditions,
   });
 
   Map<String, dynamic> toJson() {
@@ -59,6 +61,7 @@ class UserProfileRequest {
     if (fitnessGoal != null) data['fitnessGoal'] = fitnessGoal;
     if (foodPreferences != null) data['foodPreferences'] = foodPreferences;
     if (allergies != null) data['allergies'] = allergies;
+    if (healthConditions != null) data['healthConditions'] = healthConditions;
     return data;
   }
 }
@@ -108,8 +111,8 @@ class UserProfileData {
   final String? proteinLevel;
   final String? fitnessGoal;
   final List<String> foodPreferences;
-
   final List<String> allergies;
+  final List<String> healthConditions;
 
   const UserProfileData({
     this.userId,
@@ -130,13 +133,14 @@ class UserProfileData {
     this.fitnessGoal,
     this.foodPreferences = const [],
     this.allergies = const [],
+    this.healthConditions = const [],
   });
 
   factory UserProfileData.fromJson(Map<String, dynamic> json) {
     return UserProfileData(
       userId: json['userId'],
-  nickname: json['nickname'],
-  gender: json['gender']?.toString(),
+      nickname: json['nickname'],
+      gender: json['gender']?.toString(),
       height: (json['height'] as num?)?.toDouble(),
       weight: (json['weight'] as num?)?.toDouble(),
       skeletalMuscleMass: (json['skeletalMuscleMass'] as num?)?.toDouble(),
@@ -152,6 +156,7 @@ class UserProfileData {
       fitnessGoal: json['fitnessGoal'],
       foodPreferences: (json['foodPreferences'] as List?)?.map((e) => e.toString()).toList() ?? const [],
       allergies: (json['allergies'] as List?)?.map((e) => e.toString()).toList() ?? const [],
+      healthConditions: (json['healthConditions'] as List?)?.map((e) => e.toString()).toList() ?? const [],
     );
   }
 }

--- a/flutter_app/lib/screens/dashboard_screen.dart
+++ b/flutter_app/lib/screens/dashboard_screen.dart
@@ -36,6 +36,9 @@ class _DashboardScreenState extends State<DashboardScreen> {
       final UserProfileData profile = profileResp.data!;
       final jwt = await TokenStorage.getAccessToken();
 
+      // 후보 목록 먼저 가져와서 화면에 즉시 표시하고, 동일한 ID를 AI agent에 전달
+      final candidates = await RecommendationService.fetchCandidates(jwt);
+
       final request = RecommendationRequest(
         heightCm: profile.height ?? 170.0,
         weightKg: profile.weight ?? 65.0,
@@ -46,10 +49,8 @@ class _DashboardScreenState extends State<DashboardScreen> {
         allergies: profile.allergies,
         preferences: profile.foodPreferences,
         jwtToken: jwt,
+        candidateMenuIds: candidates.map((c) => c.id).toList(),
       );
-
-      // 후보 목록 먼저 가져오고 (빠름), AI 추천은 화면에서 처리
-      final candidates = await RecommendationService.fetchCandidates(jwt);
 
       if (!mounted) return;
       Navigator.push(

--- a/flutter_app/lib/screens/dashboard_screen.dart
+++ b/flutter_app/lib/screens/dashboard_screen.dart
@@ -45,7 +45,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
         location: '서울', // TODO: 사용자 위치 필드 추가 시 교체
         budget: (profile.mealBudget ?? 8000).toDouble(),
         fitnessGoal: _fitnessGoalMap[profile.fitnessGoal] ?? '일반식단',
-        healthConditions: const [], // TODO: health_conditions 필드 추가 시 연결
+        healthConditions: profile.healthConditions,
         allergies: profile.allergies,
         preferences: profile.foodPreferences,
         jwtToken: jwt,

--- a/flutter_app/lib/screens/menu_detail_screen.dart
+++ b/flutter_app/lib/screens/menu_detail_screen.dart
@@ -1,0 +1,736 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/models/recommendation_models.dart';
+import 'package:flutter_app/services/recommendation_service.dart';
+import 'package:flutter_app/theme.dart';
+
+class MenuDetailScreen extends StatefulWidget {
+  final MenuCandidate? candidate;
+  final RecommendationResult? aiResult;
+  final String? jwt;
+
+  const MenuDetailScreen({
+    super.key,
+    this.candidate,
+    this.aiResult,
+    this.jwt,
+  });
+
+  @override
+  State<MenuDetailScreen> createState() => _MenuDetailScreenState();
+}
+
+class _MenuDetailScreenState extends State<MenuDetailScreen> {
+  MenuDetail? _detail;
+  bool _loading = false;
+  String? _error;
+
+  bool get _isAiPick => widget.aiResult != null;
+
+  @override
+  void initState() {
+    super.initState();
+    if (!_isAiPick) _fetchDetail();
+  }
+
+  Future<void> _fetchDetail() async {
+    if (widget.candidate == null) return;
+    setState(() { _loading = true; _error = null; });
+    final detail = await RecommendationService.fetchMenuDetail(
+        widget.candidate!.id, widget.jwt);
+    if (!mounted) return;
+    if (detail != null) {
+      setState(() { _detail = detail; _loading = false; });
+    } else {
+      setState(() { _loading = false; _error = '상세 정보를 불러오지 못했습니다.'; });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final title = _isAiPick
+        ? widget.aiResult!.menuName
+        : (widget.candidate?.name ?? '메뉴 상세');
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title,
+            style: const TextStyle(fontWeight: FontWeight.bold),
+            overflow: TextOverflow.ellipsis),
+        centerTitle: true,
+        elevation: 0,
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        actions: _isAiPick
+            ? [
+                Container(
+                  margin: const EdgeInsets.only(right: 16),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                  decoration: BoxDecoration(
+                    gradient: AppTheme.aiGradient,
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: const Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.auto_awesome, color: Colors.white, size: 12),
+                      SizedBox(width: 4),
+                      Text('AI 픽',
+                          style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 12,
+                              fontWeight: FontWeight.bold)),
+                    ],
+                  ),
+                ),
+              ]
+            : null,
+      ),
+      body: _isAiPick
+          ? _AiPickBody(result: widget.aiResult!)
+          : _CandidateBody(
+              candidate: widget.candidate!,
+              detail: _detail,
+              loading: _loading,
+              error: _error,
+              onRetry: _fetchDetail,
+            ),
+    );
+  }
+}
+
+// ── AI 픽 상세 본문 ──────────────────────────────────────────
+class _AiPickBody extends StatelessWidget {
+  final RecommendationResult result;
+  const _AiPickBody({required this.result});
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _HeroImage(url: result.mainImg),
+          Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _SectionCard(
+                  icon: Icons.format_quote_rounded,
+                  title: 'AI 선택 이유',
+                  content: result.selectionReason,
+                ),
+                const SizedBox(height: 16),
+                _NutritionSection(info: result.nutritionInfo),
+                if (result.personalizedRecipeTip.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  _PersonalizedTip(tip: result.personalizedRecipeTip),
+                ],
+                if (result.recipeSteps.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  _RecipeSteps(steps: result.recipeSteps),
+                ],
+                if (result.naTip.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  _SectionCard(
+                    icon: Icons.water_drop_outlined,
+                    title: '나트륨 관리 팁',
+                    content: result.naTip,
+                    iconColor: Colors.blue,
+                  ),
+                ],
+                if (result.marketPrices.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  _MarketPricesTable(
+                    prices: result.marketPrices,
+                    total: result.totalEstimatedCost,
+                  ),
+                ],
+                const SizedBox(height: 32),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── 후보 메뉴 상세 본문 ──────────────────────────────────────
+class _CandidateBody extends StatelessWidget {
+  final MenuCandidate candidate;
+  final MenuDetail? detail;
+  final bool loading;
+  final String? error;
+  final VoidCallback onRetry;
+
+  const _CandidateBody({
+    required this.candidate,
+    required this.detail,
+    required this.loading,
+    required this.error,
+    required this.onRetry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _HeroImage(url: detail?.mainImageUrl ?? candidate.mainImageUrl ?? ''),
+          Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (detail != null) ...[
+                  if ((detail!.category ?? '').isNotEmpty ||
+                      (detail!.cookingMethod ?? '').isNotEmpty)
+                    _Chips(labels: [
+                      if ((detail!.category ?? '').isNotEmpty) detail!.category!,
+                      if ((detail!.cookingMethod ?? '').isNotEmpty)
+                        detail!.cookingMethod!,
+                    ]),
+                  const SizedBox(height: 16),
+                ],
+                if (loading)
+                  const _LoadingSection()
+                else if (error != null)
+                  _ErrorSection(error: error!, onRetry: onRetry)
+                else if (detail != null) ...[
+                  _DetailNutrition(detail: detail!),
+                  if ((detail!.ingredientsText ?? '').isNotEmpty) ...[
+                    const SizedBox(height: 16),
+                    _Ingredients(text: detail!.ingredientsText!),
+                  ],
+                  if ((detail!.healthTip ?? '').isNotEmpty) ...[
+                    const SizedBox(height: 16),
+                    _SectionCard(
+                      icon: Icons.health_and_safety_outlined,
+                      title: '건강 팁',
+                      content: detail!.healthTip!,
+                      iconColor: Colors.green,
+                    ),
+                  ],
+                  if (detail!.basePrice != null && detail!.basePrice! > 0) ...[
+                    const SizedBox(height: 12),
+                    _PriceRow(price: detail!.basePrice!),
+                  ],
+                ] else
+                  _BasicNutrition(candidate: candidate),
+                const SizedBox(height: 32),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── 공통 위젯들 ──────────────────────────────────────────────
+
+class _HeroImage extends StatelessWidget {
+  final String url;
+  const _HeroImage({required this.url});
+
+  @override
+  Widget build(BuildContext context) {
+    if (url.isEmpty) return _placeholder();
+    return Image.network(
+      url,
+      height: 220,
+      width: double.infinity,
+      fit: BoxFit.cover,
+      errorBuilder: (_, _, _) => _placeholder(),
+    );
+  }
+
+  Widget _placeholder() => Container(
+        height: 220,
+        color: AppTheme.primaryColor.withValues(alpha: 0.08),
+        child: const Center(
+          child: Icon(Icons.restaurant, size: 64, color: AppTheme.primaryColor),
+        ),
+      );
+}
+
+class _SectionCard extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String content;
+  final Color? iconColor;
+
+  const _SectionCard({
+    required this.icon,
+    required this.title,
+    required this.content,
+    this.iconColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.grey.shade50,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey.shade200),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(children: [
+            Icon(icon,
+                size: 16, color: iconColor ?? AppTheme.primaryColor),
+            const SizedBox(width: 6),
+            Text(title,
+                style: const TextStyle(
+                    fontWeight: FontWeight.bold, fontSize: 14)),
+          ]),
+          const SizedBox(height: 8),
+          Text(content,
+              style: TextStyle(
+                  fontSize: 13, color: Colors.grey[700], height: 1.5)),
+        ],
+      ),
+    );
+  }
+}
+
+class _NutritionSection extends StatelessWidget {
+  final NutritionInfo info;
+  const _NutritionSection({required this.info});
+
+  @override
+  Widget build(BuildContext context) {
+    final items = [
+      ('열량', info.energy),
+      ('단백질', info.protein),
+      ('지방', info.fat),
+      ('탄수화물', info.carbs),
+      ('나트륨', info.sodium),
+    ];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('영양 정보',
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 15)),
+        const SizedBox(height: 10),
+        Wrap(
+          spacing: 8,
+          runSpacing: 6,
+          children: items
+              .map((e) => _NutritionChip(label: e.$1, value: e.$2))
+              .toList(),
+        ),
+      ],
+    );
+  }
+}
+
+class _DetailNutrition extends StatelessWidget {
+  final MenuDetail detail;
+  const _DetailNutrition({required this.detail});
+
+  @override
+  Widget build(BuildContext context) {
+    final items = <(String, String)>[
+      if (detail.calories != null)
+        ('열량', '${detail.calories!.toInt()} kcal'),
+      if (detail.protein != null)
+        ('단백질', '${detail.protein!.toStringAsFixed(1)}g'),
+      if (detail.fat != null)
+        ('지방', '${detail.fat!.toStringAsFixed(1)}g'),
+      if (detail.carbs != null)
+        ('탄수화물', '${detail.carbs!.toStringAsFixed(1)}g'),
+      if (detail.sodium != null)
+        ('나트륨', '${detail.sodium!.toStringAsFixed(0)}mg'),
+    ];
+    if (items.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('영양 정보',
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 15)),
+        const SizedBox(height: 10),
+        Wrap(
+          spacing: 8,
+          runSpacing: 6,
+          children:
+              items.map((e) => _NutritionChip(label: e.$1, value: e.$2)).toList(),
+        ),
+      ],
+    );
+  }
+}
+
+class _BasicNutrition extends StatelessWidget {
+  final MenuCandidate candidate;
+  const _BasicNutrition({required this.candidate});
+
+  @override
+  Widget build(BuildContext context) {
+    final items = <(String, String)>[
+      if (candidate.calories != null)
+        ('열량', '${candidate.calories!.toInt()} kcal'),
+      if (candidate.protein != null)
+        ('단백질', '${candidate.protein!.toStringAsFixed(1)}g'),
+      if (candidate.sodium != null)
+        ('나트륨', '${candidate.sodium!.toStringAsFixed(0)}mg'),
+    ];
+    if (items.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('영양 정보',
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 15)),
+        const SizedBox(height: 10),
+        Wrap(
+          spacing: 8,
+          runSpacing: 6,
+          children:
+              items.map((e) => _NutritionChip(label: e.$1, value: e.$2)).toList(),
+        ),
+      ],
+    );
+  }
+}
+
+class _NutritionChip extends StatelessWidget {
+  final String label;
+  final String value;
+  const _NutritionChip({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: AppTheme.primaryColor.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: RichText(
+        text: TextSpan(
+          children: [
+            TextSpan(
+                text: '$label ',
+                style: TextStyle(fontSize: 12, color: Colors.grey[600])),
+            TextSpan(
+                text: value,
+                style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black87)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PersonalizedTip extends StatelessWidget {
+  final String tip;
+  const _PersonalizedTip({required this.tip});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(14),
+        gradient: LinearGradient(
+          colors: [
+            AppTheme.gradientStart.withValues(alpha: 0.15),
+            AppTheme.gradientEnd.withValues(alpha: 0.12),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        border: Border.all(
+          color: AppTheme.primaryColor.withValues(alpha: 0.35),
+          width: 1.5,
+        ),
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(children: [
+            ShaderMask(
+              blendMode: BlendMode.srcIn,
+              shaderCallback: (b) => AppTheme.aiGradient.createShader(b),
+              child: const Icon(Icons.tips_and_updates_rounded, size: 18),
+            ),
+            const SizedBox(width: 6),
+            ShaderMask(
+              blendMode: BlendMode.srcIn,
+              shaderCallback: (b) => AppTheme.aiGradient.createShader(b),
+              child: const Text('나의 맞춤 레시피 변주',
+                  style: TextStyle(
+                      fontWeight: FontWeight.bold, fontSize: 14)),
+            ),
+          ]),
+          const SizedBox(height: 10),
+          Text(tip,
+              style: TextStyle(
+                  fontSize: 13, color: Colors.grey[800], height: 1.6)),
+        ],
+      ),
+    );
+  }
+}
+
+class _RecipeSteps extends StatelessWidget {
+  final List<RecipeStep> steps;
+  const _RecipeSteps({required this.steps});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('조리 방법',
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 15)),
+        const SizedBox(height: 10),
+        ...steps.map((s) => Padding(
+              padding: const EdgeInsets.only(bottom: 10),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    width: 24,
+                    height: 24,
+                    decoration: const BoxDecoration(
+                        color: AppTheme.primaryColor, shape: BoxShape.circle),
+                    child: Center(
+                      child: Text('${s.stepNo}',
+                          style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 12,
+                              fontWeight: FontWeight.bold)),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(s.content,
+                        style: TextStyle(
+                            fontSize: 13,
+                            color: Colors.grey[800],
+                            height: 1.5)),
+                  ),
+                ],
+              ),
+            )),
+      ],
+    );
+  }
+}
+
+class _MarketPricesTable extends StatelessWidget {
+  final List<MarketPriceItem> prices;
+  final num total;
+  const _MarketPricesTable({required this.prices, required this.total});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('재료별 가격',
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 15)),
+        const SizedBox(height: 10),
+        Container(
+          decoration: BoxDecoration(
+            border: Border.all(color: Colors.grey.shade200),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Column(
+            children: [
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                decoration: BoxDecoration(
+                  color: Colors.grey.shade50,
+                  borderRadius: const BorderRadius.only(
+                    topLeft: Radius.circular(12),
+                    topRight: Radius.circular(12),
+                  ),
+                ),
+                child: Row(children: [
+                  Expanded(
+                      flex: 3,
+                      child: Text('재료',
+                          style: TextStyle(
+                              fontSize: 12,
+                              color: Colors.grey[600],
+                              fontWeight: FontWeight.w600))),
+                  Expanded(
+                      flex: 2,
+                      child: Text('사용량',
+                          style: TextStyle(
+                              fontSize: 12,
+                              color: Colors.grey[600],
+                              fontWeight: FontWeight.w600))),
+                  Expanded(
+                      flex: 2,
+                      child: Text('비용',
+                          textAlign: TextAlign.end,
+                          style: TextStyle(
+                              fontSize: 12,
+                              color: Colors.grey[600],
+                              fontWeight: FontWeight.w600))),
+                ]),
+              ),
+              const Divider(height: 1),
+              ...prices.asMap().entries.map((entry) {
+                final i = entry.key;
+                final p = entry.value;
+                return Column(children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 12, vertical: 10),
+                    child: Row(children: [
+                      Expanded(
+                          flex: 3,
+                          child: Text(p.name,
+                              style: const TextStyle(fontSize: 13))),
+                      Expanded(
+                          flex: 2,
+                          child: Text(p.recipeAmount,
+                              style: TextStyle(
+                                  fontSize: 12, color: Colors.grey[600]))),
+                      Expanded(
+                          flex: 2,
+                          child: Text('${p.calculatedCost.toInt()}원',
+                              textAlign: TextAlign.end,
+                              style: const TextStyle(
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.w500))),
+                    ]),
+                  ),
+                  if (i < prices.length - 1)
+                    const Divider(height: 1, indent: 12, endIndent: 12),
+                ]);
+              }),
+              const Divider(height: 1),
+              Padding(
+                padding: const EdgeInsets.all(12),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const Text('예상 총 재료비',
+                        style: TextStyle(
+                            fontWeight: FontWeight.bold, fontSize: 14)),
+                    Text('약 ${total.toInt()}원',
+                        style: const TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 14,
+                            color: AppTheme.primaryColor)),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Ingredients extends StatelessWidget {
+  final String text;
+  const _Ingredients({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('재료',
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 15)),
+        const SizedBox(height: 8),
+        Text(text,
+            style:
+                TextStyle(fontSize: 13, color: Colors.grey[700], height: 1.5)),
+      ],
+    );
+  }
+}
+
+class _PriceRow extends StatelessWidget {
+  final int price;
+  const _PriceRow({required this.price});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(children: [
+      const Icon(Icons.attach_money, size: 16, color: AppTheme.primaryColor),
+      const SizedBox(width: 4),
+      Text('기본 가격 약 $price원',
+          style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w500)),
+    ]);
+  }
+}
+
+class _Chips extends StatelessWidget {
+  final List<String> labels;
+  const _Chips({required this.labels});
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 6,
+      runSpacing: 4,
+      children: labels
+          .map((l) => Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                decoration: BoxDecoration(
+                  color: AppTheme.primaryColor.withValues(alpha: 0.08),
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: Text(l,
+                    style: const TextStyle(
+                        fontSize: 12, fontWeight: FontWeight.w500)),
+              ))
+          .toList(),
+    );
+  }
+}
+
+class _LoadingSection extends StatelessWidget {
+  const _LoadingSection();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 40),
+      child: Center(
+        child: CircularProgressIndicator(
+            color: AppTheme.primaryColor, strokeWidth: 2.5),
+      ),
+    );
+  }
+}
+
+class _ErrorSection extends StatelessWidget {
+  final String error;
+  final VoidCallback onRetry;
+  const _ErrorSection({required this.error, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(error,
+            style: TextStyle(color: Colors.grey[500], fontSize: 13)),
+        const SizedBox(height: 8),
+        TextButton(
+          onPressed: onRetry,
+          child: const Text('다시 시도'),
+        ),
+      ],
+    );
+  }
+}

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -51,8 +51,22 @@ class _MyPageScreenState extends State<MyPageScreen> {
   String _selectedFitnessGoal = 'GENERAL';
   Set<String> _selectedFoodPreferences = {};
 
-  // 4. 알레르기 정보
+  // 4. 건강 상태
+  Set<String> _selectedHealthConditions = {};
+
+  // 5. 알레르기 정보
   Set<String> _selectedAllergies = {'우유', '밀가루'};
+
+  final List<String> _healthConditionOptions = [
+    '고혈압',
+    '당뇨',
+    '고지혈증',
+    '비만',
+    '신장질환',
+    '간질환',
+    '심장질환',
+    '갑상선질환',
+  ];
 
   final List<String> _allergyOptions = [
     '땅콩',
@@ -97,6 +111,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
   late String _bkFitnessGoal;
   late Set<String> _bkFoodPreferences;
   late Set<String> _bkAllergies;
+  late Set<String> _bkHealthConditions;
 
   @override
   void initState() {
@@ -191,6 +206,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
     }
     _selectedFoodPreferences = data.foodPreferences.toSet();
     _selectedAllergies = data.allergies.toSet();
+    _selectedHealthConditions = data.healthConditions.toSet();
   }
 
   @override
@@ -222,6 +238,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
     _bkFitnessGoal = _selectedFitnessGoal;
     _bkFoodPreferences = Set.from(_selectedFoodPreferences);
     _bkAllergies = Set.from(_selectedAllergies);
+    _bkHealthConditions = Set.from(_selectedHealthConditions);
 
     setState(() {
       _isEditMode = true;
@@ -244,6 +261,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
     _selectedFitnessGoal = _bkFitnessGoal;
     _selectedFoodPreferences = Set.from(_bkFoodPreferences);
     _selectedAllergies = Set.from(_bkAllergies);
+    _selectedHealthConditions = Set.from(_bkHealthConditions);
 
     setState(() {
       _isEditMode = false;
@@ -278,6 +296,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
         fitnessGoal: _selectedFitnessGoal,
         foodPreferences: _selectedFoodPreferences.toList(),
         allergies: _selectedAllergies.toList(),
+        healthConditions: _selectedHealthConditions.toList(),
       );
 
       final result = await UserProfileService.updateProfile(request: request);
@@ -330,7 +349,9 @@ class _MyPageScreenState extends State<MyPageScreen> {
         _selectedFoodPreferences.length != _bkFoodPreferences.length ||
         !_selectedFoodPreferences.containsAll(_bkFoodPreferences) ||
         _selectedAllergies.length != _bkAllergies.length ||
-        !_selectedAllergies.containsAll(_bkAllergies);
+        !_selectedAllergies.containsAll(_bkAllergies) ||
+        _selectedHealthConditions.length != _bkHealthConditions.length ||
+        !_selectedHealthConditions.containsAll(_bkHealthConditions);
   }
   @override
   Widget build(BuildContext context) {
@@ -614,7 +635,56 @@ class _MyPageScreenState extends State<MyPageScreen> {
                 ),
                 const SizedBox(height: 32),
 
-                _buildSectionTitle('4. 알레르기 유발 물질'),
+                _buildSectionTitle('4. 건강 상태'),
+                Container(
+                  width: double.infinity,
+                  padding: EdgeInsets.all(_isEditMode ? 0 : 16.0),
+                  decoration: BoxDecoration(
+                    color: _isEditMode ? Colors.transparent : Colors.grey.shade100,
+                    borderRadius: BorderRadius.circular(16),
+                    border: _isEditMode ? null : Border.all(color: Colors.grey.shade300),
+                  ),
+                  child: IgnorePointer(
+                    ignoring: !_isEditMode,
+                    child: Wrap(
+                      spacing: 8.0,
+                      runSpacing: 8.0,
+                      children: _healthConditionOptions.map((cond) {
+                        final isSelected = _selectedHealthConditions.contains(cond);
+                        return FilterChip(
+                          label: Text(
+                            cond,
+                            style: TextStyle(
+                              color: _isEditMode ? Colors.black87 : Colors.grey.shade600,
+                            ),
+                          ),
+                          selected: isSelected,
+                          backgroundColor: _isEditMode ? Colors.white : Colors.grey.shade200,
+                          selectedColor: _isEditMode
+                              ? AppTheme.primaryColor.withValues(alpha: 0.2)
+                              : Colors.grey.shade300,
+                          checkmarkColor: _isEditMode ? AppTheme.primaryColor : Colors.grey.shade600,
+                          shape: RoundedRectangleBorder(
+                            side: BorderSide(
+                              color: _isEditMode ? Colors.grey.shade300 : Colors.transparent,
+                            ),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          onSelected: (bool selected) {
+                            setState(() {
+                              selected
+                                  ? _selectedHealthConditions.add(cond)
+                                  : _selectedHealthConditions.remove(cond);
+                            });
+                          },
+                        );
+                      }).toList(),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 32),
+
+                _buildSectionTitle('5. 알레르기 유발 물질'),
                 Container(
                   width: double.infinity,
                   padding: EdgeInsets.all(_isEditMode ? 0 : 16.0),

--- a/flutter_app/lib/screens/onboarding_screen.dart
+++ b/flutter_app/lib/screens/onboarding_screen.dart
@@ -31,9 +31,13 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   String _selectedFitnessGoal = 'GENERAL';
   final Set<String> _selectedFoodPreferences = {};
 
-  // 3. 알레르기 정보
+  // 3. 건강 상태
+  final Set<String> _selectedHealthConditions = {};
+
+  // 4. 알레르기 정보
   final Set<String> _selectedAllergies = {};
 
+  final List<String> _healthConditionOptions = ['고혈압', '당뇨', '고지혈증', '비만', '신장질환', '간질환', '심장질환', '갑상선질환'];
   final List<String> _allergyOptions = ['땅콩', '갑각류', '대두', '우유', '밀가루', '계란', '견과류', '생선'];
   final Map<String, String> _vegOptions = {
     'NONE': '해당 없음',
@@ -93,6 +97,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
         fitnessGoal: _selectedFitnessGoal,
         foodPreferences: _selectedFoodPreferences.toList(),
         allergies: _selectedAllergies.toList(),
+        healthConditions: _selectedHealthConditions.toList(),
       );
 
       final result = await UserProfileService.saveProfile(request: request);
@@ -238,7 +243,32 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                 ),
                 const SizedBox(height: 32),
 
-                _buildSectionTitle('3. 알레르기 유발 물질 (해당 시 선택)'),
+                _buildSectionTitle('3. 건강 상태 (해당 시 선택)'),
+                Wrap(
+                  spacing: 8.0,
+                  runSpacing: 8.0,
+                  children: _healthConditionOptions.map((condition) {
+                    final isSelected = _selectedHealthConditions.contains(condition);
+                    return FilterChip(
+                      label: Text(condition),
+                      selected: isSelected,
+                      selectedColor: AppTheme.primaryColor.withOpacity(0.2),
+                      checkmarkColor: AppTheme.primaryColor,
+                      shape: RoundedRectangleBorder(
+                        side: BorderSide(color: isSelected ? AppTheme.primaryColor : Colors.grey.shade300),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      onSelected: (bool selected) {
+                        setState(() {
+                          selected ? _selectedHealthConditions.add(condition) : _selectedHealthConditions.remove(condition);
+                        });
+                      },
+                    );
+                  }).toList(),
+                ),
+                const SizedBox(height: 32),
+
+                _buildSectionTitle('4. 알레르기 유발 물질 (해당 시 선택)'),
                 Wrap(
                   spacing: 8.0,
                   runSpacing: 8.0,

--- a/flutter_app/lib/screens/recommendation_screen.dart
+++ b/flutter_app/lib/screens/recommendation_screen.dart
@@ -18,9 +18,16 @@ class RecommendationScreen extends StatefulWidget {
 }
 
 class _RecommendationScreenState extends State<RecommendationScreen> {
+  late List<MenuCandidate> _candidates;
+  late RecommendationRequest _currentRequest;
+
   RecommendationResult? _aiResult;
   bool _aiLoading = true;
   String? _aiError;
+  bool _reloading = false;
+
+  final Set<int> _negativeFeedbackIds = {};
+  final Set<int> _positiveFeedbackIds = {};
 
   int _rating = 0;
   final TextEditingController _feedbackController = TextEditingController();
@@ -28,6 +35,8 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
   @override
   void initState() {
     super.initState();
+    _candidates = List.from(widget.candidates);
+    _currentRequest = widget.request;
     _fetchAiResult();
   }
 
@@ -39,10 +48,65 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
 
   Future<void> _fetchAiResult() async {
     try {
-      final result = await RecommendationService.recommend(widget.request);
+      final result = await RecommendationService.recommend(_currentRequest);
       if (mounted) setState(() { _aiResult = result; _aiLoading = false; });
     } catch (e) {
       if (mounted) setState(() { _aiError = e.toString(); _aiLoading = false; });
+    }
+  }
+
+  Future<void> _onFeedback(int menuId, bool isPositive) async {
+    setState(() {
+      if (isPositive) {
+        _positiveFeedbackIds.add(menuId);
+        _negativeFeedbackIds.remove(menuId);
+      } else {
+        _negativeFeedbackIds.add(menuId);
+        _positiveFeedbackIds.remove(menuId);
+      }
+    });
+
+    await RecommendationService.saveFeedback(
+      menuId, isPositive ? 1 : -1, widget.request.jwtToken);
+
+    _checkAllNegative();
+  }
+
+  void _checkAllNegative() {
+    final aiPickId = _aiResult?.menuId;
+    final nonAiPick = _candidates.where((c) => c.id != aiPickId).toList();
+    if (nonAiPick.isEmpty) return;
+    if (nonAiPick.every((c) => _negativeFeedbackIds.contains(c.id))) {
+      _reload();
+    }
+  }
+
+  Future<void> _reload() async {
+    if (_reloading) return;
+    setState(() => _reloading = true);
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('후보 메뉴를 다시 불러오는 중입니다...')),
+    );
+
+    try {
+      final newCandidates = await RecommendationService.fetchCandidates(widget.request.jwtToken);
+      if (!mounted) return;
+      setState(() {
+        _candidates = newCandidates;
+        _currentRequest = widget.request.copyWith(
+          candidateMenuIds: newCandidates.map((c) => c.id).toList(),
+        );
+        _aiLoading = true;
+        _aiResult = null;
+        _aiError = null;
+        _negativeFeedbackIds.clear();
+        _positiveFeedbackIds.clear();
+        _reloading = false;
+      });
+      _fetchAiResult();
+    } catch (_) {
+      if (mounted) setState(() => _reloading = false);
     }
   }
 
@@ -128,7 +192,7 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final aiPickName = _aiResult?.menuName;
+    final aiPickId = _aiResult?.menuId;
 
     return Scaffold(
       appBar: AppBar(
@@ -167,16 +231,23 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
                         const Icon(Icons.list_alt, size: 18, color: AppTheme.primaryColor),
                         const SizedBox(width: 6),
                         Text(
-                          '후보 메뉴 ${widget.candidates.length}개',
+                          '후보 메뉴 ${_candidates.length}개',
                           style: const TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
                         ),
+                        if (!_aiLoading) ...[
+                          const SizedBox(width: 8),
+                          Text(
+                            '(마음에 드는 메뉴에 반응을 남겨보세요)',
+                            style: TextStyle(fontSize: 12, color: Colors.grey[500]),
+                          ),
+                        ],
                       ],
                     ),
                   ),
                 ),
 
                 // ── 후보 메뉴 목록 ────────────────────────────
-                widget.candidates.isEmpty
+                _candidates.isEmpty
                     ? SliverToBoxAdapter(
                         child: Padding(
                           padding: const EdgeInsets.all(32),
@@ -188,12 +259,22 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
                       )
                     : SliverList(
                         delegate: SliverChildBuilderDelegate(
-                          (ctx, i) => _CandidateCard(
-                            candidate: widget.candidates[i],
-                            isAiPick: aiPickName != null &&
-                                widget.candidates[i].name == aiPickName,
-                          ),
-                          childCount: widget.candidates.length,
+                          (ctx, i) {
+                            final c = _candidates[i];
+                            final isAiPick = aiPickId != null && c.id == aiPickId;
+                            bool? feedbackGiven;
+                            if (_positiveFeedbackIds.contains(c.id)) feedbackGiven = true;
+                            if (_negativeFeedbackIds.contains(c.id)) feedbackGiven = false;
+
+                            return _CandidateCard(
+                              candidate: c,
+                              isAiPick: isAiPick,
+                              showFeedback: !_aiLoading && !isAiPick,
+                              feedbackGiven: feedbackGiven,
+                              onFeedback: (isPos) => _onFeedback(c.id, isPos),
+                            );
+                          },
+                          childCount: _candidates.length,
                         ),
                       ),
 
@@ -202,7 +283,7 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
             ),
           ),
 
-          // ── 피드백 버튼 ───────────────────────────────────
+          // ── AI 픽 피드백 버튼 ─────────────────────────────
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 20),
             child: OutlinedButton(
@@ -344,7 +425,6 @@ class _ResultCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          // 이미지
           if (result.mainImg.isNotEmpty)
             Image.network(
               result.mainImg,
@@ -361,17 +441,13 @@ class _ResultCard extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                // 메뉴명
                 Text(result.menuName,
                     style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
                 const SizedBox(height: 8),
-                // 추천 이유
                 Text(result.selectionReason,
                     style: TextStyle(fontSize: 13, color: Colors.grey[700], height: 1.5)),
                 const SizedBox(height: 12),
-                // 영양 정보 칩
                 _NutritionRow(info: result.nutritionInfo),
-                // 예상 비용
                 if (result.totalEstimatedCost > 0) ...[
                   const SizedBox(height: 10),
                   Row(children: [
@@ -383,7 +459,6 @@ class _ResultCard extends StatelessWidget {
                             fontSize: 13, fontWeight: FontWeight.w600)),
                   ]),
                 ],
-                // 레시피 단계 (있는 경우)
                 if (result.recipeSteps.isNotEmpty) ...[
                   const Divider(height: 24),
                   const Text('조리 방법',
@@ -459,8 +534,17 @@ class _NutritionRow extends StatelessWidget {
 class _CandidateCard extends StatelessWidget {
   final MenuCandidate candidate;
   final bool isAiPick;
+  final bool showFeedback;
+  final bool? feedbackGiven;
+  final void Function(bool isPositive)? onFeedback;
 
-  const _CandidateCard({required this.candidate, required this.isAiPick});
+  const _CandidateCard({
+    required this.candidate,
+    required this.isAiPick,
+    required this.showFeedback,
+    this.feedbackGiven,
+    this.onFeedback,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -484,7 +568,6 @@ class _CandidateCard extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
         child: Row(
           children: [
-            // 썸네일
             ClipRRect(
               borderRadius: BorderRadius.circular(8),
               child: candidate.mainImageUrl != null &&
@@ -497,7 +580,6 @@ class _CandidateCard extends StatelessWidget {
                   : _placeholder(),
             ),
             const SizedBox(width: 12),
-            // 이름 + 칼로리
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -518,23 +600,55 @@ class _CandidateCard extends StatelessWidget {
                 ],
               ),
             ),
-            // AI 픽 뱃지
             if (isAiPick)
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                decoration: BoxDecoration(
-                  gradient: AppTheme.aiGradient,
-                  borderRadius: BorderRadius.circular(20),
-                ),
-                child: const Text('AI 픽',
-                    style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 11,
-                        fontWeight: FontWeight.bold)),
-              ),
+              _aiBadge()
+            else if (showFeedback)
+              _feedbackWidget(),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _aiBadge() => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          gradient: AppTheme.aiGradient,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: const Text('AI 픽',
+            style: TextStyle(
+                color: Colors.white,
+                fontSize: 11,
+                fontWeight: FontWeight.bold)),
+      );
+
+  Widget _feedbackWidget() {
+    if (feedbackGiven != null) {
+      return Icon(
+        feedbackGiven! ? Icons.thumb_up_rounded : Icons.thumb_down_rounded,
+        color: feedbackGiven! ? AppTheme.primaryColor : Colors.redAccent,
+        size: 22,
+      );
+    }
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        IconButton(
+          onPressed: () => onFeedback?.call(true),
+          icon: const Icon(Icons.thumb_up_outlined, size: 20),
+          color: AppTheme.primaryColor,
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+        ),
+        IconButton(
+          onPressed: () => onFeedback?.call(false),
+          icon: const Icon(Icons.thumb_down_outlined, size: 20),
+          color: Colors.grey,
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+        ),
+      ],
     );
   }
 

--- a/flutter_app/lib/screens/recommendation_screen.dart
+++ b/flutter_app/lib/screens/recommendation_screen.dart
@@ -151,6 +151,7 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
               TextField(
                 controller: _feedbackController,
                 maxLines: 3,
+                onChanged: (_) => setModal(() {}),
                 decoration: InputDecoration(
                   hintText: '아쉬운 점이 있다면 알려주세요...',
                   filled: true,
@@ -162,34 +163,46 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
                 ),
               ),
               const SizedBox(height: 24),
-              Container(
-                height: 56,
-                decoration: BoxDecoration(
-                  gradient: AppTheme.aiGradient,
-                  borderRadius: BorderRadius.circular(30),
-                ),
-                child: ElevatedButton(
-                  onPressed: () async {
-                    final menuId = _aiResult?.menuId;
-                    final rating = _rating;
-                    final reason = _feedbackController.text;
-                    Navigator.pop(context);
-                    if (menuId != null && menuId > 0 && rating > 0) {
-                      await RecommendationService.saveDetailedFeedback(
-                          menuId, rating, reason, widget.request.jwtToken);
-                    }
-                    messenger.showSnackBar(
-                      const SnackBar(content: Text('소중한 피드백 감사합니다!')),
-                    );
-                  },
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.transparent,
-                    shadowColor: Colors.transparent,
-                    shape: const StadiumBorder(),
-                  ),
-                  child: const Text('피드백 제출하기',
-                      style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white)),
-                ),
+              Builder(
+                builder: (_) {
+                  final canSubmit =
+                      _rating > 0 && _feedbackController.text.trim().isNotEmpty;
+                  return Container(
+                    height: 56,
+                    decoration: BoxDecoration(
+                      gradient: canSubmit ? AppTheme.aiGradient : null,
+                      color: canSubmit ? null : Colors.grey[300],
+                      borderRadius: BorderRadius.circular(30),
+                    ),
+                    child: ElevatedButton(
+                      onPressed: canSubmit
+                          ? () async {
+                              final menuId = _aiResult?.menuId;
+                              final rating = _rating;
+                              final reason = _feedbackController.text;
+                              Navigator.pop(context);
+                              if (menuId != null && menuId > 0) {
+                                await RecommendationService.saveDetailedFeedback(
+                                    menuId, rating, reason, widget.request.jwtToken);
+                              }
+                              messenger.showSnackBar(
+                                const SnackBar(content: Text('소중한 피드백 감사합니다!')),
+                              );
+                            }
+                          : null,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.transparent,
+                        shadowColor: Colors.transparent,
+                        shape: const StadiumBorder(),
+                      ),
+                      child: Text('피드백 제출하기',
+                          style: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
+                              color: canSubmit ? Colors.white : Colors.grey[600])),
+                    ),
+                  );
+                },
               ),
             ],
           ),

--- a/flutter_app/lib/screens/recommendation_screen.dart
+++ b/flutter_app/lib/screens/recommendation_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_app/models/recommendation_models.dart';
+import 'package:flutter_app/screens/menu_detail_screen.dart';
 import 'package:flutter_app/services/recommendation_service.dart';
 import 'package:flutter_app/theme.dart';
 
@@ -239,6 +240,14 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
                         setState(() { _aiLoading = true; _aiError = null; });
                         _fetchAiResult();
                       },
+                      onDetailTap: _aiResult != null
+                          ? () => Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) => MenuDetailScreen(aiResult: _aiResult),
+                              ),
+                            )
+                          : null,
                     ),
                   ),
                 ),
@@ -293,6 +302,15 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
                               showFeedback: !_aiLoading && !isAiPick,
                               feedbackGiven: feedbackGiven,
                               onFeedback: (isPos) => _onFeedback(c.id, isPos),
+                              onTap: () => Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (_) => MenuDetailScreen(
+                                    candidate: c,
+                                    jwt: widget.request.jwtToken,
+                                  ),
+                                ),
+                              ),
                             );
                           },
                           childCount: _candidates.length,
@@ -333,12 +351,14 @@ class _AiPickSection extends StatelessWidget {
   final RecommendationResult? result;
   final String? error;
   final VoidCallback onRetry;
+  final VoidCallback? onDetailTap;
 
   const _AiPickSection({
     required this.loading,
     required this.result,
     required this.error,
     required this.onRetry,
+    this.onDetailTap,
   });
 
   @override
@@ -368,7 +388,7 @@ class _AiPickSection extends StatelessWidget {
         else if (error != null)
           _ErrorCard(error: error!, onRetry: onRetry)
         else if (result != null)
-          _ResultCard(result: result!),
+          _ResultCard(result: result!, onDetailTap: onDetailTap),
       ],
     );
   }
@@ -436,7 +456,8 @@ class _ErrorCard extends StatelessWidget {
 
 class _ResultCard extends StatelessWidget {
   final RecommendationResult result;
-  const _ResultCard({required this.result});
+  final VoidCallback? onDetailTap;
+  const _ResultCard({required this.result, this.onDetailTap});
 
   @override
   Widget build(BuildContext context) {
@@ -512,6 +533,20 @@ class _ResultCard extends StatelessWidget {
                     ),
                   )),
                 ],
+                const Divider(height: 20),
+                SizedBox(
+                  width: double.infinity,
+                  child: TextButton.icon(
+                    onPressed: onDetailTap,
+                    icon: const Icon(Icons.open_in_new_rounded, size: 15),
+                    label: const Text('맞춤 레시피 변주 · 재료별 가격 자세히 보기'),
+                    style: TextButton.styleFrom(
+                      foregroundColor: AppTheme.primaryColor,
+                      textStyle: const TextStyle(
+                          fontSize: 13, fontWeight: FontWeight.w600),
+                    ),
+                  ),
+                ),
               ],
             ),
           ),
@@ -558,6 +593,7 @@ class _CandidateCard extends StatelessWidget {
   final bool showFeedback;
   final bool? feedbackGiven;
   final void Function(bool isPositive)? onFeedback;
+  final VoidCallback? onTap;
 
   const _CandidateCard({
     required this.candidate,
@@ -565,11 +601,14 @@ class _CandidateCard extends StatelessWidget {
     required this.showFeedback,
     this.feedbackGiven,
     this.onFeedback,
+    this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(14),
@@ -628,6 +667,7 @@ class _CandidateCard extends StatelessWidget {
           ],
         ),
       ),
+      ),
     );
   }
 
@@ -680,3 +720,4 @@ class _CandidateCard extends StatelessWidget {
             size: 24, color: AppTheme.primaryColor),
       );
 }
+

--- a/flutter_app/lib/screens/recommendation_screen.dart
+++ b/flutter_app/lib/screens/recommendation_screen.dart
@@ -113,6 +113,7 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
   void _showFeedbackBottomSheet() {
     _rating = 0;
     _feedbackController.clear();
+    final messenger = ScaffoldMessenger.of(context);
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
@@ -168,9 +169,16 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
                   borderRadius: BorderRadius.circular(30),
                 ),
                 child: ElevatedButton(
-                  onPressed: () {
+                  onPressed: () async {
+                    final menuId = _aiResult?.menuId;
+                    final rating = _rating;
+                    final reason = _feedbackController.text;
                     Navigator.pop(context);
-                    ScaffoldMessenger.of(context).showSnackBar(
+                    if (menuId != null && menuId > 0 && rating > 0) {
+                      await RecommendationService.saveDetailedFeedback(
+                          menuId, rating, reason, widget.request.jwtToken);
+                    }
+                    messenger.showSnackBar(
                       const SnackBar(content: Text('소중한 피드백 감사합니다!')),
                     );
                   },

--- a/flutter_app/lib/services/recommendation_service.dart
+++ b/flutter_app/lib/services/recommendation_service.dart
@@ -83,4 +83,23 @@ class RecommendationService {
           .timeout(const Duration(seconds: 5));
     } catch (_) {}
   }
+
+  static Future<MenuDetail?> fetchMenuDetail(int id, String? jwt) async {
+    final uri = Uri.parse('${ApiConfig.baseUrl}/api/menus/$id');
+    final headers = <String, String>{};
+    if (jwt != null && jwt.isNotEmpty) {
+      headers['Authorization'] = 'Bearer $jwt';
+    }
+    try {
+      final response = await http
+          .get(uri, headers: headers)
+          .timeout(const Duration(seconds: 10));
+      if (response.statusCode != 200) return null;
+      final json = jsonDecode(utf8.decode(response.bodyBytes));
+      if (json['success'] != true || json['data'] == null) return null;
+      return MenuDetail.fromJson(json['data'] as Map<String, dynamic>);
+    } catch (_) {
+      return null;
+    }
+  }
 }

--- a/flutter_app/lib/services/recommendation_service.dart
+++ b/flutter_app/lib/services/recommendation_service.dart
@@ -46,4 +46,21 @@ class RecommendationService {
     final json = jsonDecode(utf8.decode(response.bodyBytes));
     return RecommendationResult.fromJson(json);
   }
+
+  static Future<void> saveFeedback(int menuId, int feedbackScore, String? jwt) async {
+    if (jwt == null || jwt.isEmpty) return;
+    final uri = Uri.parse('${ApiConfig.baseUrl}/api/recommendation-logs');
+    try {
+      await http
+          .post(
+            uri,
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer $jwt',
+            },
+            body: jsonEncode({'menuId': menuId, 'feedbackScore': feedbackScore}),
+          )
+          .timeout(const Duration(seconds: 5));
+    } catch (_) {}
+  }
 }

--- a/flutter_app/lib/services/recommendation_service.dart
+++ b/flutter_app/lib/services/recommendation_service.dart
@@ -63,4 +63,24 @@ class RecommendationService {
           .timeout(const Duration(seconds: 5));
     } catch (_) {}
   }
+
+  static Future<void> saveDetailedFeedback(
+      int menuId, int starRating, String feedbackReason, String? jwt) async {
+    if (jwt == null || jwt.isEmpty) return;
+    final uri = Uri.parse('${ApiConfig.baseUrl}/api/recommendation-logs');
+    try {
+      final body = <String, dynamic>{'menuId': menuId, 'starRating': starRating};
+      if (feedbackReason.isNotEmpty) body['feedbackReason'] = feedbackReason;
+      await http
+          .post(
+            uri,
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer $jwt',
+            },
+            body: jsonEncode(body),
+          )
+          .timeout(const Duration(seconds: 5));
+    } catch (_) {}
+  }
 }


### PR DESCRIPTION
Summary

- 피드백 수집 및 추천 반영: 후보 메뉴에 긍/부정 피드백 UI를 추가하고, 다음 추천 요청 시 해당 피드백을 반영
- AI 픽 피드백 저장 연동: 추천 결과에 별점·텍스트 피드백 입력 UI 추가 및 백엔드 저장 연동 (별점·텍스트 미입력 시 제출 버튼 비활성화)
- 메뉴 상세 페이지 신규 구현: 후보 메뉴 및 AI 픽 메뉴 카드 탭 시 상세 페이지로 이동
  - 후보 모드: 이미지 즉시 표시 후 재료·영양 정보 비동기 로드
  - AI 픽 모드: 추천 이유·맞춤 레시피 팁·재료별 시세 즉시 표시
- 건강 상태 전 스택 구현: 고혈압·당뇨·고지혈증 등 8개 건강 상태 항목을 DB → 백엔드 엔티티/DTO → Flutter 마이페이지 UI → AI 추천 요청까지 연결
- AI 레시피 팁 사용자 특성 반영 강화: 운동 목표·건강 상태·선호 음식을 프롬프트에 명시, 개인화된 레시피 변주 팁 생성

Bug Fixes

- 음식 선호·건강 상태 저장 불가 (UserProfileRequest @Setter 누락 → Jackson List 필드 역직렬화 실패)
- 온보딩 건강 상태 섹션 누락 → 온보딩에 건강  리
- 재료 중복 표시 (GROUP_CONCAT에 DISTINCT 추가)
- 피드백 조회 실패 시 500 오류 → 방어적 예외
- SQL 1241 오류 (다중 원소 컬렉션 파라미터 IS NULL 체크)

Test Plan

- 온보딩 완료 후 마이페이지에서 음식 선호·건강 상태 체크 항목이 저장된 대로 표시되는지 확인
- 추천 화면에서 후보 메뉴 카드 탭 → 상세 페이  인
- AI 픽 메뉴 탭 → 상세 페이지에 추천 이유·맞춤 레시피 팁·재료 시세 표시 확인
- AI 픽 피드백 별점·텍스트 입력 → 저장 후 다음
- 메뉴 상세 재료 목록 중복 없이 표시되는지 확인
- 백엔드 ./gradlew test 통과 확인