### PR TITLE
feat: AI 추천 결과 5개 SSE 스트리밍 + 스와이프 카드 UI

### DIFF
--- a/ai_agent_app/RecipeGraph.py
+++ b/ai_agent_app/RecipeGraph.py
@@ -223,6 +223,13 @@ class RecipeGraphBuilder:
             )
         return result
 
+    async def stream_analyze(self, state: GraphState):
+        """Top5 분석 결과를 완료된 순서대로 yield (SSE용)"""
+        tasks = [self._analyze_one(seq, state) for seq in state["top5_ids"]]
+        for coro in asyncio.as_completed(tasks):
+            result = await coro
+            yield result
+
     async def analyze_node(self, state: GraphState) -> GraphState:
         print("[analyze_node] 상위 5개 상세 분석 (병렬 처리)")
         tasks = [self._analyze_one(seq, state) for seq in state["top5_ids"]]

--- a/ai_agent_app/server.py
+++ b/ai_agent_app/server.py
@@ -1,7 +1,9 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from typing import List, Optional
 import os
+import json
 from langchain_openai import ChatOpenAI
 from dotenv import load_dotenv
 
@@ -158,51 +160,57 @@ def _resolve_recipes(jwt_token: Optional[str], candidate_menu_ids: Optional[List
 @app.post("/recommend")
 async def get_recommendation(user_input: UserRequest):
     """
-    초기 추천 요청
+    초기 추천 요청 (SSE 스트리밍)
 
-    Args:
-        user_input: 사용자 정보 (user_id, jwt_token 포함)
-
-    Returns:
-        {
-            "user_id": str,
-            "recommendations": List[Dict]
-        }
+    Returns text/event-stream:
+        각 분석 완료 시마다 `data: {...}\n\n` 전송
+        마지막에 `data: [DONE]\n\n`
     """
     try:
         user_id = _user_id_from_jwt(user_input.jwt_token)
         active_recipes = _resolve_recipes(user_input.jwt_token, user_input.candidate_menu_ids)
         if not active_recipes:
-            raise ValueError("메뉴 후보를 가져올 수 없습니다. Spring 백엔드 연결을 확인하세요.")
+            raise HTTPException(status_code=422, detail="메뉴 후보를 가져올 수 없습니다. Spring 백엔드 연결을 확인하세요.")
 
         user_query = user_input.dict(exclude={"jwt_token"})
-
-        # 벡터 검색으로 현재 요청과 관련 있는 과거 이력 K개 추출
         history_texts = await user_history_manager.search_relevant_history(
             user_id=user_id,
             user_query=user_query,
             k=5,
         )
 
-        result = await recommendation_service.recommend(user_id, user_query, active_recipes, history_texts)
-        # Flutter는 flat 구조 + menu_id(int) 를 기대하므로 변환
-        recs = result.get("recommendations", [])
-        if not recs:
-            raise ValueError("추천 결과가 없습니다.")
-        top = recs[0]
-        rid = top.get("recipe_id") or top.get("menu_id")
-        try:
-            top["menu_id"] = int(rid) if rid is not None else 0
-        except (TypeError, ValueError):
-            top["menu_id"] = 0
-        return top
-    except ValueError as e:
-        raise HTTPException(status_code=422, detail=str(e))
-    except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"AI 에이전트 실행 중 오류 발생: {str(e)}",
+        session_manager.create_or_get_session(user_id, user_query)
+
+        async def event_generator():
+            try:
+                async for result in recommendation_engine.stream_initial_recommendations(
+                    active_recipes, user_query, history_texts
+                ):
+                    rid = result.get("recipe_id") or result.get("menu_id")
+                    try:
+                        result["menu_id"] = int(rid) if rid is not None else 0
+                    except (TypeError, ValueError):
+                        result["menu_id"] = 0
+                    yield f"data: {json.dumps(result, ensure_ascii=False)}\n\n"
+            except ValueError as e:
+                yield f"data: {json.dumps({'error': str(e)}, ensure_ascii=False)}\n\n"
+            except Exception as e:
+                yield f"data: {json.dumps({'error': f'AI 에이전트 실행 중 오류: {str(e)}'}, ensure_ascii=False)}\n\n"
+            finally:
+                yield "data: [DONE]\n\n"
+
+        return StreamingResponse(
+            event_generator(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+            },
         )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"AI 에이전트 실행 중 오류 발생: {str(e)}")
 
 
 @app.post("/history")

--- a/ai_agent_app/services/recommendation_engine.py
+++ b/ai_agent_app/services/recommendation_engine.py
@@ -55,6 +55,56 @@ class RecommendationEngine:
         final_state = await self.graph.ainvoke(initial_state)
         return final_state
 
+    async def stream_initial_recommendations(
+        self,
+        recipes: List[Dict],
+        user_query: Dict,
+        history_texts: Optional[List[str]] = None,
+    ):
+        """초기 추천 파이프라인을 실행하고 analyze 결과를 완료 순서대로 yield (SSE용)"""
+        print("[RecommendationEngine] SSE 스트리밍 추천 시작")
+
+        if history_texts is None:
+            history_texts = []
+
+        state = {
+            "recipes": recipes,
+            "recipes_by_seq": _build_recipes_by_seq(recipes),
+            "user_query": user_query,
+            "rejected_ids": [],
+            "feedback_reason": None,
+            "feedback_constraints": None,
+            "filtered_recipes": [],
+            "allowed_ids": [],
+            "history_texts": history_texts,
+            "candidate_ids": [],
+            "enriched": [],
+            "price_cache": {},
+            "top5_ids": [],
+            "top10_ids": [],
+            "final_results": [],
+            "error": None,
+        }
+
+        state = self.graph_builder.filter_node(state)
+        if state.get("error"):
+            raise ValueError(state["error"])
+
+        state = self.graph_builder.candidate_node(state)
+        if state.get("error"):
+            raise ValueError(state["error"])
+
+        state = await self.graph_builder.price_node(state)
+        if state.get("error"):
+            raise ValueError(state.get("error", "price_node 오류"))
+
+        state = self.graph_builder.rank_node(state)
+        if state.get("error"):
+            raise ValueError(state["error"])
+
+        async for result in self.graph_builder.stream_analyze(state):
+            yield result
+
     async def get_feedback_recommendations(
         self,
         recipes: List[Dict],

--- a/flutter_app/lib/screens/recommendation_screen.dart
+++ b/flutter_app/lib/screens/recommendation_screen.dart
@@ -22,7 +22,7 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
   late List<MenuCandidate> _candidates;
   late RecommendationRequest _currentRequest;
 
-  RecommendationResult? _aiResult;
+  final List<RecommendationResult> _aiResults = [];
   bool _aiLoading = true;
   String? _aiError;
   bool _reloading = false;
@@ -49,8 +49,11 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
 
   Future<void> _fetchAiResult() async {
     try {
-      final result = await RecommendationService.recommend(_currentRequest);
-      if (mounted) setState(() { _aiResult = result; _aiLoading = false; });
+      await for (final result in RecommendationService.recommendStream(_currentRequest)) {
+        if (!mounted) return;
+        setState(() => _aiResults.add(result));
+      }
+      if (mounted) setState(() => _aiLoading = false);
     } catch (e) {
       if (mounted) setState(() { _aiError = e.toString(); _aiLoading = false; });
     }
@@ -74,8 +77,8 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
   }
 
   void _checkAllNegative() {
-    final aiPickId = _aiResult?.menuId;
-    final nonAiPick = _candidates.where((c) => c.id != aiPickId).toList();
+    final aiPickIds = _aiResults.map((r) => r.menuId).toSet();
+    final nonAiPick = _candidates.where((c) => !aiPickIds.contains(c.id)).toList();
     if (nonAiPick.isEmpty) return;
     if (nonAiPick.every((c) => _negativeFeedbackIds.contains(c.id))) {
       _reload();
@@ -99,7 +102,7 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
           candidateMenuIds: newCandidates.map((c) => c.id).toList(),
         );
         _aiLoading = true;
-        _aiResult = null;
+        _aiResults.clear();
         _aiError = null;
         _negativeFeedbackIds.clear();
         _positiveFeedbackIds.clear();
@@ -178,7 +181,7 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
                     child: ElevatedButton(
                       onPressed: canSubmit
                           ? () async {
-                              final menuId = _aiResult?.menuId;
+                              final menuId = _aiResults.isNotEmpty ? _aiResults.first.menuId : null;
                               final rating = _rating;
                               final reason = _feedbackController.text;
                               Navigator.pop(context);
@@ -214,7 +217,7 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final aiPickId = _aiResult?.menuId;
+    final aiPickIds = _aiResults.map((r) => r.menuId).toSet();
 
     return Scaffold(
       appBar: AppBar(
@@ -228,26 +231,24 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
           Expanded(
             child: CustomScrollView(
               slivers: [
-                // ── AI 추천 1픽 섹션 ──────────────────────────
+                // ── AI 추천 섹션 ──────────────────────────────
                 SliverToBoxAdapter(
                   child: Padding(
                     padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
                     child: _AiPickSection(
                       loading: _aiLoading,
-                      result: _aiResult,
+                      results: _aiResults,
                       error: _aiError,
                       onRetry: () {
-                        setState(() { _aiLoading = true; _aiError = null; });
+                        setState(() { _aiLoading = true; _aiError = null; _aiResults.clear(); });
                         _fetchAiResult();
                       },
-                      onDetailTap: _aiResult != null
-                          ? () => Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (_) => MenuDetailScreen(aiResult: _aiResult),
-                              ),
-                            )
-                          : null,
+                      onDetailTap: (result) => Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => MenuDetailScreen(aiResult: result),
+                        ),
+                      ),
                     ),
                   ),
                 ),
@@ -291,7 +292,7 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
                         delegate: SliverChildBuilderDelegate(
                           (ctx, i) {
                             final c = _candidates[i];
-                            final isAiPick = aiPickId != null && c.id == aiPickId;
+                            final isAiPick = aiPickIds.contains(c.id);
                             bool? feedbackGiven;
                             if (_positiveFeedbackIds.contains(c.id)) feedbackGiven = true;
                             if (_negativeFeedbackIds.contains(c.id)) feedbackGiven = false;
@@ -345,27 +346,59 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
   }
 }
 
-// ── AI 추천 1픽 섹션 ─────────────────────────────────────────
-class _AiPickSection extends StatelessWidget {
+// ── AI 추천 섹션 ─────────────────────────────────────────────
+class _AiPickSection extends StatefulWidget {
   final bool loading;
-  final RecommendationResult? result;
+  final List<RecommendationResult> results;
   final String? error;
   final VoidCallback onRetry;
-  final VoidCallback? onDetailTap;
+  final void Function(RecommendationResult) onDetailTap;
 
   const _AiPickSection({
     required this.loading,
-    required this.result,
+    required this.results,
     required this.error,
     required this.onRetry,
-    this.onDetailTap,
+    required this.onDetailTap,
   });
 
   @override
+  State<_AiPickSection> createState() => _AiPickSectionState();
+}
+
+class _AiPickSectionState extends State<_AiPickSection> {
+  final PageController _pageController = PageController(viewportFraction: 0.92);
+  int _currentPage = 0;
+
+  @override
+  void didUpdateWidget(_AiPickSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // 로딩 완료 시 loading placeholder 페이지에 있었다면 마지막 결과 카드로 이동
+    if (!widget.loading && oldWidget.loading && _currentPage >= widget.results.length) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && widget.results.isNotEmpty) {
+          _pageController.jumpToPage(widget.results.length - 1);
+        }
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final hasResults = widget.results.isNotEmpty;
+    final pageCount = widget.results.length + (widget.loading ? 1 : 0);
+    final displayCount = pageCount == 0 ? 1 : pageCount;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        // ── 헤더 ───────────────────────────────────────────
         Row(
           children: [
             ShaderMask(
@@ -377,24 +410,83 @@ class _AiPickSection extends StatelessWidget {
             ShaderMask(
               blendMode: BlendMode.srcIn,
               shaderCallback: (b) => AppTheme.aiGradient.createShader(b),
-              child: const Text('AI 추천 1픽',
-                  style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold)),
+              child: Text(
+                widget.loading
+                    ? 'AI 추천 분석 중 (${widget.results.length}/5)'
+                    : 'AI 추천 ${widget.results.length}픽',
+                style: const TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
+              ),
             ),
           ],
         ),
         const SizedBox(height: 8),
-        if (loading)
-          _LoadingCard()
-        else if (error != null)
-          _ErrorCard(error: error!, onRetry: onRetry)
-        else if (result != null)
-          _ResultCard(result: result!, onDetailTap: onDetailTap),
+        // ── 에러 (결과 없을 때) ─────────────────────────────
+        if (!hasResults && !widget.loading && widget.error != null)
+          _ErrorCard(error: widget.error!, onRetry: widget.onRetry)
+        else
+          // ── 카드 PageView ─────────────────────────────────
+          SizedBox(
+            height: 460,
+            child: PageView.builder(
+              controller: _pageController,
+              onPageChanged: (i) => setState(() => _currentPage = i),
+              itemCount: displayCount,
+              itemBuilder: (context, index) {
+                if (!hasResults || index >= widget.results.length) {
+                  return const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 4),
+                    child: _LoadingCard(),
+                  );
+                }
+                final r = widget.results[index];
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  child: SingleChildScrollView(
+                    physics: const ClampingScrollPhysics(),
+                    child: _ResultCard(
+                      result: r,
+                      onDetailTap: () => widget.onDetailTap(r),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        // ── 페이지 인디케이터 ──────────────────────────────
+        if (displayCount > 1)
+          Padding(
+            padding: const EdgeInsets.only(top: 10),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: List.generate(displayCount, (i) {
+                final isActive = i == _currentPage;
+                return AnimatedContainer(
+                  duration: const Duration(milliseconds: 200),
+                  margin: const EdgeInsets.symmetric(horizontal: 3),
+                  width: isActive ? 16 : 6,
+                  height: 6,
+                  decoration: BoxDecoration(
+                    color: isActive ? AppTheme.primaryColor : Colors.grey[300],
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                );
+              }),
+            ),
+          ),
+        // ── 에러 (부분 결과 있을 때) ────────────────────────
+        if (hasResults && widget.error != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: _ErrorCard(error: widget.error!, onRetry: widget.onRetry),
+          ),
       ],
     );
   }
 }
 
 class _LoadingCard extends StatelessWidget {
+  const _LoadingCard();
+
   @override
   Widget build(BuildContext context) {
     return Card(

--- a/flutter_app/lib/services/recommendation_service.dart
+++ b/flutter_app/lib/services/recommendation_service.dart
@@ -24,27 +24,40 @@ class RecommendationService {
         .toList();
   }
 
-  static Future<RecommendationResult> recommend(RecommendationRequest request) async {
-    final uri = Uri.parse('${ApiConfig.aiBaseUrl}/recommend');
+  static Stream<RecommendationResult> recommendStream(RecommendationRequest request) async* {
+    final client = http.Client();
+    try {
+      final uri = Uri.parse('${ApiConfig.aiBaseUrl}/recommend');
+      final httpRequest = http.Request('POST', uri)
+        ..headers['Content-Type'] = 'application/json; charset=utf-8'
+        ..body = jsonEncode(request.toJson());
 
-    final response = await http
-        .post(
-          uri,
-          headers: {'Content-Type': 'application/json'},
-          body: jsonEncode(request.toJson()),
-        )
-        .timeout(
-          const Duration(seconds: 120),
-          onTimeout: () => throw Exception('AI 서버 응답 시간 초과 (120초)'),
-        );
+      final streamedResponse = await client.send(httpRequest).timeout(
+        const Duration(seconds: 180),
+        onTimeout: () => throw Exception('AI 서버 응답 시간 초과 (180초)'),
+      );
 
-    if (response.statusCode != 200) {
-      final body = jsonDecode(response.body);
-      throw Exception(body['detail'] ?? 'AI 추천 실패 (${response.statusCode})');
+      if (streamedResponse.statusCode != 200) {
+        final body = await streamedResponse.stream.bytesToString();
+        final decoded = jsonDecode(body);
+        throw Exception(decoded['detail'] ?? 'AI 추천 실패 (${streamedResponse.statusCode})');
+      }
+
+      final lines = streamedResponse.stream
+          .transform(utf8.decoder)
+          .transform(const LineSplitter());
+
+      await for (final line in lines) {
+        if (!line.startsWith('data: ')) continue;
+        final data = line.substring(6);
+        if (data == '[DONE]') return;
+        final decoded = jsonDecode(data) as Map<String, dynamic>;
+        if (decoded.containsKey('error')) throw Exception(decoded['error']);
+        yield RecommendationResult.fromJson(decoded);
+      }
+    } finally {
+      client.close();
     }
-
-    final json = jsonDecode(utf8.decode(response.bodyBytes));
-    return RecommendationResult.fromJson(json);
   }
 
   static Future<void> saveFeedback(int menuId, int feedbackScore, String? jwt) async {


### PR DESCRIPTION
## 변경 사항

### Python (ai_agent_app)

**RecipeGraph.py**
- `stream_analyze` async generator 추가
  - 기존 `asyncio.gather`(전체 완료 대기) 대신 `asyncio.as_completed`로 완료 순서대로 yield
  - 기존 `analyze_node`는 피드백 재추천 경로에서 그대로 사용

**recommendation_engine.py**
- `stream_initial_recommendations` async generator 추가
  - filter → candidate → price → rank 노드를 직접 순차 호출 후 `stream_analyze` yield
  - 기존 `get_initial_recommendations`는 피드백 경로에서 유지

**server.py**
- `/recommend` 응답을 `StreamingResponse(text/event-stream)`으로 전환
  - 각 분석 완료 시: `data: {...json...}\n\n` 전송
  - 전체 완료 시: `data: [DONE]\n\n` 전송
  - 에러 발생 시: `data: {"error": "..."}\n\n` 전송 후 종료

### Flutter (flutter_app)

**recommendation_service.dart**
- `recommend()` 제거 → `recommendStream()` 추가
  - `http.Client.send()`로 SSE 커넥션 유지
  - `utf8.decoder + LineSplitter`로 라인 파싱, `data:` prefix 처리
  - `Stream<RecommendationResult>` 반환

**recommendation_screen.dart**
- `_aiResult: RecommendationResult?` → `_aiResults:List<RecommendationResult>`
- `_fetchAiResult()`: `await for`로 스트림 수신, 도착 순서대로 `setState(() => _aiResults.add(result))`
- **PageView 캐러셀 UI**
  - `viewportFraction: 0.92`로 옆 카드 살짝 보이게
  - 로딩 중: 마지막 페이지에 스피너 placeholder + 헤더 "AI 추천 분석 중 (N/5)"
  - 완료 시: 헤더 "AI 추천 5픽", 스피너 페이지 제거 (자동 이동)
  - 하단 인디케이터 도트 (AnimatedContainer, 200ms 전환)
- `isAiPick` 판단: `_aiResults.map((r) => r.menuId).toSet()`으로 다중 픽 처리

---

## 사용자 경험 변화

| | Before | After |
|---|---|---|
| 첫 결과까지 | ~47초 대기 (전체 완료 후) | ~35초 (첫 결과 도착 즉시 카드 표시) |
| 결과 수 | 1개 | 최대 5개 순차 표시 |
| 탐색 방식 | 단일 카드 | 좌우 스와이프 |

> 첫 결과까지 ~35초는 filter → candidate → price → rank 순차 파이프라인시간이며, 이후 결과는 분석 완료 순서대로 도착합니다.

---

## 테스트 항목

- [ ] `/recommend` POST → `Content-Type: text/event-stream` 확인
- [ ] SSE 이벤트 5개 순차 수신 확인 (curl 또는 Postman SSE 모드)
- [ ] Flutter: 첫 카드 도착 전 스피너 표시
- [ ] Flutter: 카드 도착 시마다 PageView에 추가되는 것 확인
- [ ] Flutter: 스와이프로 카드 전환 및 인디케이터 동작 확인
- [ ] Flutter: 로딩 완료 후 스피너 페이지 자동 제거 확인
- [ ] 피드백(싫어요) 및 재추천(`/feedback`) 기존 동작 유지 확인
