### PR TITLE
feat: 랭그래프, rag, 식단에 따른 분기 추가

### DIFF
--- a/ai_agent_app/DataLoader.py
+++ b/ai_agent_app/DataLoader.py
@@ -1,9 +1,8 @@
 import json
-from typing import List, Dict, Any
-
+from typing import List, Dict
 
 class RecipeDataLoader:
     @staticmethod
-    def load_json(path: str) -> Any:
-        with open(path, "r", encoding="utf-8") as f:
+    def load_json(path: str) -> List[Dict]:
+        with open(path, 'r', encoding='utf-8') as f:
             return json.load(f)

--- a/ai_agent_app/GetMarketPrices.py
+++ b/ai_agent_app/GetMarketPrices.py
@@ -34,21 +34,61 @@ class GetMarketPrices:
             for name, items in price_groups.items()
         }
         
-    def _get_target_pool(self, user_district: str) -> Tuple[List[Dict], Dict[str, Dict]]:
-            if user_district in self.price_data_by_district:
+    def _get_target_pool(self, user_district: str = None) -> Tuple[List[Dict], Dict[str, Dict]]:
+            # [변경] user_district가 None이면 국가 풀 사용
+            if user_district and user_district in self.price_data_by_district:
                 return (
                     self.price_data_by_district[user_district],
                     self.index_by_district[user_district]
                 )
             return self._national_pool, self._national_index
-        
+
     def _match_item(self, word: str, pool: List[Dict], index: Dict[str, Dict]) -> Optional[Dict]:
         """정확히 일치 → 부분 일치 순으로 탐색."""
         if exact := index.get(word):
             return exact
         return next((p for p in pool if word in p['PRDLST_NM']), None)
