### PR TITLE
feat: KAMIS API를 활용한 시세 탭 구현

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/controller/IngredientPriceController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/controller/IngredientPriceController.java
@@ -36,6 +36,15 @@ public class IngredientPriceController {
     }
 
     /**
+     * 전체 재료 최신 가격 목록 조회
+     * GET /api/v1/ingredients/prices/all
+     */
+    @GetMapping("/all")
+    public ResponseEntity<ApiResponse<List<IngredientPriceResponse>>> getAllPrices() {
+        return ResponseEntity.ok(ApiResponse.ok(service.getAllLatest()));
+    }
+
+    /**
      * 단일 재료의 최신 가격 조회
      * GET /api/v1/ingredients/prices?name=양파
      */

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/IngredientPriceResponse.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/IngredientPriceResponse.java
@@ -12,7 +12,10 @@ public record IngredientPriceResponse(
         String originalUnit,
         String marketName,
         String marketType,
-        LocalDateTime baseDate
+        LocalDateTime baseDate,
+        Double dayChangeRate,
+        Double weekChangeRate,
+        Double monthChangeRate
 ) {
     public static IngredientPriceResponse from(IngredientPrice price) {
         return new IngredientPriceResponse(
@@ -23,7 +26,15 @@ public record IngredientPriceResponse(
                 price.getOriginalUnit(),
                 price.getMarketName(),
                 price.getMarketType(),
-                price.getBaseDate()
+                price.getBaseDate(),
+                calcChangeRate(price.getOriginalPrice(), price.getPrevDayPrice()),
+                calcChangeRate(price.getOriginalPrice(), price.getPrevWeekPrice()),
+                calcChangeRate(price.getOriginalPrice(), price.getPrevMonthPrice())
         );
+    }
+
+    private static Double calcChangeRate(Integer current, Integer prev) {
+        if (current == null || prev == null || prev == 0) return null;
+        return Math.round((current - prev) * 1000.0 / prev) / 10.0;
     }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/entity/IngredientPrice.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/entity/IngredientPrice.java
@@ -35,4 +35,8 @@ public class IngredientPrice extends BaseEntity {
 
     @Column(nullable = false)
     private LocalDateTime baseDate;
+
+    private Integer prevDayPrice;
+    private Integer prevWeekPrice;
+    private Integer prevMonthPrice;
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/IngredientPriceRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/IngredientPriceRepository.java
@@ -17,4 +17,15 @@ public interface IngredientPriceRepository extends JpaRepository<IngredientPrice
             ORDER BY ip.baseDate DESC, ip.id DESC
             """)
     List<IngredientPrice> findLatestByIngredientName(@Param("name") String name, Pageable pageable);
+
+    @Query("""
+            SELECT ip FROM IngredientPrice ip
+            JOIN FETCH ip.ingredient i
+            WHERE ip.id IN (
+                SELECT MAX(ip2.id) FROM IngredientPrice ip2
+                GROUP BY ip2.ingredient.id
+            )
+            ORDER BY i.name ASC
+            """)
+    List<IngredientPrice> findAllLatest();
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/service/IngredientPriceService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/service/IngredientPriceService.java
@@ -19,6 +19,12 @@ public class IngredientPriceService {
 
     private final IngredientPriceRepository repository;
 
+    public List<IngredientPriceResponse> getAllLatest() {
+        return repository.findAllLatest().stream()
+                .map(IngredientPriceResponse::from)
+                .toList();
+    }
+
     public Optional<IngredientPriceResponse> getLatestByName(String name) {
         List<IngredientPrice> results = repository.findLatestByIngredientName(name, PageRequest.of(0, 1));
         return results.isEmpty() ? Optional.empty() : Optional.of(IngredientPriceResponse.from(results.get(0)));

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/entity/IngredientPrice.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/entity/IngredientPrice.java
@@ -54,10 +54,18 @@ public class IngredientPrice extends BaseEntity {
     @Column(name = "last_sync_at")
     private LocalDateTime lastSyncAt; // 배치 실행 확인용 — 가격 변동 없어도 항상 갱신
 
-    public void updatePrice(double pricePerGram, Integer originalPrice, String originalUnit) {
+    private Integer prevDayPrice;   // dpr2: 1일전 가격 (원본 단위)
+    private Integer prevWeekPrice;  // dpr3: 1주일전 가격 (원본 단위)
+    private Integer prevMonthPrice; // dpr5: 1개월전 가격 (원본 단위)
+
+    public void updatePrice(double pricePerGram, Integer originalPrice, String originalUnit,
+                            Integer prevDayPrice, Integer prevWeekPrice, Integer prevMonthPrice) {
         this.pricePerGram = pricePerGram;
         this.originalPrice = originalPrice;
         this.originalUnit = originalUnit;
+        this.prevDayPrice = prevDayPrice;
+        this.prevWeekPrice = prevWeekPrice;
+        this.prevMonthPrice = prevMonthPrice;
         this.lastSyncAt = LocalDateTime.now();
     }
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisNaturePriceListXmlParser.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisNaturePriceListXmlParser.java
@@ -55,6 +55,9 @@ public class KamisNaturePriceListXmlParser {
 				String unit = textContent(el, "unit"); // 단위
 				String lastestDay = textContent(el, "lastest_day"); // 실제 조사 날짜 (yyyy-MM-dd)
 				String dpr1 = textContent(el, "dpr1"); // 당일 가격
+				String dpr2 = textContent(el, "dpr2"); // 1일전 가격
+				String dpr3 = textContent(el, "dpr3"); // 1주일전 가격
+				String dpr5 = textContent(el, "dpr5"); // 1개월전 가격
 
 				// 가격이나 코드가 없으면(또는 "-" 처리되어 있으면) 스킵
 				if ((dpr1 == null || dpr1.isBlank() || "-".equals(dpr1)) || productno == null) {
@@ -68,7 +71,10 @@ public class KamisNaturePriceListXmlParser {
 						itemName,
 						unit,
 						lastestDay,
-						dpr1));
+						dpr1,
+						dpr2,
+						dpr3,
+						dpr5));
 			}
 
 			return new ParsedKamisResponse(errorCode, errorMsg, items);
@@ -108,5 +114,8 @@ public class KamisNaturePriceListXmlParser {
 			String itemName,
 			String unit,
 			String lastestDay,
-			String dpr1) {}
+			String dpr1,
+			String dpr2,
+			String dpr3,
+			String dpr5) {}
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisPriceUpdateService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisPriceUpdateService.java
@@ -98,6 +98,9 @@ public class KamisPriceUpdateService {
                         row.marketName(),
                         row.marketType(),
                         row.baseDate(),
+                        row.prevDayPrice(),
+                        row.prevWeekPrice(),
+                        row.prevMonthPrice(),
                         forceUpdate);
 
                 switch (outcome) {
@@ -122,8 +125,12 @@ public class KamisPriceUpdateService {
         LocalDateTime baseDate = parseKamisDate(item.lastestDay());
         String marketName = item.productClsName();
         String marketType = item.categoryName();
+        Integer prevDayPrice = parsePrice(item.dpr2());
+        Integer prevWeekPrice = parsePrice(item.dpr3());
+        Integer prevMonthPrice = parsePrice(item.dpr5());
 
-        return new NormalizedRow(ingredient, pricePerGram, originalPrice, originalUnit, marketName, marketType, baseDate);
+        return new NormalizedRow(ingredient, pricePerGram, originalPrice, originalUnit,
+                marketName, marketType, baseDate, prevDayPrice, prevWeekPrice, prevMonthPrice);
     }
 
     private LocalDateTime parseKamisDate(String day1) {
@@ -177,7 +184,10 @@ public class KamisPriceUpdateService {
             String originalUnit,
             String marketName,
             String marketType,
-            LocalDateTime baseDate) {}
+            LocalDateTime baseDate,
+            Integer prevDayPrice,
+            Integer prevWeekPrice,
+            Integer prevMonthPrice) {}
 
     private enum UpsertOutcome { INSERTED, UPDATED, SKIPPED }
 
@@ -189,6 +199,9 @@ public class KamisPriceUpdateService {
             String marketName,
             String marketType,
             LocalDateTime baseDate,
+            Integer prevDayPrice,
+            Integer prevWeekPrice,
+            Integer prevMonthPrice,
             boolean forceUpdate) {
 
         var existing = ingredientPriceRepository
@@ -210,6 +223,9 @@ public class KamisPriceUpdateService {
                     .marketName(marketName)
                     .marketType(marketType)
                     .baseDate(baseDate)
+                    .prevDayPrice(prevDayPrice)
+                    .prevWeekPrice(prevWeekPrice)
+                    .prevMonthPrice(prevMonthPrice)
                     .build());
             return UpsertOutcome.INSERTED;
         }
@@ -219,7 +235,7 @@ public class KamisPriceUpdateService {
             return UpsertOutcome.SKIPPED;
         }
 
-        old.updatePrice(pricePerGram, originalPrice, originalUnit);
+        old.updatePrice(pricePerGram, originalPrice, originalUnit, prevDayPrice, prevWeekPrice, prevMonthPrice);
         ingredientPriceRepository.save(old);
         return UpsertOutcome.UPDATED;
     }

--- a/flutter_app/lib/models/market_price_models.dart
+++ b/flutter_app/lib/models/market_price_models.dart
@@ -6,6 +6,9 @@ class IngredientPriceModel {
   final String? marketName;
   final String? marketType;
   final DateTime baseDate;
+  final double? dayChangeRate;
+  final double? weekChangeRate;
+  final double? monthChangeRate;
 
   const IngredientPriceModel({
     required this.ingredientName,
@@ -15,6 +18,9 @@ class IngredientPriceModel {
     this.marketName,
     this.marketType,
     required this.baseDate,
+    this.dayChangeRate,
+    this.weekChangeRate,
+    this.monthChangeRate,
   });
 
   factory IngredientPriceModel.fromJson(Map<String, dynamic> json) {
@@ -26,6 +32,9 @@ class IngredientPriceModel {
       marketName: json['marketName'] as String?,
       marketType: json['marketType'] as String?,
       baseDate: DateTime.parse(json['baseDate'] as String),
+      dayChangeRate: (json['dayChangeRate'] as num?)?.toDouble(),
+      weekChangeRate: (json['weekChangeRate'] as num?)?.toDouble(),
+      monthChangeRate: (json['monthChangeRate'] as num?)?.toDouble(),
     );
   }
 

--- a/flutter_app/lib/models/market_price_models.dart
+++ b/flutter_app/lib/models/market_price_models.dart
@@ -1,0 +1,52 @@
+class IngredientPriceModel {
+  final String ingredientName;
+  final double pricePerGram;
+  final int? originalPrice;
+  final String? originalUnit;
+  final String? marketName;
+  final String? marketType;
+  final DateTime baseDate;
+
+  const IngredientPriceModel({
+    required this.ingredientName,
+    required this.pricePerGram,
+    this.originalPrice,
+    this.originalUnit,
+    this.marketName,
+    this.marketType,
+    required this.baseDate,
+  });
+
+  factory IngredientPriceModel.fromJson(Map<String, dynamic> json) {
+    return IngredientPriceModel(
+      ingredientName: json['ingredientName'] as String,
+      pricePerGram: (json['pricePerGram'] as num).toDouble(),
+      originalPrice: json['originalPrice'] as int?,
+      originalUnit: json['originalUnit'] as String?,
+      marketName: json['marketName'] as String?,
+      marketType: json['marketType'] as String?,
+      baseDate: DateTime.parse(json['baseDate'] as String),
+    );
+  }
+
+  String get displayPrice {
+    if (originalPrice != null && originalUnit != null) {
+      return '${_formatNumber(originalPrice!)}원 / $originalUnit';
+    }
+    return '${_formatNumber((pricePerGram * 1000).round())}원 / 1kg';
+  }
+
+  String get displayDate {
+    return '${baseDate.month}/${baseDate.day} ${baseDate.hour}시 기준';
+  }
+
+  static String _formatNumber(int n) {
+    final s = n.toString();
+    final buf = StringBuffer();
+    for (int i = 0; i < s.length; i++) {
+      if (i > 0 && (s.length - i) % 3 == 0) buf.write(',');
+      buf.write(s[i]);
+    }
+    return buf.toString();
+  }
+}

--- a/flutter_app/lib/screens/main_screen.dart
+++ b/flutter_app/lib/screens/main_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'dashboard_screen.dart';
+import 'market_price_screen.dart';
 import 'mypage_screen.dart';
 import 'package:flutter_app/theme.dart';
 
@@ -16,6 +17,7 @@ class _MainScreenState extends State<MainScreen> {
   // 탭별로 보여줄 화면 목록
   static const List<Widget> _widgetOptions = <Widget>[
     DashboardScreen(),
+    MarketPriceScreen(),
     MyPageScreen(),
   ];
 
@@ -59,7 +61,6 @@ class _MainScreenState extends State<MainScreen> {
             items: <BottomNavigationBarItem>[
               BottomNavigationBarItem(
                 icon: const Icon(Icons.home_filled),
-                // 💡 선택된 아이콘에 ShaderMask를 씌워 그라데이션 적용!
                 activeIcon: ShaderMask(
                   blendMode: BlendMode.srcIn,
                   shaderCallback: (Rect bounds) {
@@ -70,8 +71,18 @@ class _MainScreenState extends State<MainScreen> {
                 label: '대시보드',
               ),
               BottomNavigationBarItem(
+                icon: const Icon(Icons.storefront_outlined),
+                activeIcon: ShaderMask(
+                  blendMode: BlendMode.srcIn,
+                  shaderCallback: (Rect bounds) {
+                    return AppTheme.aiGradient.createShader(bounds);
+                  },
+                  child: const Icon(Icons.storefront),
+                ),
+                label: '시세',
+              ),
+              BottomNavigationBarItem(
                 icon: const Icon(Icons.person),
-                // 💡 마이페이지 활성화 아이콘에도 동일한 그라데이션 적용
                 activeIcon: ShaderMask(
                   blendMode: BlendMode.srcIn,
                   shaderCallback: (Rect bounds) {

--- a/flutter_app/lib/screens/market_price_detail_screen.dart
+++ b/flutter_app/lib/screens/market_price_detail_screen.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/models/market_price_models.dart';
+import 'package:flutter_app/theme.dart';
+
+class MarketPriceDetailScreen extends StatelessWidget {
+  final IngredientPriceModel price;
+
+  const MarketPriceDetailScreen({super.key, required this.price});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.backgroundColor,
+      body: SafeArea(
+        child: Column(
+          children: [
+            _buildTopBar(context),
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(24, 8, 24, 24),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildPriceHeroCard(),
+                    const SizedBox(height: 16),
+                    _buildChangeRatesCard(),
+                    const SizedBox(height: 16),
+                    _buildMarketInfoCard(),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTopBar(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(8, 12, 24, 4),
+      child: Row(
+        children: [
+          IconButton(
+            icon: const Icon(Icons.arrow_back_ios_new_rounded),
+            onPressed: () => Navigator.pop(context),
+          ),
+          Expanded(
+            child: Text(
+              price.ingredientName,
+              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w800),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPriceHeroCard() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        gradient: AppTheme.aiGradient,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '현재 시세',
+            style: TextStyle(
+              fontSize: 13,
+              color: Colors.white.withValues(alpha: 0.8),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            price.displayPrice,
+            style: const TextStyle(
+              fontSize: 26,
+              fontWeight: FontWeight.w900,
+              color: Colors.white,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            price.displayDate,
+            style: TextStyle(
+              fontSize: 12,
+              color: Colors.white.withValues(alpha: 0.75),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChangeRatesCard() {
+    final hasAny = price.dayChangeRate != null ||
+        price.weekChangeRate != null ||
+        price.monthChangeRate != null;
+    if (!hasAny) return const SizedBox.shrink();
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.04),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '가격 변동률',
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: Colors.black87,
+            ),
+          ),
+          const SizedBox(height: 16),
+          if (price.dayChangeRate != null)
+            _buildRateBar('전일 대비', price.dayChangeRate!),
+          if (price.weekChangeRate != null) ...[
+            const SizedBox(height: 14),
+            _buildRateBar('1주일 전 대비', price.weekChangeRate!),
+          ],
+          if (price.monthChangeRate != null) ...[
+            const SizedBox(height: 14),
+            _buildRateBar('1개월 전 대비', price.monthChangeRate!),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRateBar(String label, double rate) {
+    final isPositive = rate > 0;
+    final isZero = rate == 0;
+    final color = isZero
+        ? Colors.grey
+        : (isPositive ? const Color(0xFFE53935) : const Color(0xFF1E88E5));
+    final fill = (rate.abs() / 30.0).clamp(0.0, 1.0);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              label,
+              style: const TextStyle(fontSize: 12, color: Colors.black54),
+            ),
+            Text(
+              isZero
+                  ? '변동 없음'
+                  : '${isPositive ? '+' : ''}${rate.toStringAsFixed(1)}%',
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: color,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: LinearProgressIndicator(
+            value: fill,
+            minHeight: 6,
+            backgroundColor: color.withValues(alpha: 0.1),
+            valueColor: AlwaysStoppedAnimation<Color>(color),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMarketInfoCard() {
+    if (price.marketName == null && price.marketType == null) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.04),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '시장 정보',
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: Colors.black87,
+            ),
+          ),
+          const SizedBox(height: 14),
+          if (price.marketName != null) _buildInfoRow('시장명', price.marketName!),
+          if (price.marketType != null) ...[
+            const SizedBox(height: 10),
+            _buildInfoRow('유형', price.marketType!),
+          ],
+          const SizedBox(height: 10),
+          _buildInfoRow('기준일', price.displayDate),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(String label, String value) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 64,
+          child: Text(
+            label,
+            style: const TextStyle(fontSize: 13, color: Colors.black54),
+          ),
+        ),
+        Expanded(
+          child: Text(
+            value,
+            style: const TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: Colors.black87,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/flutter_app/lib/screens/market_price_screen.dart
+++ b/flutter_app/lib/screens/market_price_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_app/models/market_price_models.dart';
+import 'package:flutter_app/screens/market_price_detail_screen.dart';
 import 'package:flutter_app/services/market_price_service.dart';
 import 'package:flutter_app/theme.dart';
 
@@ -173,13 +174,19 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
       );
     }
 
+    final bool showSummary = _allPrices.any((p) => p.dayChangeRate != null);
+
     return RefreshIndicator(
       color: AppTheme.primaryColor,
       onRefresh: _loadPrices,
       child: ListView.builder(
         padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
-        itemCount: _filtered.length,
-        itemBuilder: (context, index) => _buildPriceCard(_filtered[index]),
+        itemCount: _filtered.length + (showSummary ? 1 : 0),
+        itemBuilder: (context, index) {
+          if (showSummary && index == 0) return _buildSummarySection();
+          final item = _filtered[showSummary ? index - 1 : index];
+          return _buildPriceCard(item);
+        },
       ),
     );
   }
@@ -219,8 +226,118 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
     );
   }
 
-  Widget _buildPriceCard(IngredientPriceModel price) {
+  Widget _buildSummarySection() {
+    final withRates = _allPrices.where((p) => p.dayChangeRate != null).toList();
+    final topUp = (withRates.where((p) => p.dayChangeRate! > 0).toList()
+          ..sort((a, b) => b.dayChangeRate!.compareTo(a.dayChangeRate!)))
+        .take(3)
+        .toList();
+    final topDown = (withRates.where((p) => p.dayChangeRate! < 0).toList()
+          ..sort((a, b) => a.dayChangeRate!.compareTo(b.dayChangeRate!)))
+        .take(3)
+        .toList();
+
+    if (topUp.isEmpty && topDown.isEmpty) return const SizedBox.shrink();
+
     return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.04),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '오늘의 주요 변동',
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: Colors.black54,
+            ),
+          ),
+          const SizedBox(height: 10),
+          if (topUp.isNotEmpty)
+            Wrap(
+              spacing: 6,
+              runSpacing: 6,
+              children: topUp.map((p) => _buildSummaryChip(p, true)).toList(),
+            ),
+          if (topUp.isNotEmpty && topDown.isNotEmpty) const SizedBox(height: 6),
+          if (topDown.isNotEmpty)
+            Wrap(
+              spacing: 6,
+              runSpacing: 6,
+              children: topDown.map((p) => _buildSummaryChip(p, false)).toList(),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSummaryChip(IngredientPriceModel price, bool isUp) {
+    final color = isUp ? const Color(0xFFE53935) : const Color(0xFF1E88E5);
+    final icon = isUp ? Icons.arrow_upward : Icons.arrow_downward;
+    final rate = price.dayChangeRate!.abs().toStringAsFixed(1);
+    return GestureDetector(
+      onTap: () => Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => MarketPriceDetailScreen(price: price),
+        ),
+      ),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: color.withValues(alpha: 0.2)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 11, color: color),
+            const SizedBox(width: 3),
+            Text(
+              price.ingredientName,
+              style: const TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: Colors.black87,
+              ),
+            ),
+            const SizedBox(width: 4),
+            Text(
+              '$rate%',
+              style: TextStyle(
+                fontSize: 11,
+                color: color,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPriceCard(IngredientPriceModel price) {
+    return GestureDetector(
+      onTap: () => Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => MarketPriceDetailScreen(price: price),
+        ),
+      ),
+      child: Container(
       margin: const EdgeInsets.only(bottom: 10),
       padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
       decoration: BoxDecoration(
@@ -293,6 +410,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
           ),
         ],
       ),
+    ),
     );
   }
 }

--- a/flutter_app/lib/screens/market_price_screen.dart
+++ b/flutter_app/lib/screens/market_price_screen.dart
@@ -1,0 +1,260 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/models/market_price_models.dart';
+import 'package:flutter_app/services/market_price_service.dart';
+import 'package:flutter_app/theme.dart';
+
+class MarketPriceScreen extends StatefulWidget {
+  const MarketPriceScreen({super.key});
+
+  @override
+  State<MarketPriceScreen> createState() => _MarketPriceScreenState();
+}
+
+class _MarketPriceScreenState extends State<MarketPriceScreen> {
+  List<IngredientPriceModel> _allPrices = [];
+  List<IngredientPriceModel> _filtered = [];
+  bool _isLoading = true;
+  String? _error;
+  final TextEditingController _searchController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPrices();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadPrices() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final prices = await MarketPriceService.getAllPrices();
+      setState(() {
+        _allPrices = prices;
+        _filtered = prices;
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _error = e.toString();
+        _isLoading = false;
+      });
+    }
+  }
+
+  void _onSearch(String query) {
+    final q = query.trim();
+    setState(() {
+      _filtered = q.isEmpty
+          ? _allPrices
+          : _allPrices
+              .where((p) => p.ingredientName.contains(q))
+              .toList();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.backgroundColor,
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(),
+            _buildSearchBar(),
+            Expanded(child: _buildBody()),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 24, 24, 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ShaderMask(
+            blendMode: BlendMode.srcIn,
+            shaderCallback: (bounds) => AppTheme.aiGradient.createShader(bounds),
+            child: const Text(
+              '오늘의 시세',
+              style: TextStyle(fontSize: 28, fontWeight: FontWeight.w900),
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'KAMIS 실시간 농수산물 가격 정보',
+            style: TextStyle(fontSize: 14, color: Colors.grey[500]),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchBar() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 8, 24, 16),
+      child: TextField(
+        controller: _searchController,
+        onChanged: _onSearch,
+        decoration: InputDecoration(
+          hintText: '재료명 검색 (예: 감자, 양파)',
+          hintStyle: TextStyle(color: Colors.grey[400], fontSize: 14),
+          prefixIcon: Icon(Icons.search, color: Colors.grey[400]),
+          suffixIcon: _searchController.text.isNotEmpty
+              ? IconButton(
+                  icon: Icon(Icons.clear, color: Colors.grey[400]),
+                  onPressed: () {
+                    _searchController.clear();
+                    _onSearch('');
+                  },
+                )
+              : null,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading) {
+      return const Center(
+        child: CircularProgressIndicator(
+          color: AppTheme.primaryColor,
+        ),
+      );
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline, size: 48, color: Colors.grey[400]),
+            const SizedBox(height: 12),
+            Text(
+              '데이터를 불러오지 못했습니다',
+              style: TextStyle(color: Colors.grey[600], fontSize: 15),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _loadPrices,
+              child: const Text('다시 시도'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (_filtered.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.search_off, size: 48, color: Colors.grey[400]),
+            const SizedBox(height: 12),
+            Text(
+              _searchController.text.isNotEmpty
+                  ? "'${_searchController.text}'에 대한 시세 정보가 없습니다"
+                  : '시세 정보가 없습니다',
+              style: TextStyle(color: Colors.grey[600], fontSize: 15),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      color: AppTheme.primaryColor,
+      onRefresh: _loadPrices,
+      child: ListView.builder(
+        padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
+        itemCount: _filtered.length,
+        itemBuilder: (context, index) => _buildPriceCard(_filtered[index]),
+      ),
+    );
+  }
+
+  Widget _buildPriceCard(IngredientPriceModel price) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 10),
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.04),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: AppTheme.primaryColor.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: const Icon(
+              Icons.storefront_outlined,
+              color: AppTheme.primaryColor,
+              size: 20,
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  price.ingredientName,
+                  style: const TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                    color: Colors.black87,
+                  ),
+                ),
+                const SizedBox(height: 3),
+                Text(
+                  price.marketName != null ? price.marketName! : '',
+                  style: TextStyle(fontSize: 12, color: Colors.grey[500]),
+                ),
+              ],
+            ),
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                price.displayPrice,
+                style: const TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                  color: Colors.black87,
+                ),
+              ),
+              const SizedBox(height: 3),
+              Text(
+                price.displayDate,
+                style: TextStyle(fontSize: 11, color: Colors.grey[400]),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/screens/market_price_screen.dart
+++ b/flutter_app/lib/screens/market_price_screen.dart
@@ -184,6 +184,41 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
     );
   }
 
+  Widget _buildChangeRateBadge(double rate) {
+    final isPositive = rate > 0;
+    final isZero = rate == 0;
+    final color = isZero
+        ? Colors.grey
+        : (isPositive ? const Color(0xFFE53935) : const Color(0xFF1E88E5));
+    final icon = isZero
+        ? Icons.remove
+        : (isPositive ? Icons.arrow_upward : Icons.arrow_downward);
+    final label = isZero ? '변동없음' : '${rate.abs().toStringAsFixed(1)}% 전일대비';
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 10, color: color),
+          const SizedBox(width: 2),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 10,
+              color: color,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildPriceCard(IngredientPriceModel price) {
     return Container(
       margin: const EdgeInsets.only(bottom: 10),
@@ -247,10 +282,13 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
                 ),
               ),
               const SizedBox(height: 3),
-              Text(
-                price.displayDate,
-                style: TextStyle(fontSize: 11, color: Colors.grey[400]),
-              ),
+              if (price.dayChangeRate != null)
+                _buildChangeRateBadge(price.dayChangeRate!)
+              else
+                Text(
+                  price.displayDate,
+                  style: TextStyle(fontSize: 11, color: Colors.grey[400]),
+                ),
             ],
           ),
         ],

--- a/flutter_app/lib/services/market_price_service.dart
+++ b/flutter_app/lib/services/market_price_service.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+
+import 'package:flutter_app/models/market_price_models.dart';
+import 'package:flutter_app/services/auth_service.dart';
+import 'package:flutter_app/services/token_storage.dart';
+import 'package:http/http.dart' as http;
+
+class MarketPriceService {
+  static const String _basePath = '/api/v1/ingredients/prices';
+
+  static Future<Map<String, String>> _headers() async {
+    final headers = <String, String>{'Content-Type': 'application/json'};
+    final token = await TokenStorage.getAccessToken();
+    if (token != null && token.isNotEmpty) {
+      headers['Authorization'] = 'Bearer $token';
+    }
+    return headers;
+  }
+
+  static Future<List<IngredientPriceModel>> getAllPrices() async {
+    final uri = Uri.parse('${ApiConfig.baseUrl}$_basePath/all');
+    final response = await http
+        .get(uri, headers: await _headers())
+        .timeout(const Duration(seconds: 10));
+    if (response.statusCode == 200) {
+      final body = jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>;
+      final data = body['data'] as List<dynamic>;
+      return data
+          .map((e) => IngredientPriceModel.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    throw Exception('시세 데이터를 불러오지 못했습니다.');
+  }
+}


### PR DESCRIPTION
## Summary

KAMIS API에서 수집한 식재료 시세 데이터를 앱에서 직접 확인할 수 있는 시세 탭을 추가합니다.
전일/주간/월간 변동률을 파싱하여 저장하고, Flutter에서 검색·요약·상세 화면으로 제공합니다.

## 변경 내용

### 배치 서버 (ai-meal-assistant-batch)
- `KamisNaturePriceListXmlParser`: XML에서 전일(dpr2) / 1주일전(dpr3) / 1개월전(dpr5) 가격 파싱 추가
- `KamisPriceUpdateService`: 파싱된 변동 가격을 DB에 저장하도록 NormalizedRow 및 upsert 로직 확장
- `IngredientPrice` 엔티티: `prevDayPrice`, `prevWeekPrice`, `prevMonthPrice` 컬럼 추가

### 백엔드 서버 (ai-meal-assistant-backend)
- `IngredientPrice` 엔티티: 배치와 동일하게 변동 가격 3개 필드 추가
- `IngredientPriceRepository`: 재료별 최신 가격 1건씩 조회하는 `findAllLatest()` 쿼리 추가
- `IngredientPriceService`: `getAllLatest()` 메서드 추가
- `IngredientPriceController`: `GET /api/v1/ingredients/prices/all` 엔드포인트 추가
- `IngredientPriceResponse`: `dayChangeRate` / `weekChangeRate` / `monthChangeRate` 필드 추가, 변동률 계산 로직 포함

### Flutter (flutter_app)
- `market_price_models.dart` (신규): 변동률 포함 `IngredientPriceModel` 정의, 가격/날짜 포맷 헬퍼
- `market_price_service.dart` (신규): Spring `GET /api/v1/ingredients/prices/all` 호출
- `market_price_screen.dart` (신규): 시세 탭 메인 화면
  - 재료명 검색 (실시간 필터)
  - 오늘의 주요 변동 요약 섹션 (상승/하락 Top 3 칩)
  - 가격 카드 목록 + 전일 변동률 뱃지
  - 새로고침 지원
- `market_price_detail_screen.dart` (신규): 재료별 상세 화면
  - 현재 시세 히어로 카드 (그라데이션)
  - 전일 / 주간 / 월간 변동률 바 차트
  - 시장명 · 유형 · 기준일 정보
- `main_screen.dart`: 하단 탭바에 '시세' 탭(storefront 아이콘) 추가

## 참고

- 변동률 계산: `(현재가 - 기준가) / 기준가 × 100`, 소수점 1자리 반올림
- 배치 재시작 전에는 `prevDayPrice` 등이 NULL → 변동률 미표시로 처리
- `findAllLatest()`: 재료별 `MAX(id)` 서브쿼리로 최신 1건만 조회

## Test plan

- [ ] 배치 실행 후 `ingredient_prices` 테이블에 `prev_day_price` 등 컬럼이 채워지는지 확인
- [ ] `GET /api/v1/ingredients/prices/all` 응답에 `dayChangeRate` 포함되는지 확인
- [ ] Flutter 시세 탭 진입 → 가격 목록 로드 확인
- [ ] 재료명 검색 필터 동작 확인
- [ ] 변동률 있는 항목에서 요약 섹션 표시 확인
- [ ] 카드 탭 → 상세 화면 이동 확인
- [ ] 배치 미실행 상태(변동률 NULL)에서도 화면 정상 표시 확인