### PR TITLE
feat: kamis 재료 번호와 기존 재료를 매핑하고 재료-가격 테이블 생성

### DIFF
--- a/ai-meal-assistant-backend/build.gradle
+++ b/ai-meal-assistant-backend/build.gradle
@@ -49,13 +49,20 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
-	// 7. Test (테스트 환경)
+	// 7. API 문서 (Swagger UI)
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+
+	// 8. Test (테스트 환경)
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.compilerArgs << '-parameters'
 }
 
 // 스프링 클라우드 버전을 관리해 주는 설정

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/controller/AdminKamisMappingController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/controller/AdminKamisMappingController.java
@@ -1,0 +1,45 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.controller;
+
+import capstone.ai_meal_assistant_backend.domain.ingredient.dto.AutoConfirmResult;
+import capstone.ai_meal_assistant_backend.domain.ingredient.dto.KamisMappingGroupResponse;
+import capstone.ai_meal_assistant_backend.domain.ingredient.dto.KamisMappingPatchRequest;
+import capstone.ai_meal_assistant_backend.domain.ingredient.service.AdminKamisMappingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/kamis-mappings")
+@RequiredArgsConstructor
+public class AdminKamisMappingController {
+
+    private final AdminKamisMappingService service;
+
+    @GetMapping
+    public ResponseEntity<List<KamisMappingGroupResponse>> getUnconfirmedMappings() {
+        return ResponseEntity.ok(service.getUnconfirmedMappings());
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> patchMapping(
+            @PathVariable Long id,
+            @RequestBody KamisMappingPatchRequest request) {
+        service.patchMapping(id, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/auto-confirm")
+    public ResponseEntity<AutoConfirmResult> autoConfirm(
+            @RequestParam(name = "minScore", defaultValue = "0.85") double minScore,
+            @RequestParam(name = "deleteBelow", defaultValue = "0.333") double deleteBelow) {
+        return ResponseEntity.ok(service.autoConfirm(minScore, deleteBelow));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteMapping(@PathVariable Long id) {
+        service.deleteMapping(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/controller/IngredientPriceController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/controller/IngredientPriceController.java
@@ -1,0 +1,59 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.controller;
+
+import capstone.ai_meal_assistant_backend.domain.ingredient.dto.BatchPriceItem;
+import capstone.ai_meal_assistant_backend.domain.ingredient.dto.BatchPriceRequest;
+import capstone.ai_meal_assistant_backend.domain.ingredient.dto.IngredientPriceResponse;
+import capstone.ai_meal_assistant_backend.domain.ingredient.service.IngredientPriceService;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/ingredients/prices")
+@RequiredArgsConstructor
+public class IngredientPriceController {
+
+    private final IngredientPriceService service;
+
+    @Getter
+    @AllArgsConstructor
+    private static class ApiResponse<T> {
+        private boolean success;
+        private T data;
+        private String error;
+
+        static <T> ApiResponse<T> ok(T data) {
+            return new ApiResponse<>(true, data, null);
+        }
+
+        static <T> ApiResponse<T> fail(String error) {
+            return new ApiResponse<>(false, null, error);
+        }
+    }
+
+    /**
+     * 단일 재료의 최신 가격 조회
+     * GET /api/v1/ingredients/prices?name=양파
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<IngredientPriceResponse>> getPrice(@RequestParam("name") String name) {
+        return service.getLatestByName(name)
+                .<ResponseEntity<ApiResponse<IngredientPriceResponse>>>map(r -> ResponseEntity.ok(ApiResponse.ok(r)))
+                .orElseGet(() -> ResponseEntity.status(404).body(ApiResponse.fail("가격 데이터 없음: " + name)));
+    }
+
+    /**
+     * 여러 재료의 최신 가격 일괄 조회
+     * POST /api/v1/ingredients/prices/batch
+     * Body: { "names": ["양파", "당근"] }
+     */
+    @PostMapping("/batch")
+    public ResponseEntity<ApiResponse<List<BatchPriceItem>>> getBatchPrices(@RequestBody BatchPriceRequest request) {
+        List<BatchPriceItem> results = service.getBatchByNames(request.names());
+        return ResponseEntity.ok(ApiResponse.ok(results));
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/AutoConfirmResult.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/AutoConfirmResult.java
@@ -1,0 +1,7 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.dto;
+
+public record AutoConfirmResult(
+        int confirmedCount,
+        int deletedCount,
+        int needsReviewCount
+) {}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/BatchPriceItem.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/BatchPriceItem.java
@@ -1,0 +1,27 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.dto;
+
+import java.time.LocalDateTime;
+
+public record BatchPriceItem(
+        String ingredientName,
+        boolean found,
+        Double pricePerGram,
+        Integer originalPrice,
+        String originalUnit,
+        LocalDateTime baseDate
+) {
+    public static BatchPriceItem notFound(String name) {
+        return new BatchPriceItem(name, false, null, null, null, null);
+    }
+
+    public static BatchPriceItem found(IngredientPriceResponse r) {
+        return new BatchPriceItem(
+                r.ingredientName(),
+                true,
+                r.pricePerGram(),
+                r.originalPrice(),
+                r.originalUnit(),
+                r.baseDate()
+        );
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/BatchPriceRequest.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/BatchPriceRequest.java
@@ -1,0 +1,5 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.dto;
+
+import java.util.List;
+
+public record BatchPriceRequest(List<String> names) {}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/IngredientPriceResponse.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/IngredientPriceResponse.java
@@ -1,0 +1,29 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.dto;
+
+import capstone.ai_meal_assistant_backend.domain.ingredient.entity.IngredientPrice;
+
+import java.time.LocalDateTime;
+
+public record IngredientPriceResponse(
+        Long ingredientId,
+        String ingredientName,
+        Double pricePerGram,
+        Integer originalPrice,
+        String originalUnit,
+        String marketName,
+        String marketType,
+        LocalDateTime baseDate
+) {
+    public static IngredientPriceResponse from(IngredientPrice price) {
+        return new IngredientPriceResponse(
+                price.getIngredient().getId(),
+                price.getIngredient().getName(),
+                price.getPricePerGram(),
+                price.getOriginalPrice(),
+                price.getOriginalUnit(),
+                price.getMarketName(),
+                price.getMarketType(),
+                price.getBaseDate()
+        );
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/KamisMappingGroupResponse.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/KamisMappingGroupResponse.java
@@ -1,0 +1,16 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.dto;
+
+import java.util.List;
+
+public record KamisMappingGroupResponse(
+        Long ingredientId,
+        String ingredientName,
+        List<CandidateDto> candidates
+) {
+    public record CandidateDto(
+            Long id,
+            String kamisItemCode,
+            String kamisItemName,
+            Double autoScore
+    ) {}
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/KamisMappingPatchRequest.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/KamisMappingPatchRequest.java
@@ -1,0 +1,7 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.dto;
+
+public record KamisMappingPatchRequest(
+        String kamisItemCode,
+        String kamisItemName,
+        Boolean confirm
+) {}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/entity/Ingredient.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/entity/Ingredient.java
@@ -1,0 +1,25 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.entity;
+
+import capstone.ai_meal_assistant_backend.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ingredients")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Ingredient extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    private String standardUnit;
+
+    private Integer latestPrice;
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/entity/IngredientKamisMapping.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/entity/IngredientKamisMapping.java
@@ -1,0 +1,63 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.entity;
+
+import capstone.ai_meal_assistant_backend.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ingredient_kamis_mappings")
+@Getter
+@NoArgsConstructor
+public class IngredientKamisMapping extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "ingredient_id", nullable = false)
+    private Long ingredientId;
+
+    @Column(name = "ingredient_name", nullable = false)
+    private String ingredientName;
+
+    @Column(name = "kamis_item_code", nullable = false)
+    private String kamisItemCode;
+
+    @Column(name = "kamis_item_name")
+    private String kamisItemName;
+
+    @Column(name = "kamis_item_category_code")
+    private String kamisItemCategoryCode;
+
+    @Column(name = "kind_code")
+    private String kindCode;
+
+    @Column(name = "product_rank_code")
+    private String productRankCode;
+
+    @Column(name = "country_code")
+    private String countryCode;
+
+    @Column(name = "convert_kg_yn")
+    private String convertKgYn;
+
+    @Column(name = "auto_score")
+    private Double autoScore;
+
+    @Column(nullable = false)
+    private boolean confirmed;
+
+    public void confirm() {
+        this.confirmed = true;
+    }
+
+    public void updateKamisInfo(String kamisItemCode, String kamisItemName) {
+        if (kamisItemCode != null && !kamisItemCode.isBlank()) {
+            this.kamisItemCode = kamisItemCode;
+        }
+        if (kamisItemName != null) {
+            this.kamisItemName = kamisItemName;
+        }
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/entity/IngredientPrice.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/entity/IngredientPrice.java
@@ -1,0 +1,38 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.entity;
+
+import capstone.ai_meal_assistant_backend.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ingredient_prices")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IngredientPrice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ingredient_id", nullable = false)
+    private Ingredient ingredient;
+
+    @Column(nullable = false)
+    private Double pricePerGram;
+
+    @Column(nullable = false)
+    private String sourceApi;
+
+    private Integer originalPrice;
+    private String originalUnit;
+    private String marketName;
+    private String marketType;
+
+    @Column(nullable = false)
+    private LocalDateTime baseDate;
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/IngredientKamisMappingRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/IngredientKamisMappingRepository.java
@@ -1,0 +1,13 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.repository;
+
+import capstone.ai_meal_assistant_backend.domain.ingredient.entity.IngredientKamisMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface IngredientKamisMappingRepository extends JpaRepository<IngredientKamisMapping, Long> {
+
+    List<IngredientKamisMapping> findAllByConfirmedFalse();
+
+    List<IngredientKamisMapping> findAllByIngredientIdAndConfirmedFalseAndIdNot(Long ingredientId, Long excludeId);
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/IngredientPriceRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/IngredientPriceRepository.java
@@ -1,0 +1,20 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.repository;
+
+import capstone.ai_meal_assistant_backend.domain.ingredient.entity.IngredientPrice;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface IngredientPriceRepository extends JpaRepository<IngredientPrice, Long> {
+
+    @Query("""
+            SELECT ip FROM IngredientPrice ip
+            JOIN FETCH ip.ingredient i
+            WHERE i.name = :name
+            ORDER BY ip.baseDate DESC, ip.id DESC
+            """)
+    List<IngredientPrice> findLatestByIngredientName(@Param("name") String name, Pageable pageable);
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/service/AdminKamisMappingService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/service/AdminKamisMappingService.java
@@ -1,0 +1,111 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.service;
+
+import capstone.ai_meal_assistant_backend.domain.ingredient.dto.AutoConfirmResult;
+import capstone.ai_meal_assistant_backend.domain.ingredient.dto.KamisMappingGroupResponse;
+import capstone.ai_meal_assistant_backend.domain.ingredient.dto.KamisMappingPatchRequest;
+import capstone.ai_meal_assistant_backend.domain.ingredient.entity.IngredientKamisMapping;
+import capstone.ai_meal_assistant_backend.domain.ingredient.repository.IngredientKamisMappingRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AdminKamisMappingService {
+
+    private final IngredientKamisMappingRepository repository;
+
+    @Transactional(readOnly = true)
+    public List<KamisMappingGroupResponse> getUnconfirmedMappings() {
+        List<IngredientKamisMapping> mappings = repository.findAllByConfirmedFalse();
+
+        Map<Long, List<IngredientKamisMapping>> grouped = mappings.stream()
+                .collect(Collectors.groupingBy(IngredientKamisMapping::getIngredientId));
+
+        return grouped.entrySet().stream()
+                .map(e -> {
+                    String ingredientName = e.getValue().get(0).getIngredientName();
+                    List<KamisMappingGroupResponse.CandidateDto> candidates = e.getValue().stream()
+                            .sorted(Comparator.comparingDouble(
+                                    m -> -(m.getAutoScore() != null ? m.getAutoScore() : 0.0)))
+                            .map(m -> new KamisMappingGroupResponse.CandidateDto(
+                                    m.getId(), m.getKamisItemCode(), m.getKamisItemName(), m.getAutoScore()))
+                            .toList();
+                    return new KamisMappingGroupResponse(e.getKey(), ingredientName, candidates);
+                })
+                .sorted(Comparator.comparing(KamisMappingGroupResponse::ingredientName))
+                .toList();
+    }
+
+    @Transactional
+    public void patchMapping(Long id, KamisMappingPatchRequest request) {
+        IngredientKamisMapping mapping = repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Mapping not found: " + id));
+
+        mapping.updateKamisInfo(request.kamisItemCode(), request.kamisItemName());
+
+        if (Boolean.TRUE.equals(request.confirm())) {
+            mapping.confirm();
+            // 같은 재료의 나머지 미확정 후보 자동 삭제
+            List<IngredientKamisMapping> others = repository
+                    .findAllByIngredientIdAndConfirmedFalseAndIdNot(mapping.getIngredientId(), id);
+            repository.deleteAll(others);
+        }
+    }
+
+    @Transactional
+    public AutoConfirmResult autoConfirm(double minScore, double deleteBelow) {
+        List<IngredientKamisMapping> candidates = repository.findAllByConfirmedFalse();
+
+        Map<Long, List<IngredientKamisMapping>> grouped = candidates.stream()
+                .collect(Collectors.groupingBy(IngredientKamisMapping::getIngredientId));
+
+        int confirmedCount = 0;
+        int deletedCount = 0;
+        int needsReviewCount = 0;
+
+        for (List<IngredientKamisMapping> group : grouped.values()) {
+            IngredientKamisMapping best = group.stream()
+                    .max(Comparator.comparingDouble(m -> m.getAutoScore() != null ? m.getAutoScore() : 0.0))
+                    .orElse(null);
+            if (best == null) continue;
+
+            double bestScore = best.getAutoScore() != null ? best.getAutoScore() : 0.0;
+
+            if (bestScore >= minScore) {
+                // 점수 충분 → 자동 확정, 나머지 삭제
+                best.confirm();
+                List<IngredientKamisMapping> others = group.stream()
+                        .filter(m -> !m.getId().equals(best.getId()))
+                        .toList();
+                repository.deleteAll(others);
+                confirmedCount++;
+            } else if (bestScore < deleteBelow) {
+                // 최고 점수도 너무 낮음 → 전부 삭제
+                repository.deleteAll(group);
+                deletedCount++;
+            } else {
+                // 중간 점수 → 수동 검수
+                needsReviewCount++;
+            }
+        }
+
+        return new AutoConfirmResult(confirmedCount, deletedCount, needsReviewCount);
+    }
+
+    @Transactional
+    public void deleteMapping(Long id) {
+        IngredientKamisMapping mapping = repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Mapping not found: " + id));
+        if (mapping.isConfirmed()) {
+            throw new IllegalStateException("Cannot delete a confirmed mapping. id=" + id);
+        }
+        repository.delete(mapping);
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/service/IngredientPriceService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/service/IngredientPriceService.java
@@ -1,0 +1,34 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.service;
+
+import capstone.ai_meal_assistant_backend.domain.ingredient.dto.BatchPriceItem;
+import capstone.ai_meal_assistant_backend.domain.ingredient.dto.IngredientPriceResponse;
+import capstone.ai_meal_assistant_backend.domain.ingredient.entity.IngredientPrice;
+import capstone.ai_meal_assistant_backend.domain.ingredient.repository.IngredientPriceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class IngredientPriceService {
+
+    private final IngredientPriceRepository repository;
+
+    public Optional<IngredientPriceResponse> getLatestByName(String name) {
+        List<IngredientPrice> results = repository.findLatestByIngredientName(name, PageRequest.of(0, 1));
+        return results.isEmpty() ? Optional.empty() : Optional.of(IngredientPriceResponse.from(results.get(0)));
+    }
+
+    public List<BatchPriceItem> getBatchByNames(List<String> names) {
+        return names.stream()
+                .map(name -> getLatestByName(name)
+                        .map(BatchPriceItem::found)
+                        .orElseGet(() -> BatchPriceItem.notFound(name)))
+                .toList();
+    }
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/entity/IngredientKamisMapping.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/entity/IngredientKamisMapping.java
@@ -1,0 +1,53 @@
+package capstone.ai_meal_assistant_batch.domain.ingredient.entity;
+
+import capstone.ai_meal_assistant_batch.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "ingredient_kamis_mappings")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class IngredientKamisMapping extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ingredient_id", nullable = false)
+    private Ingredient ingredient;
+
+    @Column(name = "ingredient_name", nullable = false)
+    private String ingredientName;
+
+    @Column(name = "kamis_item_code", nullable = false)
+    private String kamisItemCode;
+
+    @Column(name = "kamis_item_name")
+    private String kamisItemName;
+
+    @Column(name = "kamis_item_category_code")
+    private String kamisItemCategoryCode;
+
+    @Column(name = "kind_code")
+    private String kindCode;
+
+    @Column(name = "product_rank_code")
+    private String productRankCode;
+
+    @Column(name = "country_code")
+    private String countryCode;
+
+    @Column(name = "convert_kg_yn")
+    private String convertKgYn;
+
+    @Column(name = "auto_score")
+    private Double autoScore;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean confirmed = false;
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/entity/IngredientPrice.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/entity/IngredientPrice.java
@@ -51,9 +51,13 @@ public class IngredientPrice extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime baseDate; // P_DATE: 2026-03-24
 
+    @Column(name = "last_sync_at")
+    private LocalDateTime lastSyncAt; // 배치 실행 확인용 — 가격 변동 없어도 항상 갱신
+
     public void updatePrice(double pricePerGram, Integer originalPrice, String originalUnit) {
         this.pricePerGram = pricePerGram;
         this.originalPrice = originalPrice;
         this.originalUnit = originalUnit;
+        this.lastSyncAt = LocalDateTime.now();
     }
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientKamisMappingRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientKamisMappingRepository.java
@@ -1,0 +1,15 @@
+package capstone.ai_meal_assistant_batch.domain.ingredient.repository;
+
+import capstone.ai_meal_assistant_batch.domain.ingredient.entity.IngredientKamisMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface IngredientKamisMappingRepository extends JpaRepository<IngredientKamisMapping, Long> {
+
+    List<IngredientKamisMapping> findAllByConfirmedTrue();
+
+    boolean existsByIngredientIdAndConfirmedTrue(Long ingredientId);
+
+    boolean existsByIngredientIdAndKamisItemCode(Long ingredientId, String kamisItemCode);
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisDryRunCommand.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisDryRunCommand.java
@@ -19,7 +19,7 @@ public class KamisDryRunCommand implements ApplicationRunner {
 	@Override
 	public void run(ApplicationArguments args) {
 		log.info("[BATCH][DRYRUN] kamisPriceUpdate started");
-		KamisPriceUpdateResult result = service.updateTodayPrices(true);
+		KamisPriceUpdateResult result = service.updateTodayPrices(true, false);
 		log.info("[BATCH][DRYRUN] kamisPriceUpdate result={}", result);
 	}
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisMapGeneratorCommand.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisMapGeneratorCommand.java
@@ -1,14 +1,10 @@
 package capstone.ai_meal_assistant_batch.job.kamis;
 
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -17,137 +13,122 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
+import capstone.ai_meal_assistant_batch.domain.ingredient.entity.Ingredient;
+import capstone.ai_meal_assistant_batch.domain.ingredient.entity.IngredientKamisMapping;
+import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientKamisMappingRepository;
 import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientRepository;
 import capstone.ai_meal_assistant_batch.global.log.BatchLog;
 import lombok.RequiredArgsConstructor;
 
 /**
  * DB의 ingredients와 KAMIS dailySalesList 전체 품목을 비교해서
- * 자동 매핑(JSON)을 생성한다.
+ * 재료당 상위 3개 후보를 ingredient_kamis_mappings 테이블에 confirmed=false로 저장한다.
  *
- * 실행:
- *  -Dspring-boot.run.arguments="--batch.kamis.generate-map=true"
+ * 실행: --batch.kamis.generate-map=true
  */
 @Component
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "batch.kamis", name = "generate-map", havingValue = "true")
 public class KamisMapGeneratorCommand implements ApplicationRunner {
 
-	private static final String JOB_NAME = "kamisGenerateIngredientMap";
+    private static final String JOB_NAME = "kamisGenerateIngredientMap";
+    private static final int TOP_K = 3;
 
-	private final IngredientRepository ingredientRepository;
-	private final KamisNaturePriceListClient client;
-	private final KamisNaturePriceListXmlParser parser;
-	private final ObjectMapper objectMapper;
-	private final ApplicationContext applicationContext;
+    private final IngredientRepository ingredientRepository;
+    private final IngredientKamisMappingRepository mappingRepository;
+    private final KamisNaturePriceListClient client;
+    private final KamisNaturePriceListXmlParser parser;
+    private final ApplicationContext applicationContext;
 
-	@Override
-	public void run(ApplicationArguments args) throws Exception {
-		Instant start = BatchLog.start(JOB_NAME);
-		try {
-			// 1) DB 재료명
-			List<String> ingredientNames = ingredientRepository.findAll().stream()
-					.map(i -> i.getName())
-					.filter(Objects::nonNull)
-					.map(String::trim)
-					.filter(s -> !s.isBlank())
-					.distinct()
-					.sorted()
-					.toList();
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        Instant start = BatchLog.start(JOB_NAME);
+        try {
+            // 1) DB 재료 목록
+            List<Ingredient> ingredients = ingredientRepository.findAll().stream()
+                    .filter(i -> i.getName() != null && !i.getName().isBlank())
+                    .sorted((a, b) -> a.getName().compareTo(b.getName()))
+                    .toList();
 
-			// 2) KAMIS 전체 품목(이미 지금 코드에서 단건 호출로 전체 items 확보 가능)
-			String xml = client.fetchXml(Map.of());
-			KamisNaturePriceListXmlParser.ParsedKamisResponse parsed = parser.parse(xml);
-			if (parsed.errorCode() != null && !"000".equals(parsed.errorCode())) {
-				throw new IllegalStateException("KAMIS responded error_code=" + parsed.errorCode() + " msg=" + parsed.errorMsg());
-			}
+            // 2) KAMIS 전체 품목 조회
+            String xml = client.fetchXml(Map.of());
+            KamisNaturePriceListXmlParser.ParsedKamisResponse parsed = parser.parse(xml);
+            if (parsed.errorCode() != null && !"000".equals(parsed.errorCode())) {
+                throw new IllegalStateException("KAMIS error_code=" + parsed.errorCode() + " msg=" + parsed.errorMsg());
+            }
 
-			// 가격 정보는 중복이 많아서, "품목코드(productno)별 대표 품목명"을 뽑고,
-			// 다(多)대1 매핑이 아닌 "이름 후보" 생성을 위해 item_name들을 유니크 리스트로 만든다.
-			Map<String, String> productNoToName = new LinkedHashMap<>();
-			for (var item : parsed.items()) {
-				if (item.productno() == null || item.productno().isBlank()) {
-					continue;
-				}
-				String name = item.itemName();
-				if (name == null || name.isBlank()) {
-					continue;
-				}
-				productNoToName.putIfAbsent(item.productno().trim(), name.trim());
-			}
-			List<KamisItem> kamisItems = productNoToName.entrySet().stream()
-					.map(e -> new KamisItem(e.getKey(), e.getValue()))
-					.toList();
-			List<String> kamisNames = kamisItems.stream().map(KamisItem::kamisName).distinct().toList();
+            // productno별 대표 품목명 추출 (중복 제거)
+            Map<String, String> productNoToName = new LinkedHashMap<>();
+            for (var item : parsed.items()) {
+                if (item.productno() == null || item.productno().isBlank()) continue;
+                if (item.itemName() == null || item.itemName().isBlank()) continue;
+                productNoToName.putIfAbsent(item.productno().trim(), item.itemName().trim());
+            }
+            List<KamisItem> kamisItems = productNoToName.entrySet().stream()
+                    .map(e -> new KamisItem(e.getKey(), e.getValue()))
+                    .toList();
+            List<String> kamisNames = kamisItems.stream().map(KamisItem::kamisName).distinct().toList();
 
-			// 3) 매칭: ingredientName -> top 후보 5개
-			List<GeneratedMapping> generated = new ArrayList<>(ingredientNames.size());
-			for (String ing : ingredientNames) {
-				KamisNameMatcher.MatchResult mr = KamisNameMatcher.bestMatch(ing, kamisNames, 5);
-				List<Candidate> top = mr.topCandidates().stream()
-						.map(s -> {
-							String bestName = s.candidate();
-							List<String> productNos = kamisItems.stream()
-									.filter(ki -> ki.kamisName().equals(bestName))
-									.map(KamisItem::productNo)
-									.sorted()
-									.toList();
-							return new Candidate(bestName, s.score(), productNos);
-						})
-						.toList();
-				generated.add(new GeneratedMapping(ing, top));
-			}
+            // 3) 재료별 상위 3개 후보 매칭 후 DB 저장
+            List<IngredientKamisMapping> toSave = new ArrayList<>();
+            int skippedConfirmed = 0;
+            int skippedDuplicate = 0;
 
-			GeneratedFile out = new GeneratedFile(
-					Instant.now().toString(),
-					ingredientNames.size(),
-					kamisItems.size(),
-					generated
-			);
+            for (Ingredient ingredient : ingredients) {
+                // confirmed=true 매핑이 이미 있는 재료는 건드리지 않음
+                if (mappingRepository.existsByIngredientIdAndConfirmedTrue(ingredient.getId())) {
+                    skippedConfirmed++;
+                    continue;
+                }
 
-			Path outPath = Path.of("build", "kamis-ingredient-map.generated.json");
-			Files.createDirectories(outPath.getParent());
-			String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(out);
-			Files.writeString(outPath, json + "\n", StandardCharsets.UTF_8);
+                KamisNameMatcher.MatchResult mr = KamisNameMatcher.bestMatch(ingredient.getName(), kamisNames, TOP_K);
 
-			System.out.println("[KAMIS][MAP_GENERATOR] saved=" + outPath.toAbsolutePath());
-			System.out.println("[KAMIS][MAP_GENERATOR] ingredients=" + ingredientNames.size() + " kamisItems=" + kamisItems.size());
+                for (KamisNameMatcher.Scored s : mr.topCandidates()) {
+                    List<String> productNos = kamisItems.stream()
+                            .filter(ki -> ki.kamisName().equals(s.candidate()))
+                            .map(KamisItem::productNo)
+                            .sorted()
+                            .toList();
+                    if (productNos.isEmpty()) continue;
 
-			BatchLog.success(JOB_NAME, start, Map.of(
-					"out", outPath.toString(),
-					"ingredientCount", ingredientNames.size(),
-					"kamisUniqueItems", kamisItems.size()));
+                    String itemCode = productNos.get(0);
 
-			int exitCode = SpringApplication.exit(applicationContext, () -> 0);
-			System.exit(exitCode);
-		} catch (Exception e) {
-			BatchLog.fail(JOB_NAME, start, e);
-			throw e;
-		}
-	}
+                    // 동일 재료 + 동일 코드 조합이 이미 있으면 스킵 (멱등성)
+                    if (mappingRepository.existsByIngredientIdAndKamisItemCode(ingredient.getId(), itemCode)) {
+                        skippedDuplicate++;
+                        continue;
+                    }
 
-	/** KAMIS 품목코드 + 대표 품목명 */
-	record KamisItem(String productNo, String kamisName) {
-	}
+                    toSave.add(IngredientKamisMapping.builder()
+                            .ingredient(ingredient)
+                            .ingredientName(ingredient.getName())
+                            .kamisItemCode(itemCode)
+                            .kamisItemName(s.candidate())
+                            .autoScore(s.score())
+                            .build());
+                }
+            }
 
-	/** 생성 파일 루트 */
-	record GeneratedFile(
-			String generatedAt,
-			int ingredientCount,
-			int kamisUniqueItemCount,
-			List<GeneratedMapping> mappings) {
-	}
+            mappingRepository.saveAll(toSave);
 
-	record GeneratedMapping(
-			String ingredientName,
-			List<Candidate> candidates) {
-	}
+            System.out.println("[KAMIS][MAP_GENERATOR] saved=" + toSave.size()
+                    + " skippedConfirmed=" + skippedConfirmed
+                    + " skippedDuplicate=" + skippedDuplicate
+                    + " ingredients=" + ingredients.size()
+                    + " kamisItems=" + kamisItems.size());
 
-	record Candidate(
-			String kamisName,
-			double score,
-			List<String> productNos) {
-	}
+            BatchLog.success(JOB_NAME, start, Map.of(
+                    "saved", toSave.size(),
+                    "ingredientCount", ingredients.size(),
+                    "kamisUniqueItems", kamisItems.size()));
+
+            int exitCode = SpringApplication.exit(applicationContext, () -> 0);
+            System.exit(exitCode);
+        } catch (Exception e) {
+            BatchLog.fail(JOB_NAME, start, e);
+            throw e;
+        }
+    }
+
+    record KamisItem(String productNo, String kamisName) {}
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisMappedPriceCommand.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisMappedPriceCommand.java
@@ -27,7 +27,7 @@ public class KamisMappedPriceCommand implements ApplicationRunner {
 	public void run(ApplicationArguments args) {
 		Instant start = BatchLog.start(JOB_NAME);
 		try {
-			KamisPriceUpdateResult result = service.updateTodayPrices(false);
+			KamisPriceUpdateResult result = service.updateTodayPrices(false, false);
 			BatchLog.success(JOB_NAME, start, result);
 			int exitCode = SpringApplication.exit(applicationContext, () -> 0);
 			System.exit(exitCode);

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisNaturePriceListXmlParser.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisNaturePriceListXmlParser.java
@@ -53,8 +53,8 @@ public class KamisNaturePriceListXmlParser {
 				String productno = textContent(el, "productno"); // 품목코드
 				String itemName = textContent(el, "item_name"); // 품목명
 				String unit = textContent(el, "unit"); // 단위
-				String day1 = textContent(el, "day1"); // 최근 조사일자
-				String dpr1 = textContent(el, "dpr1"); // 최근 조사일자 가격
+				String lastestDay = textContent(el, "lastest_day"); // 실제 조사 날짜 (yyyy-MM-dd)
+				String dpr1 = textContent(el, "dpr1"); // 당일 가격
 
 				// 가격이나 코드가 없으면(또는 "-" 처리되어 있으면) 스킵
 				if ((dpr1 == null || dpr1.isBlank() || "-".equals(dpr1)) || productno == null) {
@@ -67,7 +67,7 @@ public class KamisNaturePriceListXmlParser {
 						productno,
 						itemName,
 						unit,
-						day1,
+						lastestDay,
 						dpr1));
 			}
 
@@ -107,6 +107,6 @@ public class KamisNaturePriceListXmlParser {
 			String productno,
 			String itemName,
 			String unit,
-			String day1,
+			String lastestDay,
 			String dpr1) {}
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisPriceScheduler.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisPriceScheduler.java
@@ -3,6 +3,8 @@ package capstone.ai_meal_assistant_batch.job.kamis;
 import java.time.Instant;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -11,16 +13,23 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-@ConditionalOnProperty(
-		prefix = "batch.kamis",
-		name = {"enabled", "run-once"},
-		havingValue = "true,false",
-		matchIfMissing = true)
+@ConditionalOnProperty(prefix = "batch.kamis", name = "run-once", havingValue = "false")
 public class KamisPriceScheduler {
 
 	private static final String JOB_NAME = "kamisPriceUpdate";
 
 	private final KamisPriceUpdateService service;
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void runOnStartup() {
+		Instant start = BatchLog.start(JOB_NAME + ".startup");
+		try {
+			KamisPriceUpdateResult result = service.updateTodayPricesForced();
+			BatchLog.success(JOB_NAME + ".startup", start, result);
+		} catch (Exception e) {
+			BatchLog.fail(JOB_NAME + ".startup", start, e);
+		}
+	}
 
 	@Scheduled(cron = "${batch.kamis.cron}")
 	public void run() {

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisPriceUpdateService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisPriceUpdateService.java
@@ -9,239 +9,218 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import capstone.ai_meal_assistant_batch.domain.ingredient.entity.Ingredient;
+import capstone.ai_meal_assistant_batch.domain.ingredient.entity.IngredientKamisMapping;
 import capstone.ai_meal_assistant_batch.domain.ingredient.entity.IngredientPrice;
+import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientKamisMappingRepository;
 import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientPriceRepository;
-import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class KamisPriceUpdateService {
 
-	private static final String SOURCE_API = "KAMIS_DAILY_SALES";
+    private static final String SOURCE_API = "KAMIS_DAILY_SALES";
 
-	private final IngredientRepository ingredientRepository;
-	private final IngredientPriceRepository ingredientPriceRepository;
-	private final KamisNaturePriceListClient client;
-	private final KamisNaturePriceListXmlParser parser;
-	private final KamisIngredientMapLoader mapLoader;
+    private final IngredientPriceRepository ingredientPriceRepository;
+    private final IngredientKamisMappingRepository mappingRepository;
+    private final KamisNaturePriceListClient client;
+    private final KamisNaturePriceListXmlParser parser;
 
-	@Transactional
-	public KamisPriceUpdateResult updateTodayPrices() {
-		return updateTodayPrices(false);
-	}
+    @Transactional
+    public KamisPriceUpdateResult updateTodayPrices() {
+        return updateTodayPrices(false, false);
+    }
 
-	@Transactional
-	public KamisPriceUpdateResult updateTodayPrices(boolean dryRun) {
-		int totalFetched = 0;
-		int inserted = 0;
-		int updated = 0;
-		int skipped = 0;
+    @Transactional
+    public KamisPriceUpdateResult updateTodayPricesForced() {
+        return updateTodayPrices(false, true);
+    }
 
-		// 1. 전체 데이터 단건 호출 (파라미터 불필요)
-		Map<String, String> emptyParams = new HashMap<>();
-		String xml = client.fetchXml(emptyParams);
-		KamisNaturePriceListXmlParser.ParsedKamisResponse parsed;
-		
-		try {
-			parsed = parser.parse(xml);
-		} catch (Exception parseEx) {
-			System.out.println("[KAMIS][ERROR] XML Parsing Failed: " + parseEx.getMessage());
-			throw parseEx;
-		}
+    @Transactional
+    public KamisPriceUpdateResult updateTodayPrices(boolean dryRun, boolean forceUpdate) {
+        int totalFetched = 0;
+        int inserted = 0;
+        int updated = 0;
+        int skipped = 0;
 
-		if (parsed.errorCode() != null && !"000".equals(parsed.errorCode())) {
-			System.out.println("[KAMIS][ERROR] API responded with error_code=" + parsed.errorCode() + ", msg=" + parsed.errorMsg());
-			return new KamisPriceUpdateResult(0, 0, 0, 0);
-		}
+        String xml = client.fetchXml(new HashMap<>());
+        KamisNaturePriceListXmlParser.ParsedKamisResponse parsed;
+        try {
+            parsed = parser.parse(xml);
+        } catch (Exception parseEx) {
+            System.out.println("[KAMIS][ERROR] XML Parsing Failed: " + parseEx.getMessage());
+            throw parseEx;
+        }
 
-		totalFetched = parsed.items().size();
+        if (parsed.errorCode() != null && !"000".equals(parsed.errorCode())) {
+            System.out.println("[KAMIS][ERROR] API error_code=" + parsed.errorCode() + ", msg=" + parsed.errorMsg());
+            return new KamisPriceUpdateResult(0, 0, 0, 0);
+        }
 
-		// 2. 파싱된 데이터를 productno(품목코드) 기준으로 그룹화
-		Map<String, List<KamisNaturePriceListXmlParser.KamisDailySalesItem>> itemsByCode = parsed.items().stream()
-				.filter(item -> item.productno() != null)
-				.collect(Collectors.groupingBy(KamisNaturePriceListXmlParser.KamisDailySalesItem::productno));
+        totalFetched = parsed.items().size();
 
-		// 🚀 [여기부터 추가] KAMIS가 실제로 내려준 223개의 품목코드와 이름을 콘솔에 찍어봅니다.
-		System.out.println("=== [KAMIS 품목 코드 목록 (" + totalFetched + "개)] ===");
-		itemsByCode.forEach((code, list) -> {
-			System.out.println("코드: " + code + ", 품목명: " + list.get(0).itemName() + ", 가격: " + list.get(0).dpr1());
-		});
-		System.out.println("==============================================");
+        Map<String, List<KamisNaturePriceListXmlParser.KamisDailySalesItem>> itemsByCode = parsed.items().stream()
+                .filter(item -> item.productno() != null)
+                .collect(Collectors.groupingBy(KamisNaturePriceListXmlParser.KamisDailySalesItem::productno));
 
-		var entries = mapLoader.load();
+        List<IngredientKamisMapping> mappings = mappingRepository.findAllByConfirmedTrue();
 
-		// 3. 내부 재료 리스트를 순회하며 그룹화된 데이터와 매핑
-		for (var entry : entries) {
-			if (entry.kamis() == null || entry.kamis().itemCode() == null) {
-				skipped++;
-				continue;
-			}
-			
-			String targetCode = entry.kamis().itemCode();
-			List<KamisNaturePriceListXmlParser.KamisDailySalesItem> matchedItems = itemsByCode.get(targetCode);
+        for (IngredientKamisMapping mapping : mappings) {
+            List<KamisNaturePriceListXmlParser.KamisDailySalesItem> matchedItems =
+                    itemsByCode.get(mapping.getKamisItemCode());
 
-			if (matchedItems == null || matchedItems.isEmpty()) {
-				skipped++;
-				continue;
-			}
+            if (matchedItems == null || matchedItems.isEmpty()) {
+                skipped++;
+                continue;
+            }
 
-			// 하나의 품목코드에 도매/소매 데이터가 모두 있을 수 있으므로 전부 순회
-			for (var item : matchedItems) {
-				NormalizedRow row = normalize(entry.ingredientName(), item);
-				if (row == null) {
-					skipped++;
-					continue;
-				}
+            for (var item : matchedItems) {
+                NormalizedRow row = normalize(mapping.getIngredient(), item);
+                if (row == null) {
+                    skipped++;
+                    continue;
+                }
 
-				if (dryRun) {
-					skipped++;
-					continue;
-				}
+                if (dryRun) {
+                    skipped++;
+                    continue;
+                }
 
-				UpsertOutcome outcome = upsertPrice(
-						row.ingredientName(),
-						row.pricePerGram(),
-						row.originalPrice(),
-						row.originalUnit(),
-						row.marketName(),
-						row.marketType(),
-						row.baseDate());
+                UpsertOutcome outcome = upsertPrice(
+                        row.ingredient(),
+                        row.pricePerGram(),
+                        row.originalPrice(),
+                        row.originalUnit(),
+                        row.marketName(),
+                        row.marketType(),
+                        row.baseDate(),
+                        forceUpdate);
 
-				switch (outcome) {
-					case INSERTED -> inserted++;
-					case UPDATED -> updated++;
-					case SKIPPED -> skipped++;
-				}
-			}
-		}
+                switch (outcome) {
+                    case INSERTED -> inserted++;
+                    case UPDATED -> updated++;
+                    case SKIPPED -> skipped++;
+                }
+            }
+        }
 
-		return new KamisPriceUpdateResult(totalFetched, inserted, updated, skipped);
-	}
+        return new KamisPriceUpdateResult(totalFetched, inserted, updated, skipped);
+    }
 
-	private NormalizedRow normalize(String ingredientName, KamisNaturePriceListXmlParser.KamisDailySalesItem item) {
-		Integer originalPrice = parsePrice(item.dpr1());
-		if (originalPrice == null) return null;
+    private NormalizedRow normalize(Ingredient ingredient, KamisNaturePriceListXmlParser.KamisDailySalesItem item) {
+        Integer originalPrice = parsePrice(item.dpr1());
+        if (originalPrice == null) return null;
 
-		String originalUnit = item.unit();
-		Double pricePerGram = convertToPricePerGram(originalPrice, originalUnit);
-		if (pricePerGram == null) return null;
+        String originalUnit = item.unit();
+        Double pricePerGram = convertToPricePerGram(originalPrice, originalUnit);
+        if (pricePerGram == null) return null;
 
-		LocalDateTime baseDate = parseKamisDate(item.day1());
+        LocalDateTime baseDate = parseKamisDate(item.lastestDay());
+        String marketName = item.productClsName();
+        String marketType = item.categoryName();
 
-		// 도매/소매를 marketName으로, 부류명(채소, 과일 등)을 marketType으로 사용
-		String marketName = item.productClsName(); 
-		String marketType = item.categoryName(); 
-		
-		return new NormalizedRow(ingredientName, pricePerGram, originalPrice, originalUnit, marketName, marketType, baseDate);
-	}
+        return new NormalizedRow(ingredient, pricePerGram, originalPrice, originalUnit, marketName, marketType, baseDate);
+    }
 
-	private LocalDateTime parseKamisDate(String day1) {
-		if (day1 == null || day1.isBlank()) return LocalDateTime.now();
-		day1 = day1.trim();
-		try {
-			// YYYY-MM-DD 형식으로 올 경우
-			if (day1.length() == 10) {
-				return LocalDate.parse(day1, DateTimeFormatter.ofPattern("yyyy-MM-dd")).atStartOfDay();
-			}
-			// MM/DD 형식으로 올 경우 (KAMIS 기본 형식)
-			if (day1.length() == 5 && day1.contains("/")) {
-				int year = LocalDate.now().getYear();
-				return LocalDate.parse(year + "/" + day1, DateTimeFormatter.ofPattern("yyyy/MM/dd")).atStartOfDay();
-			}
-		} catch (Exception e) {
-			// 파싱 실패 시 현재 시간 Fallback
-		}
-		return LocalDateTime.now();
-	}
+    private LocalDateTime parseKamisDate(String day1) {
+        if (day1 == null || day1.isBlank()) return LocalDateTime.now();
+        day1 = day1.trim();
+        try {
+            if (day1.length() == 10) {
+                return LocalDate.parse(day1, DateTimeFormatter.ofPattern("yyyy-MM-dd")).atStartOfDay();
+            }
+            if (day1.length() == 5 && day1.contains("/")) {
+                int year = LocalDate.now().getYear();
+                return LocalDate.parse(year + "/" + day1, DateTimeFormatter.ofPattern("yyyy/MM/dd")).atStartOfDay();
+            }
+        } catch (Exception e) {
+            // fallback
+        }
+        return LocalDateTime.now();
+    }
 
-	private static Integer parsePrice(String raw) {
-		if (raw == null) return null;
-		String digits = raw.replaceAll("[^0-9]", "");
-		if (digits.isBlank()) return null;
-		try {
-			return Integer.parseInt(digits);
-		} catch (NumberFormatException e) {
-			return null;
-		}
-	}
+    private static Integer parsePrice(String raw) {
+        if (raw == null) return null;
+        String digits = raw.replaceAll("[^0-9]", "");
+        if (digits.isBlank()) return null;
+        try {
+            return Integer.parseInt(digits);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
 
-	private static Double convertToPricePerGram(Integer price, String unit) {
-		if (price == null || unit == null || unit.isBlank()) return null;
-		String u = unit.trim().toLowerCase(Locale.KOREA);
-		
-		if (u.endsWith("kg")) {
-			String n = u.replace("kg", "").trim();
-			double kg = n.isBlank() ? 1.0 : Double.parseDouble(n);
-			return price / (kg * 1000.0);
-		}
-		if (u.endsWith("g")) {
-			String n = u.replace("g", "").trim();
-			double g = n.isBlank() ? 1.0 : Double.parseDouble(n);
-			return price / g;
-		}
-		return null;
-	}
+    private static Double convertToPricePerGram(Integer price, String unit) {
+        if (price == null || unit == null || unit.isBlank()) return null;
+        String u = unit.trim().toLowerCase(Locale.KOREA);
+        if (u.endsWith("kg")) {
+            String n = u.replace("kg", "").trim();
+            double kg = n.isBlank() ? 1.0 : Double.parseDouble(n);
+            return price / (kg * 1000.0);
+        }
+        if (u.endsWith("g")) {
+            String n = u.replace("g", "").trim();
+            double g = n.isBlank() ? 1.0 : Double.parseDouble(n);
+            return price / g;
+        }
+        return null;
+    }
 
-	private record NormalizedRow(
-			String ingredientName,
-			double pricePerGram,
-			Integer originalPrice,
-			String originalUnit,
-			String marketName,
-			String marketType,
-			LocalDateTime baseDate) {}
+    private record NormalizedRow(
+            Ingredient ingredient,
+            double pricePerGram,
+            Integer originalPrice,
+            String originalUnit,
+            String marketName,
+            String marketType,
+            LocalDateTime baseDate) {}
 
-	private enum UpsertOutcome {
-		INSERTED, UPDATED, SKIPPED
-	}
+    private enum UpsertOutcome { INSERTED, UPDATED, SKIPPED }
 
-	private UpsertOutcome upsertPrice(
-			String ingredientName,
-			double pricePerGram,
-			Integer originalPrice,
-			String originalUnit,
-			String marketName,
-			String marketType,
-			LocalDateTime baseDate) {
-		
-		Ingredient ingredient = ingredientRepository.findByName(ingredientName)
-				.orElseGet(() -> ingredientRepository.save(Ingredient.builder().name(ingredientName).build()));
+    private UpsertOutcome upsertPrice(
+            Ingredient ingredient,
+            double pricePerGram,
+            Integer originalPrice,
+            String originalUnit,
+            String marketName,
+            String marketType,
+            LocalDateTime baseDate,
+            boolean forceUpdate) {
 
-		var existing = ingredientPriceRepository
-				.findByIngredientIdAndSourceApiAndMarketNameAndMarketTypeAndOriginalUnitAndBaseDate(
-					ingredient.getId(),
-					SOURCE_API,
-					marketName,
-					marketType,
-					originalUnit,
-					baseDate);
+        var existing = ingredientPriceRepository
+                .findByIngredientIdAndSourceApiAndMarketNameAndMarketTypeAndOriginalUnitAndBaseDate(
+                        ingredient.getId(),
+                        SOURCE_API,
+                        marketName,
+                        marketType,
+                        originalUnit,
+                        baseDate);
 
-		if (existing.isEmpty()) {
-			ingredientPriceRepository.save(IngredientPrice.builder()
-					.ingredient(ingredient)
-					.pricePerGram(pricePerGram)
-					.sourceApi(SOURCE_API)
-					.originalPrice(originalPrice)
-					.originalUnit(originalUnit)
-					.marketName(marketName)
-					.marketType(marketType)
-					.baseDate(baseDate)
-					.build());
-			return UpsertOutcome.INSERTED;
-		}
+        if (existing.isEmpty()) {
+            ingredientPriceRepository.save(IngredientPrice.builder()
+                    .ingredient(ingredient)
+                    .pricePerGram(pricePerGram)
+                    .sourceApi(SOURCE_API)
+                    .originalPrice(originalPrice)
+                    .originalUnit(originalUnit)
+                    .marketName(marketName)
+                    .marketType(marketType)
+                    .baseDate(baseDate)
+                    .build());
+            return UpsertOutcome.INSERTED;
+        }
 
-		IngredientPrice old = existing.get();
-		if (old.getPricePerGram() != null && Double.compare(old.getPricePerGram(), pricePerGram) == 0) {
-			return UpsertOutcome.SKIPPED;
-		}
+        IngredientPrice old = existing.get();
+        if (!forceUpdate && old.getPricePerGram() != null && Double.compare(old.getPricePerGram(), pricePerGram) == 0) {
+            return UpsertOutcome.SKIPPED;
+        }
 
-		old.updatePrice(pricePerGram, originalPrice, originalUnit);
-		ingredientPriceRepository.save(old);
-		return UpsertOutcome.UPDATED;
-	}
+        old.updatePrice(pricePerGram, originalPrice, originalUnit);
+        ingredientPriceRepository.save(old);
+        return UpsertOutcome.UPDATED;
+    }
 }


### PR DESCRIPTION
## 요약

   - **[배치] KAMIS 가격 수집 파이프라인 버그 수정 및 완성**
     - `<day1>` ("당일" 한글) → `<lastest_day>` (yyyy-MM-dd) 파싱 버그 수정으로 base_date 정상화
     - `@ConditionalOnProperty` 배열+`havingValue` 조건 버그 수정으로 스케줄러 정상 활성화
     - 서버 시작 시 `@EventListener(ApplicationReadyEvent)`로 즉시 강제 업데이트 실행
     - 하루 3회 정기 수집 스케줄 (08:00 / 13:00 / 18:00), 변경 없으면 스킵
     - `KamisMapGeneratorCommand`: JSON 파일 출력 → `ingredient_kamis_mappings` DB 직접 저장으로 리팩토링
     - `IngredientKamisMapping` 엔티티 / `IngredientKamisMappingRepository` 추가

   - **[백엔드] ingredient_prices 조회 API 신규**
     - `GET /api/v1/ingredients/prices?name={재료명}` — 단건 최신 가격 조회 (없으면 404)
     - `POST /api/v1/ingredients/prices/batch` — 복수 재료 가격 일괄 조회 (`found` 플래그 포함)
     - `Ingredient`, `IngredientPrice` 엔티티 (배치 테이블 읽기 전용 매핑)
     - `IngredientKamisMapping` 엔티티 및 `AdminKamisMappingService/Controller` 추가
     - `GET/PATCH/DELETE /admin/kamis-mappings`, `POST /admin/kamis-mappings/auto-c
     - Swagger UI 의존성, `-parameters` 컴파일 옵션 추가


AI 연결 시:
- GetMarketPrices 전체 초기화 불필요
- price_node 안에서 그 레시피 재료만 batch API 호출
- 응답 포맷만 기존 계산 로직에 맞게 변환