-                
-    def get_market_prices(self, ingredients_text: str, user_district: str) -> str:
+
+    def estimate_serving_cost(self, recipe_text: str, price_info: str) -> int:
+        """레시피 사용량(분수+단위) 기반 1인분 비용 추정.
+        - 매칭되는 재료만 합산 (단위 불일치/누락은 무시)
+        - 부정확할 수 있어 랭킹 참고용
+        """
+        if not recipe_text or not price_info or "Error" in price_info:
+            return 0
+
+        market = {}
+        for m in re.finditer(r'-\s*(\S+?):\s*(\d+)원\s*\(([^)]+)\)', price_info):
+            name, price, unit_full = m.groups()
+            unit_match = re.search(r'([가-힣]+)', unit_full)
+            unit = unit_match.group(1) if unit_match else ""
+            market[name] = (int(price), unit)
+
+        total = 0
+        pattern = re.compile(r'(\S+?)\s+\d+\w*\(([\d/]+)\s*([가-힣]+)\)')
+        for m in pattern.finditer(recipe_text):
+            ing_name, amount_str, unit = m.groups()
+
+            if '/' in amount_str:
+                try:
+                    n, d = amount_str.split('/')
+                    ratio = int(n) / int(d) if int(d) > 0 else 0
+                except ValueError:
+                    continue
+            else:
+                try:
+                    ratio = float(amount_str)
+                except ValueError:
+                    continue
+
+            for market_name, (price, market_unit) in market.items():
+                if (market_name in ing_name or ing_name in market_name) and unit == market_unit:
+                    total += int(price * ratio)
+                    break
+        return total
+
+    def get_market_prices(self, ingredients_text: str, user_district: str = None) -> str:
+        # [변경] user_district를 선택사항으로 변경 (기본값 None)
         try:
             keywords = {
                 w for w in re.findall(r'[가-힣]+', ingredients_text)

--- a/ai_agent_app/GoalGuidelines.py
+++ b/ai_agent_app/GoalGuidelines.py
@@ -1,0 +1,47 @@
+# =====================================================================
+# 식단 목표별 가이드라인
+# =====================================================================
+
+from typing import Dict
+
+GOAL_GUIDELINES: Dict[str, Dict[str, str]] = {
+    "다이어트": {
+        "calorie": "끼당 400~500kcal 권장 (저칼로리)",
+        "macros": "고단백(20g+), 저탄수, 저지방, 식이섬유 풍부",
+        "sodium": "나트륨 600mg 이하 권장",
+        "focus": "포만감 높고 자극 적은 메뉴 우선. 가공식품/튀김 회피.",
+    },
+    "근력운동": {
+        "calorie": "끼당 700~900kcal 권장 (충분한 에너지)",
+        "macros": "고단백(25g+), 충분한 탄수화물, 적당한 지방",
+        "sodium": "나트륨 800mg 이하 권장",
+        "focus": "근육 합성/회복에 도움되는 단백질원(닭/소/생선/콩) 우선.",
+    },
+    "유지": {
+        "calorie": "끼당 600~700kcal 권장",
+        "macros": "균형 (탄수화물:단백질:지방 ≈ 5:3:2)",
+        "sodium": "나트륨 700mg 이하 권장",
+        "focus": "다양한 식재료로 균형 잡힌 식단.",
+    },
+    "일반식단": {
+        "calorie": "끼당 600kcal 내외 (일반 권장량)",
+        "macros": "균형 잡힌 영양소",
+        "sodium": "나트륨 700mg 이하 권장",
+        "focus": "건강하고 맛있는 메뉴.",
+    },
+}
+
+
+def get_guideline(goal: str) -> Dict[str, str]:
+    return GOAL_GUIDELINES.get(goal, GOAL_GUIDELINES["일반식단"])
+
+
+def format_guideline(goal: str) -> str:
+    g = get_guideline(goal)
+    return (
+        f"[목표별 영양 가이드: {goal}]\n"
+        f"- 권장 칼로리: {g['calorie']}\n"
+        f"- 영양소 기준: {g['macros']}\n"
+        f"- 나트륨: {g['sodium']}\n"
+        f"- 중점: {g['focus']}"
+    )

--- a/ai_agent_app/MenuFetcher.py
+++ b/ai_agent_app/MenuFetcher.py
@@ -35,48 +35,49 @@ class MenuFetcher:
         return []
 
     def fetch_candidates_by_ids(self, ids: List[int], jwt_token: Optional[str]) -> List[dict]:
-        """
-        Flutter가 미리 조회한 후보 ID 목록으로 Spring GET /api/menus/candidates?ids=... 호출.
-        Flutter와 AI agent가 동일한 후보 풀을 사용하도록 보장.
-        """
-        if not ids:
+            """
+            Flutter가 미리 조회한 후보 ID 목록으로 Spring GET /api/menus/candidates?ids=... 호출.
+            Flutter와 AI agent가 동일한 후보 풀을 사용하도록 보장.
+            """
+            if not ids:
+                return []
+
+            url = f"{self.backend_url}/api/menus/candidates"
+            headers = {}
+            if jwt_token:
+                headers["Authorization"] = f"Bearer {jwt_token}"
+            params = [("ids", i) for i in ids]
+
+            try:
+                resp = requests.get(url, params=params, headers=headers, timeout=10)
+                resp.raise_for_status()
+                body = resp.json()
+                if body.get("success") and body.get("data"):
+                    return [self._to_ai_format(m) for m in body["data"]]
+            except requests.exceptions.ConnectionError:
+                print("[MenuFetcher] Spring 백엔드에 연결할 수 없습니다.")
+            except requests.exceptions.Timeout:
+                print("[MenuFetcher] Spring 백엔드 응답 시간 초과.")
+            except Exception as e:
+                print(f"[MenuFetcher] ID 기반 후보 조회 실패: {e}")
+
             return []
-
-        url = f"{self.backend_url}/api/menus/candidates"
-        headers = {}
-        if jwt_token:
-            headers["Authorization"] = f"Bearer {jwt_token}"
-        params = [("ids", i) for i in ids]
-
-        try:
-            resp = requests.get(url, params=params, headers=headers, timeout=10)
-            resp.raise_for_status()
-            body = resp.json()
-            if body.get("success") and body.get("data"):
-                return [self._to_ai_format(m) for m in body["data"]]
-        except requests.exceptions.ConnectionError:
-            print("[MenuFetcher] Spring 백엔드에 연결할 수 없습니다.")
-        except requests.exceptions.Timeout:
-            print("[MenuFetcher] Spring 백엔드 응답 시간 초과.")
-        except Exception as e:
-            print(f"[MenuFetcher] ID 기반 후보 조회 실패: {e}")
-
-        return []
 
     def _to_ai_format(self, dto: dict) -> dict:
         """Spring MenuCandidateDto → AI 내부 JSON 포맷 변환."""
         recipe = {
             "MENU_ID":          dto.get("id"),
-            "RCP_NM":           dto.get("name", ""),
-            "RCP_PARTS_DTLS":   dto.get("ingredientsText", ""),
-            "INFO_ENG":          str(dto.get("calories") or 0),
-            "INFO_PRO":          str(dto.get("protein") or 0),
-            "INFO_FAT":          str(dto.get("fat") or 0),
-            "INFO_CAR":          str(dto.get("carbs") or 0),
-            "INFO_NA":           str(dto.get("sodium") or 0),
-            "ATT_FILE_NO_MAIN":  dto.get("mainImageUrl", ""),
-            "RCP_NA_TIP":        dto.get("healthTip", ""),
+            "RCP_NM":         dto.get("name", ""),
+            "RCP_PARTS_DTLS": dto.get("ingredientsText", ""),
+            "INFO_ENG":        str(dto.get("calories") or 0),
+            "INFO_PRO":        str(dto.get("protein") or 0),
+            "INFO_FAT":        str(dto.get("fat") or 0),
+            "INFO_CAR":        str(dto.get("carbs") or 0),
+            "INFO_NA":         str(dto.get("sodium") or 0),
+            "ATT_FILE_NO_MAIN": dto.get("mainImageUrl", ""),
+            "RCP_NA_TIP":      dto.get("healthTip", ""),
         }
+        # 조리 단계 (steps 테이블 연결 후 채워짐)
         for step in dto.get("steps", []):
             num = str(step.get("stepNo", 0)).zfill(2)
             recipe[f"MANUAL{num}"]     = step.get("content", "")

--- a/ai_agent_app/ProcessDynamicInputs.py
+++ b/ai_agent_app/ProcessDynamicInputs.py
@@ -1,137 +1,64 @@
-from langchain_openai import ChatOpenAI
-from typing import List, Dict, Any
-from langchain_core.output_parsers import JsonOutputParser
-from ai_agent_app.GetMarketPrices import GetMarketPrices
-from ai_agent_app.SelectCandidates import SelectCandidates
-from ai_agent_app.Prompts import get_recipe_prompt
-import re
-
-class ProcessDynamicInputs:
-    def __init__(self, recipes: List[Dict], get_market_prices: GetMarketPrices, select_candidates: SelectCandidates, model: ChatOpenAI):
-        self.recipes = recipes
-        self.get_market_prices = get_market_prices
-        self.select_candidates = select_candidates
-        self.model = model
-        self.chain = get_recipe_prompt() | self.model | JsonOutputParser()
-        
-    def _enrich_candidates(self, candidate_ids, user_location, active_recipes) -> tuple[list[str], dict]:
-        """후보별 물가 조회 + enriched 문자열 생성"""
-        price_cache: Dict[int, str] = {}
-        enriched: List[str] = []
-        for cid in candidate_ids:
-            r = active_recipes[cid]
-            try:
-                p_info = self.get_market_prices.get_market_prices(
-                    r['RCP_PARTS_DTLS'], 
-                    user_district=user_location
-                )
-            except Exception as e:
-                p_info = "가격 데이터 조회 실패"
-            price_cache[cid] = p_info
-            enriched.append(self._format_enriched(cid, r, p_info))
-        return enriched, price_cache
-    
-    def _format_enriched(self, cid, recipe, price_info) -> str:
-        """enriched 문자열 포맷"""
-        return (
-            f"ID:{cid} | 메뉴:{recipe['RCP_NM']} | 물가:{price_info} | "
-            f"열량:{recipe['INFO_ENG']}kcal 단백질:{recipe['INFO_PRO']}g "
-            f"지방:{recipe['INFO_FAT']}g 탄수화물:{recipe['INFO_CAR']}g 나트륨:{recipe['INFO_NA']}mg"
-        )
-        
-    def _select_final_id(self, user_query, enriched, candidate_ids) -> int:
-        """LLM으로 최종 레시피 ID 선정"""
-        final_prompt = (
-            f"사용자 예산: {user_query['budget']}원\n"
-            f"사용자 목표: {user_query.get('fitness_goal', '일반식단')}\n"
-            f"건강 상태: {user_query.get('health_conditions', '없음')}\n"
-            f"아래 후보 리스트 중 예산 내에서 사용자 목표와 건강 상태에 가장 적합한 레시피를 하나 선택하세요.\n"
-            f"반드시 마지막 줄에 다음 형식으로만 답하세요 (다른 설명 금지):\n"
-            f"선택ID: <숫자>\n"
-            "----------------------\n"
-            + "\n".join(enriched)
-        )
-        raw = self.model.invoke(final_prompt).content
-        match = re.search(r"선택ID:\s*(\d+)", raw)
-        if match is None:
-            raise ValueError(f"LLM 응답에서 '선택ID:' 앵커를 찾을 수 없습니다. 응답: {raw!r}")
+from typing import List, Dict
+from GoalGuidelines import format_guideline
 
 
-        final_id = int(match.group(1))
-        # LLM이 후보 범위 밖의 ID를 반환했을 경우 방어
-        if final_id not in candidate_ids:
-            raise ValueError(
-                f"LLM이 반환한 ID({final_id})가 후보 목록에 없습니다: {candidate_ids}"
-            )
-        return final_id
-        
-    def _parse_recipe_steps(self, final_recipe) -> list[dict]:
-        """레시피 단계 파싱"""
-        recipe_steps = []
-        for i in range(1, 21):
-            num = str(i).zfill(2)
-            desc = final_recipe.get(f'MANUAL{num}', "").strip()
-            img = final_recipe.get(f'MANUAL_IMG{num}', "").strip()
-            
-            # 설명(desc)이 있는 경우에만 리스트에 추가
-            if desc:
-                recipe_steps.append({
-                    "step_no": i, # 실제 데이터상의 단계 번호
-                    "content": desc,
-                    "image": img
-                })
-        return recipe_steps
-    
-    def _build_static_data(self, final_recipe) -> dict:
-        """정적 레시피 데이터 조립"""
-        return {
-            "menu_id": final_recipe.get("MENU_ID"),
-            "menu_name": final_recipe["RCP_NM"],
-            "main_img": final_recipe["ATT_FILE_NO_MAIN"],
-            "nutrition_info": {
-                "energy": f"{final_recipe['INFO_ENG']}kcal",
-                "protein": f"{final_recipe['INFO_PRO']}g",
-                "fat": f"{final_recipe['INFO_FAT']}g",
-                "carbs": f"{final_recipe['INFO_CAR']}g",
-                "sodium": f"{final_recipe['INFO_NA']}mg",
-            },
-            "recipe_steps": self._parse_recipe_steps(final_recipe),
-            "na_tip": final_recipe["RCP_NA_TIP"],
-        }
-        
-    def _build_llm_data(self, final_recipe, price_info, user_query) -> dict:
-        """LLM chain 실행 및 결과 반환"""
-        llm_input ={
-            "menu_name": final_recipe["RCP_NM"],
-            "ingredients": final_recipe["RCP_PARTS_DTLS"],
-            "price_info": price_info,  # 캐시 재사용
-            "user_profile": (
-                f"키 {user_query.get('height_cm')}cm, "
-                f"체중 {user_query.get('weight_kg')}kg, "
-                f"운동 목표: {user_query.get('fitness_goal', '일반식단')}, "
-                f"건강 상태: {', '.join(user_query.get('health_conditions', []) or []) or '없음'}, "
-                f"선호 음식: {', '.join(user_query.get('preferences', []) or []) or '없음'}"
-            ),
-            "user_restrictions": (
-                f"알러지: {', '.join(user_query.get('allergies', []) or [])}, "
-                f"선호: {', '.join(user_query.get('preferences', []) or [])}"
-            ),
-            "health_conditions": ', '.join(user_query.get('health_conditions', []) or []) or '없음',
-        }
-        return self.chain.invoke(llm_input)
-    
-    def process_dynamic_inputs(self, user_query: Dict, recipes: List[Dict] = None) -> Dict[str, Any]:
-        active_recipes = recipes if recipes is not None else self.recipes
-        candidate_ids = self.select_candidates.select_candidates(active_recipes, user_query)
+def format_enriched(cid, recipe: Dict, price_info: str, rough_cost: int = 0) -> str:
+    """enriched 문자열 포맷 (rank_node 프롬프트용)"""
+    cost_str = f"{rough_cost}원" if rough_cost > 0 else "추정불가"
+    return (
+        f"ID:{cid} | 메뉴:{recipe['RCP_NM']} | 추정조리비:{cost_str} | "
+        f"열량:{recipe['INFO_ENG']}kcal 단백질:{recipe['INFO_PRO']}g "
+        f"지방:{recipe['INFO_FAT']}g 탄수화물:{recipe['INFO_CAR']}g 나트륨:{recipe['INFO_NA']}mg"
+    )
 
-        if not candidate_ids:
-            raise ValueError("적합한 레시피 후보가 없습니다.")
 
-        enriched, price_cache = self._enrich_candidates(candidate_ids, user_query.get("location"), active_recipes)
-        final_id    = self._select_final_id(user_query, enriched, candidate_ids)
-        print(f"최종 선정된 레시피 ID: {final_id}")
-        final_recipe = active_recipes[final_id]
-        
-        static_data = self._build_static_data(final_recipe)
-        llm_data    = self._build_llm_data(final_recipe, price_cache[final_id], user_query)
-        return {**static_data, **llm_data}
+def parse_recipe_steps(recipe: Dict) -> List[Dict]:
+    """레시피 단계 파싱 (desc 있는 단계만 포함)"""
+    steps = []
+    for i in range(1, 21):
+        num = str(i).zfill(2)
+        desc = recipe.get(f"MANUAL{num}", "").strip()
+        img = recipe.get(f"MANUAL_IMG{num}", "").strip()
+        if desc:
+            steps.append({"step_no": i, "content": desc, "image": img})
+    return steps
+
+
+def build_static_data(recipe: Dict) -> Dict:
+    """정적 레시피 데이터 조립 (LLM 호출 없이 구성 가능한 필드)"""
+    return {
+        "recipe_id": recipe.get("MENU_ID") or recipe.get("RCP_SEQ"),  # Spring MENU_ID 우선, 폴백으로 RCP_SEQ
+        "menu_name": recipe["RCP_NM"],
+        "main_img": recipe["ATT_FILE_NO_MAIN"],
+        "nutrition_info": {
+            "energy": f"{recipe['INFO_ENG']}kcal",
+            "protein": f"{recipe['INFO_PRO']}g",
+            "fat": f"{recipe['INFO_FAT']}g",
+            "carbs": f"{recipe['INFO_CAR']}g",
+            "sodium": f"{recipe['INFO_NA']}mg",
+        },
+        "recipe_steps": parse_recipe_steps(recipe),
+        "na_tip": recipe["RCP_NA_TIP"],
+    }
+
+
+def build_llm_input(recipe: Dict, price_info: str, user_query: Dict) -> Dict:
+    """LLM chain에 넘길 입력 딕셔너리 조립"""
+    return {
+        "menu_name": recipe["RCP_NM"],
+        "ingredients": recipe["RCP_PARTS_DTLS"],
+        "price_info": price_info,
+        "user_profile": (
+            f"키 {user_query.get('height_cm')}cm, "
+            f"체중 {user_query.get('weight_kg')}kg, "
+            f"운동 목표: {user_query.get('fitness_goal', '일반식단')}, "
+            f"건강 상태: {', '.join(user_query.get('health_conditions', []) or []) or '없음'}, "
+            f"선호 음식: {', '.join(user_query.get('preferences', []) or []) or '없음'}"
+        ),
+        "user_restrictions": (
+            f"알러지: {', '.join(user_query.get('allergies', []) or [])}, "
+            f"선호: {', '.join(user_query.get('preferences', []) or [])}"
+        ),
+        "health_conditions": ', '.join(user_query.get('health_conditions', []) or []) or '없음',
+        "goal_guideline": format_guideline(user_query.get('fitness_goal', '일반식단')),
+    }

--- a/ai_agent_app/ProcessDynamicInputs.py
+++ b/ai_agent_app/ProcessDynamicInputs.py
@@ -1,5 +1,5 @@
 from typing import List, Dict
-from GoalGuidelines import format_guideline
+from ai_agent_app.GoalGuidelines import format_guideline
 
 
 def format_enriched(cid, recipe: Dict, price_info: str, rough_cost: int = 0) -> str:

--- a/ai_agent_app/Prompts.py
+++ b/ai_agent_app/Prompts.py
@@ -17,6 +17,9 @@ RECIPE_ANALYST_TEMPLATE = """
 - 제한사항: {user_restrictions}
 - 건강 상태: {health_conditions}
 
+{goal_guideline}
+
+# selection_reason 작성 시 위 '목표별 영양 가이드'에 부합하는 이유를 강조하세요.
 
 # 반드시 아래 JSON 구조를 지키세요:
 {{

--- a/ai_agent_app/RecipeGraph.py
+++ b/ai_agent_app/RecipeGraph.py
@@ -8,11 +8,11 @@ from langchain_openai import ChatOpenAI
 from langchain_core.output_parsers import JsonOutputParser
 import re
 import asyncio
-from GetMarketPrices import GetMarketPrices
-from SelectCandidates import SelectCandidates
-from Prompts import get_recipe_prompt
-import ProcessDynamicInputs
-from GoalGuidelines import format_guideline
+from ai_agent_app.GetMarketPrices import GetMarketPrices
+from ai_agent_app.SelectCandidates import SelectCandidates
+from ai_agent_app.Prompts import get_recipe_prompt
+from ai_agent_app import ProcessDynamicInputs
+from ai_agent_app.GoalGuidelines import format_guideline
 
 
 # =====================================================================
@@ -55,12 +55,12 @@ class GraphState(TypedDict):
 class RecipeGraphBuilder:
     def __init__(
         self,
-        recipes: List[Dict],
         get_market_prices: GetMarketPrices,
         select_candidates: SelectCandidates,
         model: ChatOpenAI,
+        recipes: List[Dict] = None,
     ):
-        self.recipes = recipes
+        self.recipes = recipes or []
         self.get_market_prices = get_market_prices
         self.select_candidates = select_candidates
         self.model = model

--- a/ai_agent_app/RecipeGraph.py
+++ b/ai_agent_app/RecipeGraph.py
@@ -1,0 +1,268 @@
+# =====================================================================
+# RecipeGraph.py - RCP_SEQ 기반 식별자로 통일된 LangGraph 워크플로우
+# =====================================================================
+
+from typing import List, Dict, Any, TypedDict, Optional
+from langgraph.graph import StateGraph, END
+from langchain_openai import ChatOpenAI
+from langchain_core.output_parsers import JsonOutputParser
+import re
+import asyncio
+from GetMarketPrices import GetMarketPrices
+from SelectCandidates import SelectCandidates
+from Prompts import get_recipe_prompt
+import ProcessDynamicInputs
+from GoalGuidelines import format_guideline
+
+
+# =====================================================================
+# GraphState: 노드 간 공유 상태
+# - 모든 ID는 RCP_SEQ 문자열 ("28" 같은 형태)
+# - recipes_by_seq: RCP_SEQ -> recipe 빠른 룩업 dict
+# =====================================================================
+class GraphState(TypedDict):
+    # 입력
+    recipes: List[Dict]
+    recipes_by_seq: Dict[str, Dict]
+    user_query: Dict
+
+    # [피드백] 거절된 RCP_SEQ 리스트
+    rejected_ids: List[str]
+    feedback_reason: Optional[str]
+    feedback_constraints: Optional[str]
+
+    # [filter_node] 출력
+    filtered_recipes: List[Dict]
+    allowed_ids: List[str]
+    history_texts: List[str]  # 벡터 검색으로 추출한 관련 이력 텍스트 (LLM 컨텍스트용)
+
+    # [candidate_node] 출력
+    candidate_ids: List[str]
+
+    # [price_node] 출력
+    enriched: List[str]
+    price_cache: Dict[str, str]
+
+    # [rank_node] 출력
+    top5_ids: List[str]
+    top10_ids: List[str]
+
+    # 최종
+    final_results: List[Dict[str, Any]]
+    error: Optional[str]
+
+
+class RecipeGraphBuilder:
+    def __init__(
+        self,
+        recipes: List[Dict],
+        get_market_prices: GetMarketPrices,
+        select_candidates: SelectCandidates,
+        model: ChatOpenAI,
+    ):
+        self.recipes = recipes
+        self.get_market_prices = get_market_prices
+        self.select_candidates = select_candidates
+        self.model = model
+        self.chain = get_recipe_prompt() | self.model | JsonOutputParser()
+
+    # ------------------------------------------------------------------
+    # filter_node: 알러지/거절 항목 소거 → allowed_ids (RCP_SEQ)
+    # ------------------------------------------------------------------
+    def filter_node(self, state: GraphState) -> GraphState:
+        rejected = set(state.get("rejected_ids", []))
+        allergies = state["user_query"].get("allergies", [])
+
+        allowed_ids: List[str] = []
+        filtered: List[Dict] = []
+        for r in state["recipes"]:
+            seq = str(r.get("MENU_ID") or r.get("RCP_SEQ", "")).strip()
+            if not seq:
+                continue
+            if seq in rejected:
+                continue
+            if allergies:
+                ingredients = r.get("RCP_PARTS_DTLS", "")
+                if any(a in ingredients for a in allergies):
+                    continue
+            allowed_ids.append(seq)
+            filtered.append(r)
+
+        total = len(state["recipes"])
+        print(f"[filter_node] 전체 {total}개 → 알러지/거절 제거 후 {len(filtered)}개 ({total - len(filtered)}개 제외)")
+        return {**state, "filtered_recipes": filtered, "allowed_ids": allowed_ids}
+
+    # ------------------------------------------------------------------
+    # candidate_node: 이력 우선 + 부족분 LLM으로 보충
+    # ------------------------------------------------------------------
+    def candidate_node(self, state: GraphState) -> GraphState:
+        print("[candidate_node] 후보 추출 시작")
+        allowed_ids = state.get("allowed_ids", [])
+        if not allowed_ids:
+            return {**state, "error": "필터링 후 남은 레시피가 없습니다."}
+
+        history_texts = state.get("history_texts", [])
+        print(f"[candidate_node] 관련 이력 {len(history_texts)}개 컨텍스트로 사용")
+
+        try:
+            llm_local_ids = self.select_candidates.select_candidates(
+                state["filtered_recipes"],
+                state["user_query"],
+                history_texts=history_texts,
+            )
+            candidate_ids = [allowed_ids[i] for i in llm_local_ids if 0 <= i < len(allowed_ids)]
+        except Exception as e:
+            return {**state, "error": str(e)}
+
+        if not candidate_ids:
+            return {**state, "error": "적합한 레시피 후보가 없습니다."}
+        return {**state, "candidate_ids": candidate_ids[:10]}
+
+    # ------------------------------------------------------------------
+    # price_node: RCP_SEQ로 룩업 + 가격 조회 (병렬)
+    # ------------------------------------------------------------------
+    async def price_node(self, state: GraphState) -> GraphState:
+        print("[price_node] 후보 가격 조회 (병렬)")
+        location = state["user_query"].get("location")
+        recipes_by_seq = state["recipes_by_seq"]
+
+        async def fetch_one(seq: str):
+            r = recipes_by_seq[seq]
+            try:
+                p_info = await asyncio.to_thread(
+                    self.get_market_prices.get_market_prices,
+                    r["RCP_PARTS_DTLS"],
+                    location,
+                )
+                rough_cost = self.get_market_prices.estimate_serving_cost(
+                    r["RCP_PARTS_DTLS"], p_info
+                )
+            except Exception:
+                p_info = "가격 데이터 조회 실패"
+                rough_cost = 0
+            return seq, r, p_info, rough_cost
+
+        results = await asyncio.gather(*[fetch_one(seq) for seq in state["candidate_ids"]])
+
+        price_cache = {seq: p_info for seq, _, p_info, _ in results}
+        enriched = [
+            ProcessDynamicInputs.format_enriched(seq, r, p_info, rough)
+            for seq, r, p_info, rough in results
+        ]
+        return {**state, "enriched": enriched, "price_cache": price_cache}
+
+    # ------------------------------------------------------------------
+    # rank_node
+    # ------------------------------------------------------------------
+    def rank_node(self, state: GraphState) -> GraphState:
+        print("[rank_node] LLM으로 상위 10개 랭킹 선정")
+        enriched = state["enriched"]
+        candidate_ids = state["candidate_ids"]
+
+        uq = state["user_query"]
+        goal = uq.get('fitness_goal', '일반식단')
+        prompt = (
+            "[사용자 정보]\n"
+            f"예산: {uq.get('budget')}원\n"
+            f"목표: {goal}\n"
+            f"건강 상태: {', '.join(uq.get('health_conditions', [])) or '없음'}\n"
+            f"선호: {', '.join(uq.get('preferences', [])) or '없음'}\n"
+            f"이전 거절 이유: {state.get('feedback_constraints', '없음')}\n\n"
+            f"{format_guideline(goal)}\n\n"
+            "[종합 판단 지침]\n"
+            "- '추정조리비'는 일부 재료만 매칭된 부정확한 값일 수 있음. 절대적 기준이 아님.\n"
+            "- 예산을 크게 초과하는지 참고만 하고, 영양/취향/건강 적합성을 우선 고려.\n"
+            "- '추정불가'로 표시된 항목도 정상이므로 다른 기준으로 평가할 것.\n"
+            "- 선호와 건강 상태에 더 잘 맞는 메뉴가 추정조리비 약간 높아도 우선될 수 있음.\n\n"
+            "아래 후보 중 사용자에게 가장 적합한 10개를 순서대로 선정.\n"
+            "반드시 마지막 줄에 다음 형식으로만 답하세요 (다른 설명 금지):\n"
+            "랭킹ID: <ID1>, <ID2>, <ID3>, <ID4>, <ID5>, <ID6>, <ID7>, <ID8>, <ID9>, <ID10>\n"
+            "----------------------\n"
+            + "\n".join(enriched)
+        )
+
+        try:
+            raw = self.model.invoke(prompt).content
+            match = re.search(r"랭킹ID:\s*([\w,\s]+)", raw)
+            if not match:
+                raise ValueError(f"LLM 응답에서 '랭킹ID:' 앵커를 찾을 수 없습니다. 응답: {raw!r}")
+
+            parsed = [x.strip() for x in match.group(1).split(",") if x.strip()]
+            candidate_set = set(candidate_ids)
+            top10_ids = [s for s in parsed if s in candidate_set][:10]
+
+            if not top10_ids:
+                raise ValueError("유효한 랭킹 ID가 없습니다.")
+
+            top5_ids = top10_ids[:5]
+            return {**state, "top5_ids": top5_ids, "top10_ids": top10_ids}
+        except Exception as e:
+            return {**state, "error": str(e)}
+
+    # ------------------------------------------------------------------
+    # analyze_node
+    # ------------------------------------------------------------------
+    async def _analyze_one(self, seq: str, state: GraphState):
+        recipe = state["recipes_by_seq"][seq]
+        price_info = state["price_cache"].get(seq, "가격 데이터 없음")
+
+        static_data = ProcessDynamicInputs.build_static_data(recipe)
+
+        try:
+            llm_input = ProcessDynamicInputs.build_llm_input(recipe, price_info, state["user_query"])
+            llm_data = await self.chain.ainvoke(llm_input)
+        except Exception as e:
+            llm_data = {"error": str(e)}
+
+        result = {**static_data, **llm_data}
+
+        if "market_prices" in result and isinstance(result["market_prices"], list):
+            result["total_estimated_cost"] = sum(
+                float(p.get("calculated_cost", 0))
+                for p in result["market_prices"]
+            )
+        return result
+
+    async def analyze_node(self, state: GraphState) -> GraphState:
+        print("[analyze_node] 상위 5개 상세 분석 (병렬 처리)")
+        tasks = [self._analyze_one(seq, state) for seq in state["top5_ids"]]
+        final_results = await asyncio.gather(*tasks)
+        return {**state, "final_results": final_results}
+
+    async def analyze_with_rejection(self, state: GraphState) -> GraphState:
+        print(f"[analyze_with_rejection] top10에서 거절된 {len(state['rejected_ids'])}개 제외 후 analyze")
+
+        rejected_set = set(state["rejected_ids"])
+        remaining = [s for s in state["top10_ids"] if s not in rejected_set]
+
+        if not remaining:
+            return {**state, "error": "추천할 남은 레시피가 없습니다"}
+
+        new_top5 = remaining[:5]
+        tasks = [self._analyze_one(seq, state) for seq in new_top5]
+        final_results = await asyncio.gather(*tasks)
+        return {**state, "top5_ids": new_top5, "final_results": final_results}
+
+    def build(self):
+        graph = StateGraph(GraphState)
+
+        graph.add_node("filter_node", self.filter_node)
+        graph.add_node("candidate_node", self.candidate_node)
+        graph.add_node("price_node", self.price_node)
+        graph.add_node("rank_node", self.rank_node)
+        graph.add_node("analyze_node", self.analyze_node)
+
+        graph.set_entry_point("filter_node")
+        graph.add_edge("filter_node", "candidate_node")
+        graph.add_conditional_edges(
+            "candidate_node",
+            lambda s: END if s.get("error") else "price_node",
+        )
+        graph.add_conditional_edges(
+            "rank_node",
+            lambda s: END if s.get("error") else "analyze_node",
+        )
+        graph.add_edge("price_node", "rank_node")
+        graph.add_edge("analyze_node", END)
+
+        return graph.compile()

--- a/ai_agent_app/SelectCandidates.py
+++ b/ai_agent_app/SelectCandidates.py
@@ -1,8 +1,11 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from langchain_openai import ChatOpenAI
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.prompts import ChatPromptTemplate
+
+from GoalGuidelines import format_guideline
+
 
 class SelectCandidates:
     def __init__(self, model: ChatOpenAI):
@@ -17,13 +20,27 @@ class SelectCandidates:
             for i, r in enumerate(recipes[:100])
         ])
 
-    def select_candidates(self, recipes: List[Dict], query: Dict) -> List[int]:
+    @staticmethod
+    def _format_history(history_texts: Optional[List[str]]) -> str:
+        if not history_texts:
+            return "(이력 없음)"
+        return "\n".join(f"- {t}" for t in history_texts)
+
+    def select_candidates(
+        self,
+        recipes: List[Dict],
+        query: Dict,
+        history_texts: Optional[List[str]] = None,
+    ) -> List[int]:
         context = self._build_context(recipes)
+        history_block = self._format_history(history_texts)
 
         prompt = ChatPromptTemplate.from_messages([
             (
                 "system",
-                "당신은 전문 영양사입니다. 사용자의 프로필을 분석하여 최적의 식단 ID를 선정하세요. "
+                "당신은 전문 영양사입니다. 사용자의 프로필과 과거 식사 이력을 종합 분석하여 "
+                "가장 적합한 식단 ID를 선정하세요. 별점 낮은 이력은 사용자가 싫어한 패턴을 "
+                "암시하므로 피해야 합니다. "
                 "반드시 JSON으로만 답하세요. 형식: {{\"candidate_ids\": [0, 1, 2]}} (최대 10개)"
             ),
             ("human", (
@@ -33,6 +50,9 @@ class SelectCandidates:
                 "알러지: {allergy}\n"
                 "선호: {preferences}\n"
                 "운동 목표: {goal}\n\n"
+                "{guideline}\n\n"
+                "[과거 식사 이력 (현재 요청과 관련 있는 항목)]\n"
+                "{history}\n\n"
                 "[레시피 목록]\n{context}"
             ))
         ])
@@ -44,9 +64,11 @@ class SelectCandidates:
                 "weight": query.get('weight_kg'),
                 "health": ", ".join(query.get('health_conditions', [])) or "없음",
                 "allergy": ", ".join(query.get('allergies', [])) or "없음",
-                "preferences": query.get('preferences', "없음"),
+                "preferences": ", ".join(query.get('preferences', [])) or "없음",
                 "goal": query.get('fitness_goal'),
-                "context": context
+                "guideline": format_guideline(query.get('fitness_goal', '일반식단')),
+                "history": history_block,
+                "context": context,
             })
             if not isinstance(response, dict):
                 return []
@@ -60,7 +82,7 @@ class SelectCandidates:
                     out.append(int(x))
                 except Exception:
                     continue
-            print(out)  # 모델이 어떤 응답을 주는지 확인용
+            print(f"[SelectCandidates] LLM 응답 IDs: {out}")
             return out[:10]
         except Exception as e:
             print(f"Error in select_candidates: {e}")

--- a/ai_agent_app/SelectCandidates.py
+++ b/ai_agent_app/SelectCandidates.py
@@ -4,7 +4,7 @@ from langchain_openai import ChatOpenAI
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 
-from GoalGuidelines import format_guideline
+from ai_agent_app.GoalGuidelines import format_guideline
 
 
 class SelectCandidates:

--- a/ai_agent_app/UserHistoryManager.py
+++ b/ai_agent_app/UserHistoryManager.py
@@ -1,0 +1,96 @@
+from typing import List, Dict, Optional
+from langchain_chroma import Chroma
+from langchain_huggingface import HuggingFaceEmbeddings
+from langchain_core.documents import Document
+
+
+class UserHistoryManager:
+    """유저 식사 이력 저장소
+    - 저장: 메뉴 + 코멘트 + 별점 + 당시 user_query 컨텍스트
+    - 조회: 현재 요청과 의미적으로 가까운 과거 이력 K개 (벡터 검색)
+    """
+
+    def __init__(self, persist_dir: str = "./user_history_db"):
+        self.embeddings = HuggingFaceEmbeddings(model_name="BAAI/bge-m3")
+        self.vectorstore = Chroma(
+            persist_directory=persist_dir,
+            embedding_function=self.embeddings,
+        )
+
+    def save(
+        self,
+        user_id: str,
+        recipe_id: str,
+        recipe_name: str,
+        comment: str,
+        rating: float,
+        context: Optional[Dict] = None,
+    ):
+        text = self._format_text(recipe_name, comment, rating, context)
+        doc = Document(
+            page_content=text,
+            metadata={
+                "user_id": user_id,
+                "recipe_id": str(recipe_id),
+                "rating": float(rating),
+            },
+        )
+        self.vectorstore.add_documents([doc])
+
+    @staticmethod
+    def _format_text(
+        recipe_name: str,
+        comment: str,
+        rating: float,
+        context: Optional[Dict] = None,
+    ) -> str:
+        parts = [
+            f"메뉴: {recipe_name}",
+            f"코멘트: {comment}",
+            f"별점: {rating}",
+        ]
+        if context:
+            goal = context.get("fitness_goal")
+            healths = context.get("health_conditions") or []
+            prefs = context.get("preferences") or []
+            if goal:
+                parts.append(f"목표: {goal}")
+            if healths:
+                parts.append(f"건강: {', '.join(healths)}")
+            if prefs:
+                parts.append(f"선호: {', '.join(prefs)}")
+        return ", ".join(parts)
+
+    @staticmethod
+    def build_query(user_query: Dict) -> str:
+        goal = user_query.get("fitness_goal", "")
+        healths = user_query.get("health_conditions") or []
+        prefs = user_query.get("preferences") or []
+        parts = []
+        if goal:
+            parts.append(f"목표: {goal}")
+        if healths:
+            parts.append(f"건강: {', '.join(healths)}")
+        if prefs:
+            parts.append(f"선호: {', '.join(prefs)}")
+        return ", ".join(parts) or "일반 식단"
+
+    async def search_relevant_history(
+        self,
+        user_id: str,
+        user_query: Dict,
+        k: int = 5,
+    ) -> List[str]:
+        if not user_id:
+            return []
+        query = self.build_query(user_query)
+        try:
+            results = await self.vectorstore.asimilarity_search_with_score(
+                query=query,
+                k=k,
+                filter={"user_id": user_id},
+            )
+        except Exception as e:
+            print(f"[UserHistoryManager] 검색 실패: {e}")
+            return []
+        return [doc.page_content for doc, _ in results]

--- a/ai_agent_app/server.py
+++ b/ai_agent_app/server.py
@@ -6,20 +6,20 @@ from langchain_openai import ChatOpenAI
 from dotenv import load_dotenv
 
 # 데이터 로더
-from DataLoader import RecipeDataLoader
-from GetMarketPrices import GetMarketPrices
-from SelectCandidates import SelectCandidates
-from MenuFetcher import MenuFetcher
-from UserHistoryManager import UserHistoryManager
+from ai_agent_app.DataLoader import RecipeDataLoader
+from ai_agent_app.GetMarketPrices import GetMarketPrices
+from ai_agent_app.SelectCandidates import SelectCandidates
+from ai_agent_app.MenuFetcher import MenuFetcher
+from ai_agent_app.UserHistoryManager import UserHistoryManager
 
 # 그래프 및 서비스
-from RecipeGraph import RecipeGraphBuilder
-from services import (
+from ai_agent_app.RecipeGraph import RecipeGraphBuilder
+from ai_agent_app.services import (
     FeedbackAnalyzer,
     RecommendationEngine,
     RecommendationService,
 )
-from session_manager import SessionManager
+from ai_agent_app.session_manager import SessionManager
 
 # =====================================================================
 # 초기화
@@ -27,11 +27,6 @@ from session_manager import SessionManager
 load_dotenv()
 app = FastAPI(title="Recipe AI API")
 
-# 로컬 JSON 데이터 로드 (Spring 연결 실패 시 폴백용)
-recipe_path = "all_recipe_nutrition_data.json"
-price_path = "seoul_prices_weekly_2026-04-05.json"
-recipes = RecipeDataLoader.load_json(recipe_path)
-price_list = RecipeDataLoader.load_json(price_path)
 
 # Spring 백엔드 연동
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8080")
@@ -50,12 +45,11 @@ model = ChatOpenAI(
 )
 
 # 헬퍼 클래스들
-get_market_prices = GetMarketPrices(price_list)
+get_market_prices = GetMarketPrices([])
 select_candidates = SelectCandidates(model)
 
 # 그래프 및 서비스 초기화
 graph_builder = RecipeGraphBuilder(
-    recipes=recipes,
     get_market_prices=get_market_prices,
     select_candidates=select_candidates,
     model=model,
@@ -66,7 +60,7 @@ session_manager = SessionManager()
 recommendation_engine = RecommendationEngine(graph_builder)
 feedback_analyzer = FeedbackAnalyzer(model)
 recommendation_service = RecommendationService(
-    recommendation_engine, feedback_analyzer, session_manager, recipes
+    recommendation_engine, feedback_analyzer, session_manager
 )
 
 # =====================================================================
@@ -143,7 +137,6 @@ def _resolve_recipes(jwt_token: Optional[str], candidate_menu_ids: Optional[List
     """후보 메뉴 목록 반환.
     - candidate_menu_ids 제공 시: 해당 IDs로 조회 (Flutter와 동일한 후보 풀 보장)
     - 미제공 시: 전체 후보 조회
-    - 둘 다 실패 시: 로컬 JSON 폴백
     """
     if candidate_menu_ids:
         candidates = menu_fetcher.fetch_candidates_by_ids(candidate_menu_ids, jwt_token)
@@ -154,8 +147,7 @@ def _resolve_recipes(jwt_token: Optional[str], candidate_menu_ids: Optional[List
     candidates = menu_fetcher.fetch_candidates_full(jwt_token)
     if candidates:
         return candidates
-    print("[server] Spring 후보 조회 실패 → 로컬 JSON 사용")
-    return recipes
+    return []
 
 
 # =====================================================================

--- a/ai_agent_app/server.py
+++ b/ai_agent_app/server.py
@@ -4,36 +4,97 @@ from typing import List, Optional
 import os
 from langchain_openai import ChatOpenAI
 from dotenv import load_dotenv
-import asyncio
-from ai_agent_app.GetMarketPrices import GetMarketPrices
-from ai_agent_app.SelectCandidates import SelectCandidates
-from ai_agent_app.ProcessDynamicInputs import ProcessDynamicInputs
-from ai_agent_app.MenuFetcher import MenuFetcher
 
+# 데이터 로더
+from DataLoader import RecipeDataLoader
+from GetMarketPrices import GetMarketPrices
+from SelectCandidates import SelectCandidates
+from MenuFetcher import MenuFetcher
+from UserHistoryManager import UserHistoryManager
+
+# 그래프 및 서비스
+from RecipeGraph import RecipeGraphBuilder
+from services import (
+    FeedbackAnalyzer,
+    RecommendationEngine,
+    RecommendationService,
+)
+from session_manager import SessionManager
+
+# =====================================================================
+# 초기화
+# =====================================================================
 load_dotenv()
 app = FastAPI(title="Recipe AI API")
+
+# 로컬 JSON 데이터 로드 (Spring 연결 실패 시 폴백용)
+recipe_path = "all_recipe_nutrition_data.json"
+price_path = "seoul_prices_weekly_2026-04-05.json"
+recipes = RecipeDataLoader.load_json(recipe_path)
+price_list = RecipeDataLoader.load_json(price_path)
+
+# Spring 백엔드 연동
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8080")
+menu_fetcher = MenuFetcher(BACKEND_URL)
+
+# LLM 모델 초기화
+model = ChatOpenAI(
+    base_url="https://openrouter.ai/api/v1",
+    model="openai/gpt-4o-mini",
+    temperature=0,
+    openai_api_key=os.getenv("OPENROUTER_API_KEY"),
+    default_headers={
+        "HTTP-Referer": "http://localhost:3000",
+        "X-Title": "Recipe Analyst App",
+    },
+)
+
+# 헬퍼 클래스들
+get_market_prices = GetMarketPrices(price_list)
+select_candidates = SelectCandidates(model)
+
+# 그래프 및 서비스 초기화
+graph_builder = RecipeGraphBuilder(
+    recipes=recipes,
+    get_market_prices=get_market_prices,
+    select_candidates=select_candidates,
+    model=model,
+)
+
+user_history_manager = UserHistoryManager()
+session_manager = SessionManager()
+recommendation_engine = RecommendationEngine(graph_builder)
+feedback_analyzer = FeedbackAnalyzer(model)
+recommendation_service = RecommendationService(
+    recommendation_engine, feedback_analyzer, session_manager, recipes
+)
+
+# =====================================================================
+# Pydantic 모델
+# =====================================================================
 
 
 class UserRequest(BaseModel):
     height_cm: float = Field(..., gt=0, example=180.5)
     weight_kg: float = Field(..., gt=0, example=85.0)
-    location: str = Field(..., example="서울")
+    location: str = Field(default="서울", example="서울", description="사용자 위치 (지역별 물가 조회에 사용)")
     budget: float = Field(..., gt=0, example=8000)
-
     health_conditions: List[str] = Field(
         default_factory=list,
         example=["고혈압"],
-        description="사용자의 지병이나 주의가 필요한 건강 상태"
+        description="사용자의 지병이나 주의가 필요한 건강 상태",
     )
     fitness_goal: str = Field(
         default="일반식단",
         example="근력운동",
-        description="운동 목적: 다이어트, 근력운동, 유지 등"
+        description="운동 목적: 다이어트, 근력운동, 유지 등",
     )
-
-    allergies: List[str] = Field(default_factory=list, example=["견과류", "메밀"])
-    preferences: List[str] = Field(default_factory=list, example=["매운맛"])
-
+    allergies: List[str] = Field(
+        default_factory=list, example=["견과류", "메밀"]
+    )
+    preferences: List[str] = Field(
+        default_factory=list, example=["매운맛"]
+    )
     jwt_token: Optional[str] = Field(
         default=None,
         description="Spring 백엔드 JWT. 제공 시 서버 사이드 필터링 후보 사용"
@@ -44,66 +105,163 @@ class UserRequest(BaseModel):
     )
 
 
-BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8080")
-menu_fetcher = MenuFetcher(BACKEND_URL)
+class HistoryRequest(BaseModel):
+    jwt_token: Optional[str] = Field(default=None, description="Spring 백엔드 JWT")
+    recipe_id: str = Field(..., description="먹은 레시피 RCP_SEQ")
+    recipe_name: str = Field(..., description="먹은 메뉴 이름")
+    comment: str = Field(default="", description="코멘트")
+    rating: float = Field(..., ge=1, le=5, description="별점 (1~5)")
+    # 당시 사용자 컨텍스트 (선택) — 저장 시 같이 임베딩되어 검색 품질 향상
+    fitness_goal: Optional[str] = Field(default=None, description="당시 운동 목표")
+    health_conditions: List[str] = Field(default_factory=list, description="당시 건강 상태")
+    preferences: List[str] = Field(default_factory=list, description="당시 선호")
 
-model = ChatOpenAI(
-    base_url="https://openrouter.ai/api/v1",
-    model="openai/gpt-4o-mini",
-    temperature=0,
-    openai_api_key=os.getenv("OPENROUTER_API_KEY"),
-    default_headers={
-        "HTTP-Referer": "http://localhost:3000",
-        "X-Title": "Recipe Analyst App"
-    }
-)
 
-get_market_prices = GetMarketPrices([])
-select_candidates = SelectCandidates(model)
+class FeedbackRequest(BaseModel):
+    jwt_token: Optional[str] = Field(default=None, description="Spring 백엔드 JWT (세션 식별용)")
+    rejected_recipe_ids: List[str] = Field(
+        ..., description="거절한 레시피 RCP_SEQ 리스트"
+    )
+    reason: str = Field(default="", description="거절 이유")
 
-orchestrator = ProcessDynamicInputs(
-    recipes=[],
-    get_market_prices=get_market_prices,
-    select_candidates=select_candidates,
-    model=model
-)
+
+def _user_id_from_jwt(jwt_token: Optional[str]) -> str:
+    """JWT의 sub(이메일)을 user_id로 사용. 토큰 없으면 anonymous."""
+    if not jwt_token:
+        return "anonymous"
+    try:
+        import base64, json
+        payload_b64 = jwt_token.split(".")[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        return payload.get("sub", "anonymous")
+    except Exception:
+        return "anonymous"
 
 
 def _resolve_recipes(jwt_token: Optional[str], candidate_menu_ids: Optional[List[int]] = None) -> list:
-    """후보 메뉴 목록 반환. candidate_menu_ids 제공 시 해당 IDs로 조회하여 Flutter와 동일한 풀 사용."""
+    """후보 메뉴 목록 반환.
+    - candidate_menu_ids 제공 시: 해당 IDs로 조회 (Flutter와 동일한 후보 풀 보장)
+    - 미제공 시: 전체 후보 조회
+    - 둘 다 실패 시: 로컬 JSON 폴백
+    """
     if candidate_menu_ids:
         candidates = menu_fetcher.fetch_candidates_by_ids(candidate_menu_ids, jwt_token)
         if candidates:
             return candidates
-        print("[server] ID 기반 후보 조회 실패, 전체 후보로 대체")
+        print("[server] ID 기반 후보 조회 실패 → 전체 후보로 대체")
+
     candidates = menu_fetcher.fetch_candidates_full(jwt_token)
-    if not candidates:
-        print("[server] Spring 후보 조회 실패")
-    return candidates
+    if candidates:
+        return candidates
+    print("[server] Spring 후보 조회 실패 → 로컬 JSON 사용")
+    return recipes
+
+
+# =====================================================================
+# 엔드포인트
+# =====================================================================
 
 
 @app.post("/recommend")
 async def get_recommendation(user_input: UserRequest):
+    """
+    초기 추천 요청
+
+    Args:
+        user_input: 사용자 정보 (user_id, jwt_token 포함)
+
+    Returns:
+        {
+            "user_id": str,
+            "recommendations": List[Dict]
+        }
+    """
     try:
+        user_id = _user_id_from_jwt(user_input.jwt_token)
         active_recipes = _resolve_recipes(user_input.jwt_token, user_input.candidate_menu_ids)
         if not active_recipes:
             raise ValueError("메뉴 후보를 가져올 수 없습니다. Spring 백엔드 연결을 확인하세요.")
 
-        user_query = user_input.dict(exclude={"jwt_token", "candidate_menu_ids"})
+        user_query = user_input.dict(exclude={"jwt_token"})
 
-        final_result: dict = await asyncio.get_running_loop().run_in_executor(
-            None, orchestrator.process_dynamic_inputs, user_query, active_recipes
+        # 벡터 검색으로 현재 요청과 관련 있는 과거 이력 K개 추출
+        history_texts = await user_history_manager.search_relevant_history(
+            user_id=user_id,
+            user_query=user_query,
+            k=5,
         )
 
-        if "market_prices" in final_result and isinstance(final_result["market_prices"], list):
-            total_cost = sum(
-                float(item.get("calculated_cost", 0))
-                for item in final_result["market_prices"]
-            )
-            final_result["total_estimated_cost"] = total_cost
-
-        return final_result
+        result = await recommendation_service.recommend(user_id, user_query, active_recipes, history_texts)
+        # Flutter는 flat 구조 + menu_id(int) 를 기대하므로 변환
+        recs = result.get("recommendations", [])
+        if not recs:
+            raise ValueError("추천 결과가 없습니다.")
+        top = recs[0]
+        rid = top.get("recipe_id") or top.get("menu_id")
+        try:
+            top["menu_id"] = int(rid) if rid is not None else 0
+        except (TypeError, ValueError):
+            top["menu_id"] = 0
+        return top
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"AI 에이전트 실행 중 오류 발생: {str(e)}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"AI 에이전트 실행 중 오류 발생: {str(e)}",
+        )
+
+
+@app.post("/history")
+async def save_history(req: HistoryRequest):
+    """사용자가 먹은 메뉴 + 코멘트 + 별점 저장"""
+    try:
+        user_id = _user_id_from_jwt(req.jwt_token)
+        user_history_manager.save(
+            user_id=user_id,
+            recipe_id=req.recipe_id,
+            recipe_name=req.recipe_name,
+            comment=req.comment,
+            rating=req.rating,
+            context={
+                "fitness_goal": req.fitness_goal,
+                "health_conditions": req.health_conditions,
+                "preferences": req.preferences,
+            },
+        )
+        return {"status": "saved"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/feedback")
+async def provide_feedback(feedback: FeedbackRequest):
+    """
+    피드백 처리 및 재추천
+
+    Args:
+        feedback: 피드백 정보 (user_id 포함)
+
+    Returns:
+        {
+            "user_id": str,
+            "feedback_count": int,
+            "applied_constraint": str,
+            "recommendations": List[Dict]
+        }
+    """
+    try:
+        user_id = _user_id_from_jwt(feedback.jwt_token)
+        result = await recommendation_service.provide_feedback(
+            user_id,
+            feedback.rejected_recipe_ids,
+            feedback.reason,
+        )
+        # 일단 가장 적합한 1개만 반환
+        result["recommendations"] = result.get("recommendations", [])[:1]
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/ai_agent_app/services/__init__.py
+++ b/ai_agent_app/services/__init__.py
@@ -1,6 +1,6 @@
-from services.feedback_analyzer import FeedbackAnalyzer
-from services.recommendation_engine import RecommendationEngine
-from services.recommendation_service import RecommendationService
+from ai_agent_app.services.feedback_analyzer import FeedbackAnalyzer
+from ai_agent_app.services.recommendation_engine import RecommendationEngine
+from ai_agent_app.services.recommendation_service import RecommendationService
 
 __all__ = [
     "FeedbackAnalyzer",

--- a/ai_agent_app/services/__init__.py
+++ b/ai_agent_app/services/__init__.py
@@ -1,0 +1,9 @@
+from services.feedback_analyzer import FeedbackAnalyzer
+from services.recommendation_engine import RecommendationEngine
+from services.recommendation_service import RecommendationService
+
+__all__ = [
+    "FeedbackAnalyzer",
+    "RecommendationEngine",
+    "RecommendationService",
+]

--- a/ai_agent_app/services/feedback_analyzer.py
+++ b/ai_agent_app/services/feedback_analyzer.py
@@ -1,0 +1,41 @@
+# =====================================================================
+# FeedbackAnalyzer: 사용자 피드백 이유 분석
+# =====================================================================
+from langchain_openai import ChatOpenAI
+
+
+class FeedbackAnalyzer:
+    """사용자 피드백 이유를 LLM으로 분석해서 제약 조건으로 변환"""
+
+    def __init__(self, model: ChatOpenAI):
+        self.model = model
+
+    async def analyze(self, feedback_reason: str) -> str:
+        """
+        피드백 이유를 분석해서 다음 rank_node에 반영할 제약 생성
+
+        예시:
+        - "너무 매움" → "매운맛을 피하고 순한 음식"
+        - "가격이 비쌈" → "저가격 메뉴 우선"
+        - "너무 무거움" → "가볍고 소화하기 좋은 음식"
+
+        Args:
+            feedback_reason: 사용자가 제시한 거절 이유
+
+        Returns:
+            다음 추천에 반영할 제약 조건
+        """
+        prompt = f"""사용자가 다음 이유로 메뉴를 거절했습니다: "{feedback_reason}"
+
+이 거절 이유를 분석해서 다음 추천에 반영할 요구사항을 한 문장으로 정리해주세요.
+예시:
+- "너무 매움" → "매운맛을 피하고 순한 음식"
+- "가격이 비쌈" → "저가격 메뉴 우선"
+- "너무 무거움" → "가볍고 소화하기 좋은 음식"
+
+답변은 "~를 피하고" 또는 "~를 우선" 형태로 간결하게:"""
+
+        response = await self.model.ainvoke(prompt)
+        constraint = response.content.strip()
+        print(f"[FeedbackAnalyzer] '{feedback_reason}' → '{constraint}'")
+        return constraint

--- a/ai_agent_app/services/recommendation_engine.py
+++ b/ai_agent_app/services/recommendation_engine.py
@@ -2,7 +2,7 @@
 # RecommendationEngine: LangGraph 기반 추천 엔진
 # =====================================================================
 from typing import Dict, List, Any, Optional
-from RecipeGraph import RecipeGraphBuilder
+from ai_agent_app.RecipeGraph import RecipeGraphBuilder
 
 
 def _build_recipes_by_seq(recipes: List[Dict]) -> Dict[str, Dict]:

--- a/ai_agent_app/services/recommendation_engine.py
+++ b/ai_agent_app/services/recommendation_engine.py
@@ -1,0 +1,107 @@
+# =====================================================================
+# RecommendationEngine: LangGraph 기반 추천 엔진
+# =====================================================================
+from typing import Dict, List, Any, Optional
+from RecipeGraph import RecipeGraphBuilder
+
+
+def _build_recipes_by_seq(recipes: List[Dict]) -> Dict[str, Dict]:
+    """recipes 리스트에서 식별자 -> recipe dict 매핑 생성.
+    Spring 데이터는 MENU_ID, 로컬 JSON 폴백은 RCP_SEQ 를 사용.
+    """
+    def _id(r):
+        return str(r.get("MENU_ID") or r.get("RCP_SEQ", "")).strip()
+    return {_id(r): r for r in recipes if _id(r)}
+
+
+class RecommendationEngine:
+    """LangGraph를 통한 레시피 추천 실행"""
+
+    def __init__(self, graph_builder: RecipeGraphBuilder):
+        self.graph_builder = graph_builder
+        self.graph = graph_builder.build()
+
+    async def get_initial_recommendations(
+        self,
+        recipes: List[Dict],
+        user_query: Dict,
+        history_texts: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """초기 추천 (전체 파이프라인 실행)"""
+        print("[RecommendationEngine] 초기 추천 시작")
+
+        if history_texts is None:
+            history_texts = []
+
+        initial_state = {
+            "recipes": recipes,
+            "recipes_by_seq": _build_recipes_by_seq(recipes),
+            "user_query": user_query,
+            "rejected_ids": [],
+            "feedback_reason": None,
+            "feedback_constraints": None,
+            "filtered_recipes": [],
+            "allowed_ids": [],
+            "history_texts": history_texts,
+            "candidate_ids": [],
+            "enriched": [],
+            "price_cache": {},
+            "top5_ids": [],
+            "top10_ids": [],
+            "final_results": [],
+            "error": None,
+        }
+
+        final_state = await self.graph.ainvoke(initial_state)
+        return final_state
+
+    async def get_feedback_recommendations(
+        self,
+        recipes: List[Dict],
+        user_query: Dict,
+        rejected_ids: List[str],
+        feedback_reason: str,
+        feedback_constraints: str,
+        prev_state: Dict,
+    ) -> Dict[str, Any]:
+        """피드백 기반 재추천"""
+        print("[RecommendationEngine] 피드백 기반 추천 시작")
+
+        rejected_set = set(rejected_ids)
+        top10 = prev_state.get("top10_ids", [])
+        remaining = [s for s in top10 if s not in rejected_set]
+
+        if len(remaining) >= 5:
+            print(f"[RecommendationEngine] 빠른 경로: top10 잔여 {len(remaining)}개")
+            fast_state = {
+                **prev_state,
+                "rejected_ids": rejected_ids,
+                "feedback_reason": feedback_reason,
+                "feedback_constraints": feedback_constraints,
+                "user_query": user_query,
+                "recipes": recipes,
+                "recipes_by_seq": prev_state.get("recipes_by_seq") or _build_recipes_by_seq(recipes),
+            }
+            final_state = await self.graph_builder.analyze_with_rejection(fast_state)
+        else:
+            print(f"[RecommendationEngine] top10 소진(잔여 {len(remaining)}개) → 전체 재실행")
+            state = {
+                "recipes": recipes,
+                "recipes_by_seq": _build_recipes_by_seq(recipes),
+                "user_query": user_query,
+                "rejected_ids": rejected_ids,
+                "feedback_reason": feedback_reason,
+                "feedback_constraints": feedback_constraints,
+                "filtered_recipes": [],
+                "allowed_ids": [],
+                "history_texts": prev_state.get("history_texts", []),
+                "candidate_ids": [],
+                "enriched": [],
+                "price_cache": {},
+                "top5_ids": [],
+                "top10_ids": [],
+                "final_results": [],
+                "error": None,
+            }
+            final_state = await self.graph.ainvoke(state)
+        return final_state

--- a/ai_agent_app/services/recommendation_service.py
+++ b/ai_agent_app/services/recommendation_service.py
@@ -1,0 +1,112 @@
+# =====================================================================
+# RecommendationService: 추천 전체 흐름 조율
+# =====================================================================
+from typing import Dict, List, Any, Optional
+from services.recommendation_engine import RecommendationEngine
+from services.feedback_analyzer import FeedbackAnalyzer
+
+
+class RecommendationService:
+    """추천 엔진과 피드백 분석을 조율하는 서비스"""
+
+    def __init__(
+        self,
+        recommendation_engine: RecommendationEngine,
+        feedback_analyzer: FeedbackAnalyzer,
+        session_manager: "SessionManager",
+        recipes: List[Dict],
+    ):
+        self.engine = recommendation_engine
+        self.analyzer = feedback_analyzer
+        self.session_manager = session_manager
+        self.recipes = recipes
+
+    async def recommend(self, user_id: str, user_query: Dict, recipes: Optional[List[Dict]] = None, history_texts: Optional[List[str]] = None) -> Dict[str, Any]:
+        """
+        초기 추천 실행
+
+        Args:
+            user_id: 사용자 ID (백엔드에서 전달)
+            user_query: 사용자 입력 정보
+            recipes: 런타임 레시피 목록 (None이면 self.recipes 사용)
+
+        Returns:
+            {
+                "user_id": str,
+                "recommendations": List[Dict]
+            }
+        """
+        print(f"[RecommendationService] 사용자 {user_id}의 초기 추천 시작")
+
+        active_recipes = recipes if recipes is not None else self.recipes
+
+        # user_id 기반 세션 생성 또는 조회
+        self.session_manager.create_or_get_session(user_id, user_query)
+
+        # 그래프 실행
+        final_state = await self.engine.get_initial_recommendations(
+            active_recipes, user_query, history_texts or []
+        )
+
+        if final_state.get("error"):
+            raise ValueError(final_state["error"])
+
+        results = final_state.get("final_results", [])
+
+        # 상태 저장 (다음 피드백용)
+        self.session_manager.save_graph_state(user_id, final_state)
+
+        return {"user_id": user_id, "recommendations": results}
+
+    async def provide_feedback(
+        self, user_id: str, rejected_recipe_ids: List[str], reason: str
+    ) -> Dict[str, Any]:
+        """피드백 처리 및 재추천 (RCP_SEQ 기준)"""
+        print(f"[RecommendationService] 사용자 {user_id}의 피드백 처리 시작")
+
+        # 피드백 저장 (RCP_SEQ 문자열로 받음)
+        self.session_manager.add_feedback(user_id, [str(s) for s in rejected_recipe_ids], reason)
+
+        # 이전 상태 조회
+        prev_state = self.session_manager.get_last_graph_state(user_id)
+        if not prev_state or "enriched" not in prev_state:
+            raise ValueError("이전 추천 상태를 찾을 수 없습니다")
+
+        # 피드백 이유 분석
+        feedback_constraints = await self.analyzer.analyze(reason)
+
+        # 사용자 정보 조회
+        user_query = self.session_manager.get_user_query(user_id)
+        rejected_ids = self.session_manager.get_rejected_ids(user_id)
+
+        print(f"[RecommendationService] 누적 거절: {rejected_ids}")
+        print(f"[RecommendationService] 제약: {feedback_constraints}")
+
+        # 재추천 실행 (초기 추천 때 사용한 recipes 재사용)
+        final_state = await self.engine.get_feedback_recommendations(
+            prev_state.get("recipes", self.recipes),
+            user_query,
+            rejected_ids,
+            reason,
+            feedback_constraints,
+            prev_state,
+        )
+
+        if final_state.get("error"):
+            raise ValueError(final_state["error"])
+
+        results = final_state.get("final_results", [])
+
+        # 상태 저장 (연쇄 피드백 대비)
+        self.session_manager.save_graph_state(user_id, final_state)
+
+        feedback_count = len(
+            self.session_manager.sessions[user_id]["feedback_history"]
+        )
+
+        return {
+            "user_id": user_id,
+            "feedback_count": feedback_count,
+            "applied_constraint": feedback_constraints,
+            "recommendations": results,
+        }

--- a/ai_agent_app/services/recommendation_service.py
+++ b/ai_agent_app/services/recommendation_service.py
@@ -2,8 +2,8 @@
 # RecommendationService: 추천 전체 흐름 조율
 # =====================================================================
 from typing import Dict, List, Any, Optional
-from services.recommendation_engine import RecommendationEngine
-from services.feedback_analyzer import FeedbackAnalyzer
+from ai_agent_app.services.recommendation_engine import RecommendationEngine
+from ai_agent_app.services.feedback_analyzer import FeedbackAnalyzer
 
 
 class RecommendationService:
@@ -14,12 +14,12 @@ class RecommendationService:
         recommendation_engine: RecommendationEngine,
         feedback_analyzer: FeedbackAnalyzer,
         session_manager: "SessionManager",
-        recipes: List[Dict],
+        recipes: List[Dict] = None,
     ):
         self.engine = recommendation_engine
         self.analyzer = feedback_analyzer
         self.session_manager = session_manager
-        self.recipes = recipes
+        self.recipes = recipes or []
 
     async def recommend(self, user_id: str, user_query: Dict, recipes: Optional[List[Dict]] = None, history_texts: Optional[List[str]] = None) -> Dict[str, Any]:
         """

--- a/ai_agent_app/session_manager.py
+++ b/ai_agent_app/session_manager.py
@@ -1,0 +1,79 @@
+# =====================================================================
+# SessionManager: 사용자 세션 관리 (user_id 기반)
+# =====================================================================
+from typing import Dict, List, Optional
+
+
+class SessionManager:
+    """user_id 기반으로 사용자 세션 관리"""
+
+    def __init__(self):
+        self.sessions: Dict[str, Dict] = {}
+
+    def create_or_get_session(self, user_id: str, user_query: Dict) -> str:
+        """
+        user_id로 세션 생성 또는 기존 세션 반환
+
+        Args:
+            user_id: 사용자 ID (백엔드에서 전달)
+            user_query: 사용자 입력 정보
+
+        Returns:
+            user_id (세션 ID로 사용)
+        """
+        if user_id not in self.sessions:
+            self.sessions[user_id] = {
+                "user_query": user_query,
+                "rejected_ids": [],
+                "feedback_history": [],
+                "last_graph_state": None,
+            }
+            print(f"[SessionManager] 새 세션 생성: {user_id}")
+        else:
+            print(f"[SessionManager] 기존 세션 재사용: {user_id}")
+            # user_query 업데이트 (변경될 수 있음)
+            self.sessions[user_id]["user_query"] = user_query
+
+        print(f"[SessionManager] 현재 활성 세션 수: {len(self.sessions)}")
+        return user_id
+
+    def add_feedback(
+        self, user_id: str, rejected_recipe_ids: List[str], reason: str
+    ) -> None:
+        """피드백 추가 (RCP_SEQ 리스트)"""
+        print(f"[SessionManager] feedback 추가 시도: {user_id}")
+
+        if user_id not in self.sessions:
+            raise ValueError(f"사용자 세션을 찾을 수 없음: {user_id}")
+
+        self.sessions[user_id]["rejected_ids"].extend(rejected_recipe_ids)
+        self.sessions[user_id]["rejected_ids"] = list(
+            set(self.sessions[user_id]["rejected_ids"])
+        )
+        self.sessions[user_id]["feedback_history"].append(
+            {"rejected": rejected_recipe_ids, "reason": reason}
+        )
+
+    def get_rejected_ids(self, user_id: str) -> List[str]:
+        """거절된 레시피 RCP_SEQ 조회"""
+        if user_id not in self.sessions:
+            return []
+        return self.sessions[user_id]["rejected_ids"]
+
+    def get_user_query(self, user_id: str) -> Dict:
+        """사용자 입력 정보 조회"""
+        if user_id not in self.sessions:
+            return {}
+        return self.sessions[user_id]["user_query"]
+
+    def save_graph_state(self, user_id: str, state: Dict) -> None:
+        """그래프 실행 상태 저장"""
+        if user_id in self.sessions:
+            self.sessions[user_id]["last_graph_state"] = state
+
+    def get_last_graph_state(self, user_id: str) -> Optional[Dict]:
+        """저장된 그래프 상태 조회"""
+        if user_id not in self.sessions:
+            return None
+        return self.sessions[user_id]["last_graph_state"]
+


### PR DESCRIPTION
Summary

- RecommendationEngine 신규: LangGraph 컴파일·실행 책임 분리. 초기 추천은 전체 5노드(filter → candidate → price → rank → analyze) 실행, 피드백은 top10 잔여 ≥ 5면 analyze_with_rejection 빠른 경로(LLM 5회), 부족하면 그래프 전체 재실행으로 자동 분기

- RecommendationService 신규: /recommend, /feedback 전체 흐름 조율. 세션 생성/조회, history_texts 주입, 그래프 호출, 결과 슬라이싱(top1), 다음 피드백 대비 state 저장까지 한 곳에서 관리

- FeedbackAnalyzer 신규: 거절 이유 자연어를 LLM(gpt-4o-mini)으로 분석해 다음 rank_node 프롬프트에 그대로 끼울 수 있는 제약문으로 변환 (예: "너무 매움" → "매운맛을 피하고 순한 음식")

- services/init.py: FeedbackAnalyzer, RecommendationEngine, RecommendationService 세 클래스 re-export 해서 from services import ... 한 줄로 사용 가능

- 세션 기반 누적 피드백: 같은 유저가 거절을 반복하면 session_manager.rejected_ids에 누적, 다음 추천 때 자동 제외

- 빠른 경로 응답 시간 단축: 기존 거절 시 그래프 통째로 재돌리던 흐름 대비, top10에 잔여가 있으면 가격조회/랭킹 스킵하고 analyze만 재실행 → LLM 호출 12회 → 5회로 감소

Bug Fixes

- 피드백 시 ChromaDB/세션 누락으로 KeyError 나던 분기에 prev_state.get(..., default) 가드 추가
- top10 전부 거절된 경우 무한 루프 방지를 위해 "추천할 남은 레시피가 없습니다" 명시적 에러 반환
- mutable default argument 안티패턴 (history_ids: List[str] = []) → Optional[List[str]] = None 패턴으로 수정

Test Plan

- POST /recommend 호출 후 응답에 recommendations[0] 의 recipe_id, selection_reason, personalized_recipe_tip, market_prices 모두 포함되는지 확인
- POST /feedback 으로 첫 추천 거절 → 다른 메뉴 재추천, 응답 시간이 초기 추천보다 짧은지 (빠른 경로 동작) 확인
- top10 모두 거절될 때까지 반복 → 그래프 전체 재실행 트리거되고 새로운 candidate 풀에서 추천되는지 확인
- 거절 이유 "너무 짠 음식" 입력 후 다음 추천이 저나트륨 메뉴로 바뀌는지 확인 (FeedbackAnalyzer 동작 검증)
- 서버 재시작 후 세션 초기화되어 깨끗한 상태로 동작하는지 확인