### PR TITLE
feat: 배치 서버 시작 시 menu_allergies 자동 매핑 구현 (#101)

### DIFF
--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/controller/AdminDataController.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/controller/AdminDataController.java
@@ -19,4 +19,10 @@ public class AdminDataController {
         syncService.syncAllDataFromApi();
         return ResponseEntity.ok("레시피 데이터 동기화가 성공적으로 완료되었습니다!");
     }
+
+    @PostMapping("/sync-allergies")
+    public ResponseEntity<String> syncAllergies(){
+        syncService.syncAllergyMappings();
+        return ResponseEntity.ok("메뉴-알레르기 매핑이 성공적으로 완료되었습니다!");
+    }
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
@@ -5,8 +5,12 @@ import capstone.ai_meal_assistant_batch.domain.etl.parser.RecipeDataParser;
 import capstone.ai_meal_assistant_batch.domain.ingredient.dto.IngredientDto;
 import capstone.ai_meal_assistant_batch.domain.ingredient.entity.Ingredient;
 import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientRepository;
+import capstone.ai_meal_assistant_batch.domain.menu.entity.Allergy;
 import capstone.ai_meal_assistant_batch.domain.menu.entity.Menu;
+import capstone.ai_meal_assistant_batch.domain.menu.entity.MenuAllergy;
 import capstone.ai_meal_assistant_batch.domain.menu.entity.MenuIngredient;
+import capstone.ai_meal_assistant_batch.domain.menu.repository.AllergyRepository;
+import capstone.ai_meal_assistant_batch.domain.menu.repository.MenuAllergyRepository;
 import capstone.ai_meal_assistant_batch.domain.menu.repository.MenuIngredientRepository;
 import capstone.ai_meal_assistant_batch.domain.menu.repository.MenuRepository;
 import capstone.ai_meal_assistant_batch.global.s3.S3ImageUploadService;
@@ -22,8 +26,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -35,6 +42,8 @@ public class RecipeDataSyncService {
     private final MenuRepository menuRepository;
     private final IngredientRepository ingredientRepository;
     private final MenuIngredientRepository menuIngredientRepository;
+    private final AllergyRepository allergyRepository;
+    private final MenuAllergyRepository menuAllergyRepository;
     private final ObjectMapper objectMapper;
     private final S3ImageUploadService s3ImageUploadService;
 
@@ -183,6 +192,111 @@ public class RecipeDataSyncService {
         } catch (Exception e){
             log.error("API 데이터 동기화 중 에러 발생: ", e);
         }
+    }
+
+    /**
+     * STEP 4: 메뉴-알레르기 자동 매핑
+     * menu_ingredients 재료명 키워드 기반으로 menu_allergies 테이블을 채웁니다.
+     * syncAllDataFromApi()와 독립 실행 가능 — menu_ingredients가 채워진 상태라면 언제든 호출 가능.
+     * 멱등: 이미 존재하는 (menu_id, allergy_id) 쌍은 skip.
+     */
+    @Transactional
+    public void syncAllergyMappings() {
+        log.info("[STEP 4] 메뉴-알레르기 자동 매핑 시작");
+
+        // 4-1. 키워드 → 알레르기명 맵
+        Map<String, String> keywordToAllergy = buildKeywordToAllergyMap();
+        Set<String> standardNames = new HashSet<>(keywordToAllergy.values()); // 표준 8종
+
+        // 4-0. 정리: 이전 매핑 전체 삭제 후 새로 채움 (멱등 보장)
+        menuAllergyRepository.deleteAll();
+        allergyRepository.deleteNonStandardUnreferenced(standardNames);
+        log.info("[STEP 4] 기존 menu_allergies 전체 삭제, 비표준 allergies 정리 완료");
+
+        // 4-2. allergies 테이블 seed: 없는 항목만 INSERT
+        Map<String, Allergy> allergyCache = allergyRepository.findAll().stream()
+                .collect(Collectors.toMap(Allergy::getName, a -> a));
+
+        Set<String> requiredAllergyNames = new HashSet<>(keywordToAllergy.values());
+        for (String allergyName : requiredAllergyNames) {
+            allergyCache.computeIfAbsent(allergyName, name -> {
+                Allergy newAllergy = Allergy.builder().name(name).build();
+                return allergyRepository.save(newAllergy);
+            });
+        }
+        log.info("[STEP 4] allergies 테이블: {}종 준비 완료", allergyCache.size());
+
+        // 4-3. 기존 매핑 캐시 로드 (멱등 보장)
+        Set<String> existingKeys = menuAllergyRepository.findAllKeys();
+
+        // 4-4. menu_ingredients 전체 순회 → 키워드 매칭 → menu_allergies 생성
+        List<MenuIngredient> allMenuIngredients = menuIngredientRepository.findAllWithMenuAndIngredient();
+        if (allMenuIngredients.isEmpty()) {
+            log.warn("[STEP 4] menu_ingredients 데이터 없음 — syncAllDataFromApi() 먼저 실행 필요");
+            return;
+        }
+
+        List<MenuAllergy> menuAllergiesToSave = new ArrayList<>();
+        for (MenuIngredient mi : allMenuIngredients) {
+            String ingName = mi.getIngredient().getName();
+            String allergyName = matchAllergy(ingName, keywordToAllergy);
+            if (allergyName == null) continue;
+
+            Allergy allergy = allergyCache.get(allergyName);
+            if (allergy == null) continue;
+
+            String key = mi.getMenu().getId() + "_" + allergy.getId();
+            if (existingKeys.contains(key)) continue;
+
+            menuAllergiesToSave.add(MenuAllergy.builder()
+                    .menu(mi.getMenu())
+                    .allergy(allergy)
+                    .build());
+            existingKeys.add(key); // 같은 배치 내 중복 방지
+        }
+
+        menuAllergyRepository.saveAll(menuAllergiesToSave);
+        log.info("[STEP 4] 메뉴-알레르기 매핑 완료: {}건 INSERT (총 재료 {}건 처리)", menuAllergiesToSave.size(), allMenuIngredients.size());
+    }
+
+    /**
+     * 재료명에서 알레르기 키워드 매칭 (포함 검사)
+     * 예: "땅콩버터" → "땅콩" 키워드 포함 → "땅콩" 알레르기 반환
+     */
+    private String matchAllergy(String ingredientName, Map<String, String> keywordToAllergy) {
+        for (Map.Entry<String, String> entry : keywordToAllergy.entrySet()) {
+            if (ingredientName.contains(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 키워드 → 알레르기명 매핑 테이블
+     * 한국 식품위생법 알레르기 표시 의무 22종 기준
+     */
+    private Map<String, String> buildKeywordToAllergyMap() {
+        Map<String, String> map = new HashMap<>();
+        // 우유
+        for (String kw : List.of("우유", "치즈", "버터", "크림", "요구르트", "요거트")) map.put(kw, "우유");
+        // 계란
+        for (String kw : List.of("계란", "달걀")) map.put(kw, "계란");
+        // 밀가루
+        for (String kw : List.of("밀가루", "빵가루", "글루텐")) map.put(kw, "밀가루");
+        // 대두
+        for (String kw : List.of("두부", "된장", "청국장", "두유")) map.put(kw, "대두");
+        // 땅콩
+        map.put("땅콩", "땅콩");
+        // 견과류
+        for (String kw : List.of("호두", "아몬드", "잣", "캐슈", "피스타치오", "마카다미아")) map.put(kw, "견과류");
+        // 갑각류
+        for (String kw : List.of("새우", "랍스터")) map.put(kw, "갑각류");
+        // 게 (단독 키워드 — "게살", "꽃게" 등 포함)
+        map.put("게", "갑각류");
+        // 생선
+        for (String kw : List.of("고등어", "연어", "참치", "명태", "대구", "멸치", "가자미", "조기", "갈치", "삼치")) map.put(kw, "생선");
+        return map;
     }
 
 //    공공데이터의 빈 문자열이나 이상한 값을 안전하게 0.0으로 변환해 주는 메서드

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
@@ -206,12 +206,11 @@ public class RecipeDataSyncService {
 
         // 4-1. 키워드 → 알레르기명 맵
         Map<String, String> keywordToAllergy = buildKeywordToAllergyMap();
-        Set<String> standardNames = new HashSet<>(keywordToAllergy.values()); // 표준 8종
 
-        // 4-0. 정리: 이전 매핑 전체 삭제 후 새로 채움 (멱등 보장)
+        // 4-0. 정리: menu_allergies 전체 삭제 후 새로 채움 (멱등 보장)
+        // allergies 테이블은 user_allergies FK가 있어 배치에서 직접 삭제하지 않음
         menuAllergyRepository.deleteAll();
-        allergyRepository.deleteNonStandardUnreferenced(standardNames);
-        log.info("[STEP 4] 기존 menu_allergies 전체 삭제, 비표준 allergies 정리 완료");
+        log.info("[STEP 4] 기존 menu_allergies 전체 삭제 완료");
 
         // 4-2. allergies 테이블 seed: 없는 항목만 INSERT
         Map<String, Allergy> allergyCache = allergyRepository.findAll().stream()

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/repository/AllergyRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/repository/AllergyRepository.java
@@ -2,10 +2,23 @@ package capstone.ai_meal_assistant_batch.domain.menu.repository;
 
 import capstone.ai_meal_assistant_batch.domain.menu.entity.Allergy;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
+import java.util.Set;
 
 // 알레르기 조회용
 public interface AllergyRepository extends JpaRepository<Allergy, Long> {
     Optional<Allergy> findByName(String name); // 우유, 땅콩 등으로 검색
+
+    // 표준 목록 이외이면서 user_allergies에 아무도 설정하지 않은 항목만 삭제 (FK 안전)
+    @Modifying
+    @Query(value = """
+            DELETE FROM allergies
+            WHERE name NOT IN :names
+              AND id NOT IN (SELECT allergy_id FROM user_allergies)
+            """, nativeQuery = true)
+    void deleteNonStandardUnreferenced(@Param("names") Set<String> names);
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/repository/AllergyRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/repository/AllergyRepository.java
@@ -2,23 +2,9 @@ package capstone.ai_meal_assistant_batch.domain.menu.repository;
 
 import capstone.ai_meal_assistant_batch.domain.menu.entity.Allergy;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
 import java.util.Optional;
-import java.util.Set;
 
 // 알레르기 조회용
 public interface AllergyRepository extends JpaRepository<Allergy, Long> {
     Optional<Allergy> findByName(String name); // 우유, 땅콩 등으로 검색
-
-    // 표준 목록 이외이면서 user_allergies에 아무도 설정하지 않은 항목만 삭제 (FK 안전)
-    @Modifying
-    @Query(value = """
-            DELETE FROM allergies
-            WHERE name NOT IN :names
-              AND id NOT IN (SELECT allergy_id FROM user_allergies)
-            """, nativeQuery = true)
-    void deleteNonStandardUnreferenced(@Param("names") Set<String> names);
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/repository/MenuAllergyRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/repository/MenuAllergyRepository.java
@@ -3,8 +3,10 @@ package capstone.ai_meal_assistant_batch.domain.menu.repository;
 import capstone.ai_meal_assistant_batch.domain.menu.entity.MenuAllergy;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Set;
 
 // 메뉴에 포함된 알레르기
 public interface MenuAllergyRepository extends JpaRepository<MenuAllergy, Long> {
@@ -12,4 +14,8 @@ public interface MenuAllergyRepository extends JpaRepository<MenuAllergy, Long> 
     //  N+1 방지: 메뉴 알레르기 목록을 가져올 때 실제 Allergy 이름까지 한 번에 JOIN 해서 가져옴
     @EntityGraph(attributePaths = {"allergy"})
     List<MenuAllergy> findAllByMenuId(Long menuId);
+
+    // STEP 4 멱등 보장: 기존 (menu_id, allergy_id) 쌍을 "menuId_allergyId" 문자열 Set으로 반환
+    @Query("SELECT CONCAT(ma.menu.id, '_', ma.allergy.id) FROM MenuAllergy ma")
+    Set<String> findAllKeys();
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/repository/MenuIngredientRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/repository/MenuIngredientRepository.java
@@ -3,6 +3,7 @@ package capstone.ai_meal_assistant_batch.domain.menu.repository;
 import capstone.ai_meal_assistant_batch.domain.menu.entity.MenuIngredient;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -12,4 +13,8 @@ public interface MenuIngredientRepository extends JpaRepository<MenuIngredient, 
     // 예: 제육덮밥의 재료를 꺼낼 때 Ingredient(돼지고기, 양파) 엔티티까지 한 번에 조인 (가격 계산 시 필수)
     @EntityGraph(attributePaths = {"ingredient"})
     List<MenuIngredient> findAllByMenuId(Long menuId);
+
+    // STEP 4 용: 전체 menu_ingredients를 menu·ingredient 포함해서 한 번에 조회 (N+1 방지)
+    @Query("SELECT mi FROM MenuIngredient mi JOIN FETCH mi.menu JOIN FETCH mi.ingredient")
+    List<MenuIngredient> findAllWithMenuAndIngredient();
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/seed/AllergySeedCommand.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/seed/AllergySeedCommand.java
@@ -1,0 +1,39 @@
+package capstone.ai_meal_assistant_batch.job.seed;
+
+import java.time.Instant;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import capstone.ai_meal_assistant_batch.domain.ingredient.service.RecipeDataSyncService;
+import capstone.ai_meal_assistant_batch.global.log.BatchLog;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 서버 시작 시 menu_allergies 자동 매핑 실행
+ * - syncAllergyMappings()는 멱등(이미 존재하는 쌍 skip)이므로 매 시작 시 안전하게 실행 가능
+ * - application.yml: batch.seed.allergies.enabled=true 로 활성화
+ */
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "batch.seed.allergies", name = "enabled", havingValue = "true")
+public class AllergySeedCommand implements ApplicationRunner {
+
+    private static final String JOB_NAME = "allergySeed";
+
+    private final RecipeDataSyncService recipeDataSyncService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Instant start = BatchLog.start(JOB_NAME);
+        try {
+            recipeDataSyncService.syncAllergyMappings();
+            BatchLog.success(JOB_NAME, start, "menu_allergies auto-mapping complete");
+        } catch (Exception e) {
+            BatchLog.fail(JOB_NAME, start, e);
+            throw e;
+        }
+    }
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/seed/IngredientSeedCommand.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/seed/IngredientSeedCommand.java
@@ -30,7 +30,8 @@ public class IngredientSeedCommand implements ApplicationRunner {
 		Instant start = BatchLog.start(JOB_NAME);
 		try {
 			recipeDataSyncService.syncAllDataFromApi();
-			BatchLog.success(JOB_NAME, start, "seeded ingredients via cleaned_recipe_data.json");
+			recipeDataSyncService.syncAllergyMappings();
+			BatchLog.success(JOB_NAME, start, "seeded ingredients + allergy mappings via cleaned_recipe_data.json");
 		} catch (Exception e) {
 			BatchLog.fail(JOB_NAME, start, e);
 			throw e;


### PR DESCRIPTION
## Summary

Spring 백엔드의 알레르기 필터링 로직(`MenuCandidateService`)이 의존하는
`menu_allergies` 테이블이 비어있어 알레르기 필터링이 동작하지 않던 문제를 해결합니다.
배치 서버 시작 시 `menu_ingredients`의 재료명을 기반으로 자동 매핑합니다.

## 변경 내용

### 배치 서버 (ai-meal-assistant-batch)

- `RecipeDataSyncService`: `syncAllergyMappings()` 독립 메서드 추가
  - 표준 8종 알레르기 seed (없는 항목만 INSERT)
  - `menu_allergies` 전체 초기화 후 재생성
  - `menu_ingredients` 재료명 키워드 기반 매핑 (포함 검사)
  - 멱등 보장: 배치 재실행 시 중복 없이 재구성

- `AllergySeedCommand`: 배치 서버 시작 시 자동 실행
  - `application.yml`에서 `batch.seed.allergies.enabled=true`로 활성화

- `IngredientSeedCommand`: 재료 적재 후 알레르기 매핑 연속 실행

- `AdminDataController`: `POST /api/admin/data/sync-allergies` 엔드포인트 추가

- `MenuIngredientRepository`: `findAllWithMenuAndIngredient()` 추가 (N+1 방지)
- `MenuAllergyRepository`: `findAllKeys()` 추가 (중복 방지용)

### 알레르기 표준 8종 및 키워드 (Flutter UI 기준)

| 알레르기 | 매핑 키워드 |
|---------|-----------|
| 우유 | 우유, 치즈, 버터, 크림, 요구르트, 요거트 |
| 계란 | 계란, 달걀 |
| 밀가루 | 밀가루, 빵가루, 글루텐 |
| 대두 | 두부, 된장, 청국장, 두유 |
| 땅콩 | 땅콩 |
| 견과류 | 호두, 아몬드, 잣, 캐슈, 피스타치오, 마카다미아 |
| 갑각류 | 새우, 게, 랍스터 |
| 생선 | 고등어, 연어, 참치, 명태, 대구, 멸치, 가자미, 조기, 갈치, 삼치 |


## 관련 이슈
- Closes #101
- Related: #99 (Python filter_node 알레르기 스트링 매칭 제거)

## Test plan
- [x] `./gradlew test` 통과
- [ ] 배치 서버 시작 후 `allergies` 테이블에 8종 존재 확인
- [ ] `menu_allergies` 테이블에 매핑 데이터 존재 확인
- [ ] 우유 알레르기 설정 후 추천 요청 시 유제품 재료 포함 메뉴 제외 확인
