### PR TITLE
feat: 식약처 이미지 AWS S3 마이그레이션 구현

### DIFF
--- a/ai-meal-assistant-batch/build.gradle
+++ b/ai-meal-assistant-batch/build.gradle
@@ -47,6 +47,10 @@ dependencies {
 	// WebClient 및 ExchangeStrategies 사용을 위한 WebFlux 의존성 추가
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	// AWS S3
+	implementation platform('software.amazon.awssdk:bom:2.25.0')
+	implementation 'software.amazon.awssdk:s3'
+
 	// Spring Security 의존성 추가
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
@@ -9,6 +9,7 @@ import capstone.ai_meal_assistant_batch.domain.menu.entity.Menu;
 import capstone.ai_meal_assistant_batch.domain.menu.entity.MenuIngredient;
 import capstone.ai_meal_assistant_batch.domain.menu.repository.MenuIngredientRepository;
 import capstone.ai_meal_assistant_batch.domain.menu.repository.MenuRepository;
+import capstone.ai_meal_assistant_batch.global.s3.S3ImageUploadService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,7 @@ public class RecipeDataSyncService {
     private final IngredientRepository ingredientRepository;
     private final MenuIngredientRepository menuIngredientRepository;
     private final ObjectMapper objectMapper;
+    private final S3ImageUploadService s3ImageUploadService;
 
     @Transactional
     public void syncAllDataFromApi(){
@@ -73,12 +75,15 @@ public class RecipeDataSyncService {
 
                 // 캐시에 없는 새로운 레시피만 골라냅니다.
                 if (!menuCache.containsKey(foodCode)) {
+                    String originalImageUrl = recipeNode.path("ATT_FILE_NO_MAIN").asText();
+                    String mainImageUrl = s3ImageUploadService.uploadFromUrl(originalImageUrl);
+
                     Menu newMenu = Menu.builder()
                             .foodCode(foodCode)                                                // 일련번호
                             .name(recipeNode.path("RCP_NM").asText())                       // 메뉴명
                             .category(recipeNode.path("RCP_PAT2").asText())                 // 카테고리
                             .cookingMethod(recipeNode.path("RCP_WAY2").asText())            // 조리법
-                            .mainImageUrl(recipeNode.path("ATT_FILE_NO_MAIN").asText())     // 메인 이미지
+                            .mainImageUrl(mainImageUrl)                                      // S3 업로드 후 URL (실패 시 원본)
                             .healthTip(recipeNode.path("RCP_NA_TIP").asText())              // 팁
                             .calories(parseDoubleSafe(recipeNode.path("INFO_ENG").asText()))// 열량
                             .protein(parseDoubleSafe(recipeNode.path("INFO_PRO").asText())) // 단백질
@@ -148,6 +153,32 @@ public class RecipeDataSyncService {
             menuIngredientRepository.saveAll(menuIngredientsToSave);
 
             log.info("데이터 동기화 완전 성공! 총 저장된 식재료 매핑 수: {}", menuIngredientsToSave.size());
+
+            // =========================================================================
+            // STEP 3: [기존 메뉴 이미지 S3 마이그레이션]
+            // 원본 URL(foodsafetykorea)을 가진 기존 메뉴를 S3 URL로 업데이트합니다.
+            // =========================================================================
+            List<Menu> menusToMigrate = menuRepository.findAll().stream()
+                    .filter(m -> m.getMainImageUrl() != null
+                            && !m.getMainImageUrl().isBlank()
+                            && !m.getMainImageUrl().contains("amazonaws.com"))
+                    .collect(Collectors.toList());
+
+            if (!menusToMigrate.isEmpty()) {
+                log.info("S3 마이그레이션 대상 메뉴: {}개", menusToMigrate.size());
+                int successCount = 0;
+                for (Menu menu : menusToMigrate) {
+                    String s3Url = s3ImageUploadService.uploadFromUrl(menu.getMainImageUrl());
+                    if (s3Url.contains("amazonaws.com")) {
+                        menu.updateMainImageUrl(s3Url);
+                        successCount++;
+                    }
+                }
+                menuRepository.saveAll(menusToMigrate);
+                log.info("S3 마이그레이션 완료: {}개 성공 / {}개 대상", successCount, menusToMigrate.size());
+            } else {
+                log.info("S3 마이그레이션 대상 없음 (이미 모두 S3 URL)");
+            }
 
         } catch (Exception e){
             log.error("API 데이터 동기화 중 에러 발생: ", e);

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/entity/Menu.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/entity/Menu.java
@@ -44,6 +44,10 @@ public class Menu extends BaseEntity {
     private Double carbs;        // 매핑: INFO_CAR (탄수화물)
     private Double sodium;       // 매핑: INFO_NA (나트륨)
 
+    public void updateMainImageUrl(String url) {
+        this.mainImageUrl = url;
+    }
+
     // 메뉴 삭제 시 레시피(MenuIngredient)도 한 번에 날아가도록 Cascade 걸기 (벌크성 작업 최적화)
     @Builder.Default // 해당 어노테이션이 없으면 빌더 패턴으로 객체를 생성할 때 해당 리스트가 빈 배열이 아니라 null로 덮어씌워짐 -> add 시 NullPointerEx
     @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/global/config/S3Config.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/global/config/S3Config.java
@@ -1,0 +1,34 @@
+package capstone.ai_meal_assistant_batch.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/global/s3/S3ImageUploadService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/global/s3/S3ImageUploadService.java
@@ -1,0 +1,87 @@
+package capstone.ai_meal_assistant_batch.global.s3;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3ImageUploadService {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    /**
+     * 원본 URL에서 이미지를 다운로드해 S3에 업로드하고 S3 URL을 반환한다.
+     * 빈 URL이면 그대로, 업로드 실패 시 원본 URL을 반환한다.
+     */
+    public String uploadFromUrl(String originalUrl) {
+        if (originalUrl == null || originalUrl.isBlank()) {
+            return originalUrl;
+        }
+        if (originalUrl.contains("amazonaws.com")) {
+            return originalUrl;
+        }
+
+        String fileName = originalUrl.substring(originalUrl.lastIndexOf('/') + 1);
+        String key = "images/food/" + fileName;
+
+        if (existsInS3(key)) {
+            log.debug("S3 이미 존재, 스킵: {}", key);
+            return buildS3Url(key);
+        }
+
+        try {
+            URL url = URI.create(originalUrl).toURL();
+            try (InputStream is = url.openStream()) {
+                byte[] bytes = is.readAllBytes();
+                String contentType = originalUrl.endsWith(".jpg") || originalUrl.endsWith(".jpeg")
+                        ? "image/jpeg" : "image/png";
+                s3Client.putObject(
+                        PutObjectRequest.builder()
+                                .bucket(bucket)
+                                .key(key)
+                                .contentType(contentType)
+                                .build(),
+                        RequestBody.fromBytes(bytes)
+                );
+                log.info("S3 업로드 성공: {}", key);
+                return buildS3Url(key);
+            }
+        } catch (Exception e) {
+            log.warn("S3 업로드 실패, 원본 URL 사용: {} | 원인: {}", originalUrl, e.getMessage());
+            return originalUrl;
+        }
+    }
+
+    private boolean existsInS3(String key) {
+        try {
+            s3Client.headObject(HeadObjectRequest.builder().bucket(bucket).key(key).build());
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private String buildS3Url(String key) {
+        return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + key;
+    }
+}


### PR DESCRIPTION
현재 DB에 직접 저장되고 있는 음식 사진 데이터를 AWS S3로 이관하여 DB의 저장 공간 부담을 해소하고 이미지 로딩 성능 및 서버 리소스 효율을 개선했습니다.
