### PR TITLE
feat: 마이페이지 피드백 탭 추가 - 좋아요/싫어요 이력 조회·삭제·검색 (#110)

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
@@ -1,5 +1,6 @@
 package capstone.ai_meal_assistant_backend.domain.history.controller;
 
+import capstone.ai_meal_assistant_backend.domain.history.dto.RecommendationLogResponse;
 import capstone.ai_meal_assistant_backend.domain.history.service.RecommendationLogService;
 import capstone.ai_meal_assistant_backend.global.security.JwtUtil;
 import lombok.Getter;
@@ -9,6 +10,7 @@ import lombok.Setter;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -32,6 +34,37 @@ public class RecommendationLogController {
         recommendationLogService.saveFeedback(email, request.getMenuId(),
                 request.getFeedbackScore(), request.getStarRating(), request.getFeedbackReason());
         return ResponseEntity.ok(Map.of("success", true));
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<?> getMyFeedbacks(
+            @RequestHeader(value = "Authorization", required = false) String authHeader) {
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return ResponseEntity.status(401).body(Map.of("success", false, "error", "인증이 필요합니다."));
+        }
+
+        String email = jwtUtil.getEmailFromToken(authHeader.substring(7));
+        List<RecommendationLogResponse> feedbacks = recommendationLogService.getUserFeedbacks(email);
+        return ResponseEntity.ok(Map.of("success", true, "data", feedbacks));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteFeedback(
+            @RequestHeader(value = "Authorization", required = false) String authHeader,
+            @PathVariable("id") Long id) {
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return ResponseEntity.status(401).body(Map.of("success", false, "error", "인증이 필요합니다."));
+        }
+
+        String email = jwtUtil.getEmailFromToken(authHeader.substring(7));
+        try {
+            recommendationLogService.deleteFeedback(email, id);
+            return ResponseEntity.ok(Map.of("success", true));
+        } catch (SecurityException e) {
+            return ResponseEntity.status(403).body(Map.of("success", false, "error", e.getMessage()));
+        }
     }
 
     @Getter

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/dto/RecommendationLogResponse.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/dto/RecommendationLogResponse.java
@@ -1,0 +1,20 @@
+package capstone.ai_meal_assistant_backend.domain.history.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RecommendationLogResponse {
+    private Long id;
+    private Long menuId;
+    private String menuName;
+    private String menuImageUrl;
+    private Integer feedbackScore;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDateTime createdAt;
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/repository/RecommendationLogRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/repository/RecommendationLogRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Set;
 
 @Repository
@@ -14,4 +15,7 @@ public interface RecommendationLogRepository extends JpaRepository<Recommendatio
 
     @Query("SELECT r.selectedMenu.id FROM RecommendationLog r WHERE r.user = :user AND r.feedbackScore < 0")
     Set<Long> findNegativeMenuIdsByUser(@Param("user") User user);
+
+    @Query("SELECT r FROM RecommendationLog r WHERE r.user = :user AND r.feedbackScore IS NOT NULL ORDER BY r.createdAt DESC")
+    List<RecommendationLog> findFeedbacksByUser(@Param("user") User user);
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
@@ -1,5 +1,6 @@
 package capstone.ai_meal_assistant_backend.domain.history.service;
 
+import capstone.ai_meal_assistant_backend.domain.history.dto.RecommendationLogResponse;
 import capstone.ai_meal_assistant_backend.domain.history.entity.RecommendationLog;
 import capstone.ai_meal_assistant_backend.domain.history.repository.RecommendationLogRepository;
 import capstone.ai_meal_assistant_backend.domain.menu.entity.Menu;
@@ -10,7 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -39,5 +42,33 @@ public class RecommendationLogService {
     @Transactional(readOnly = true)
     public Set<Long> getNegativeMenuIds(User user) {
         return recommendationLogRepository.findNegativeMenuIdsByUser(user);
+    }
+
+    @Transactional(readOnly = true)
+    public List<RecommendationLogResponse> getUserFeedbacks(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        return recommendationLogRepository.findFeedbacksByUser(user).stream()
+                .map(log -> RecommendationLogResponse.builder()
+                        .id(log.getId())
+                        .menuId(log.getSelectedMenu().getId())
+                        .menuName(log.getSelectedMenu().getName())
+                        .menuImageUrl(log.getSelectedMenu().getMainImageUrl())
+                        .feedbackScore(log.getFeedbackScore())
+                        .createdAt(log.getCreatedAt())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void deleteFeedback(String email, Long logId) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        RecommendationLog log = recommendationLogRepository.findById(logId)
+                .orElseThrow(() -> new IllegalArgumentException("피드백을 찾을 수 없습니다."));
+        if (!log.getUser().getId().equals(user.getId())) {
+            throw new SecurityException("권한이 없습니다.");
+        }
+        recommendationLogRepository.delete(log);
     }
 }

--- a/flutter_app/lib/models/recommendation_models.dart
+++ b/flutter_app/lib/models/recommendation_models.dart
@@ -207,6 +207,34 @@ class RecommendationResult {
       );
 }
 
+class FeedbackHistoryItem {
+  final int id;
+  final int menuId;
+  final String menuName;
+  final String? menuImageUrl;
+  final int feedbackScore;
+  final String? createdAt;
+
+  const FeedbackHistoryItem({
+    required this.id,
+    required this.menuId,
+    required this.menuName,
+    this.menuImageUrl,
+    required this.feedbackScore,
+    this.createdAt,
+  });
+
+  factory FeedbackHistoryItem.fromJson(Map<String, dynamic> json) =>
+      FeedbackHistoryItem(
+        id: (json['id'] as num).toInt(),
+        menuId: (json['menuId'] as num).toInt(),
+        menuName: json['menuName'] ?? '',
+        menuImageUrl: json['menuImageUrl'],
+        feedbackScore: (json['feedbackScore'] as num).toInt(),
+        createdAt: json['createdAt'],
+      );
+}
+
 class MenuDetail {
   final int id;
   final String name;

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_app/models/recommendation_models.dart';
 import 'package:flutter_app/models/user_profile_models.dart';
+import 'package:flutter_app/services/recommendation_service.dart';
 import 'package:flutter_app/services/user_profile_service.dart';
 import 'package:flutter_app/services/token_storage.dart';
 import 'package:flutter_app/theme.dart';
@@ -11,72 +13,65 @@ class MyPageScreen extends StatefulWidget {
   State<MyPageScreen> createState() => _MyPageScreenState();
 }
 
-class _MyPageScreenState extends State<MyPageScreen> {
+class _MyPageScreenState extends State<MyPageScreen>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+
+  // ── 프로필 탭 상태 ──────────────────────────────
   final _formKey = GlobalKey<FormState>();
   bool _isEditMode = false;
   bool _isLoading = false;
 
-  // 1. 기본 정보
-  final TextEditingController _nicknameController = TextEditingController(
-    text: "김철수",
-  );
+  final TextEditingController _nicknameController =
+      TextEditingController(text: "김철수");
   String? _selectedGender = '남성';
 
-  // 2. 인바디 정보
-  final TextEditingController _heightController = TextEditingController(
-    text: "175",
-  );
-  final TextEditingController _weightController = TextEditingController(
-    text: "70",
-  );
-  final TextEditingController _muscleController = TextEditingController(
-    text: "35",
-  );
-  final TextEditingController _fatController = TextEditingController(
-    text: "15",
-  );
-  final TextEditingController _bmrController = TextEditingController(
-    text: "1600",
-  );
-  final TextEditingController _inbodyScoreController = TextEditingController(
-    text: "80",
-  );
+  final TextEditingController _heightController =
+      TextEditingController(text: "175");
+  final TextEditingController _weightController =
+      TextEditingController(text: "70");
+  final TextEditingController _muscleController =
+      TextEditingController(text: "35");
+  final TextEditingController _fatController =
+      TextEditingController(text: "15");
+  final TextEditingController _bmrController =
+      TextEditingController(text: "1600");
+  final TextEditingController _inbodyScoreController =
+      TextEditingController(text: "80");
+  final TextEditingController _budgetController =
+      TextEditingController(text: "8000");
 
-  // 3. 식습관 및 예산
-  final TextEditingController _budgetController = TextEditingController(
-    text: "8000",
-  );
   String _selectedVegType = 'NONE';
   double _spicyLevel = 3;
   String _selectedFitnessGoal = 'GENERAL';
   Set<String> _selectedFoodPreferences = {};
-
-  // 4. 건강 상태
   Set<String> _selectedHealthConditions = {};
-
-  // 5. 알레르기 정보
   Set<String> _selectedAllergies = {'우유', '밀가루'};
 
-  final List<String> _healthConditionOptions = [
-    '고혈압',
-    '당뇨',
-    '고지혈증',
-    '비만',
-    '신장질환',
-    '간질환',
-    '심장질환',
-    '갑상선질환',
-  ];
+  late String _bkNickname;
+  late String? _bkGender;
+  late String _bkHeight, _bkWeight, _bkMuscle, _bkFat, _bkBmr, _bkScore,
+      _bkBudget;
+  late String _bkVegType;
+  late double _bkSpicy;
+  late String _bkFitnessGoal;
+  late Set<String> _bkFoodPreferences;
+  late Set<String> _bkAllergies;
+  late Set<String> _bkHealthConditions;
 
+  // ── 피드백 탭 상태 ──────────────────────────────
+  List<FeedbackHistoryItem> _feedbackItems = [];
+  bool _feedbackLoading = false;
+  final TextEditingController _searchController = TextEditingController();
+  String _searchQuery = '';
+  bool _showLiked = true;
+
+  // ── 옵션 상수 ────────────────────────────────────
+  final List<String> _healthConditionOptions = [
+    '고혈압', '당뇨', '고지혈증', '비만', '신장질환', '간질환', '심장질환', '갑상선질환',
+  ];
   final List<String> _allergyOptions = [
-    '땅콩',
-    '갑각류',
-    '대두',
-    '우유',
-    '밀가루',
-    '계란',
-    '견과류',
-    '생선',
+    '땅콩', '갑각류', '대두', '우유', '밀가루', '계란', '견과류', '생선',
   ];
   final Map<String, String> _vegOptions = {
     'NONE': '해당 없음',
@@ -96,62 +91,57 @@ class _MyPageScreenState extends State<MyPageScreen> {
     '매운맛', '담백한맛', '달콤한맛', '고단백', '저칼로리',
   ];
 
-  // 취소 버튼을 위한 데이터 백업 저장소
-  late String _bkNickname;
-  late String? _bkGender;
-  late String _bkHeight,
-      _bkWeight,
-      _bkMuscle,
-      _bkFat,
-      _bkBmr,
-      _bkScore,
-      _bkBudget;
-  late String _bkVegType;
-  late double _bkSpicy;
-  late String _bkFitnessGoal;
-  late Set<String> _bkFoodPreferences;
-  late Set<String> _bkAllergies;
-  late Set<String> _bkHealthConditions;
-
   @override
   void initState() {
     super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+    _tabController.addListener(() {
+      if (!_tabController.indexIsChanging) setState(() {});
+    });
     _loadProfile();
     _loadBasicUserInfoFromLocal();
+    _loadFeedbacks();
   }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    _nicknameController.dispose();
+    _heightController.dispose();
+    _weightController.dispose();
+    _muscleController.dispose();
+    _fatController.dispose();
+    _bmrController.dispose();
+    _inbodyScoreController.dispose();
+    _budgetController.dispose();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  // ── 프로필 로드 ──────────────────────────────────
 
   Future<void> _loadBasicUserInfoFromLocal() async {
     try {
       final nickname = await TokenStorage.getUserNickname();
       final gender = await TokenStorage.getGender();
-
       if (!mounted) return;
       setState(() {
         if (nickname != null && nickname.isNotEmpty) {
           _nicknameController.text = nickname;
         }
         final normalizedGender = _normalizeGender(gender);
-        if (normalizedGender != null) {
-          _selectedGender = normalizedGender;
-        }
+        if (normalizedGender != null) _selectedGender = normalizedGender;
       });
-    } catch (_) {
-      // 로컬 저장소 접근 실패는 조용히 무시
-    }
+    } catch (_) {}
   }
 
   String? _normalizeGender(String? raw) {
     if (raw == null) return null;
     final v = raw.trim();
-
-    // 서버/로컬 값이 다양하게 올 수 있어서 UI 드롭다운 값으로 정규화
     if (v == '남성' || v == 'M' || v.toLowerCase() == 'male') return '남성';
     if (v == '여성' || v == 'F' || v.toLowerCase() == 'female') return '여성';
-
-    // 이미 '남자/여자'로 저장된 케이스도 흡수
     if (v == '남자') return '남성';
     if (v == '여자') return '여성';
-
     return null;
   }
 
@@ -160,10 +150,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
     try {
       final result = await UserProfileService.getProfile();
       if (!mounted) return;
-      if (!result.success || result.data == null) {
-        // 서버가 아직 준비 안 된 경우를 고려해서 조용히 유지
-        return;
-      }
+      if (!result.success || result.data == null) return;
       _applyProfileToForm(result.data!);
     } finally {
       if (mounted) setState(() => _isLoading = false);
@@ -173,7 +160,6 @@ class _MyPageScreenState extends State<MyPageScreen> {
   void _applyProfileToForm(UserProfileData data) {
     if (data.nickname != null && data.nickname!.isNotEmpty) {
       _nicknameController.text = data.nickname!;
-      // 서버 값이 최신이면 로컬에도 동기화
       // ignore: discarded_futures
       TokenStorage.saveNickname(data.nickname!);
     }
@@ -183,9 +169,10 @@ class _MyPageScreenState extends State<MyPageScreen> {
       // ignore: discarded_futures
       TokenStorage.saveGender(normalizedGender);
     }
-
-    _heightController.text = data.height?.toString() ?? _heightController.text;
-    _weightController.text = data.weight?.toString() ?? _weightController.text;
+    _heightController.text =
+        data.height?.toString() ?? _heightController.text;
+    _weightController.text =
+        data.weight?.toString() ?? _weightController.text;
     _muscleController.text =
         data.skeletalMuscleMass?.toString() ?? _muscleController.text;
     _fatController.text =
@@ -195,34 +182,16 @@ class _MyPageScreenState extends State<MyPageScreen> {
         data.inbodyScore?.toString() ?? _inbodyScoreController.text;
     _budgetController.text =
         data.mealBudget?.toString() ?? _budgetController.text;
-    if (data.vegetarianType != null) {
-      _selectedVegType = data.vegetarianType!;
-    }
+    if (data.vegetarianType != null) _selectedVegType = data.vegetarianType!;
     if (data.spicyPreference != null) {
       _spicyLevel = data.spicyPreference!.toDouble();
     }
-    if (data.fitnessGoal != null) {
-      _selectedFitnessGoal = data.fitnessGoal!;
-    }
+    if (data.fitnessGoal != null) _selectedFitnessGoal = data.fitnessGoal!;
     _selectedFoodPreferences = data.foodPreferences.toSet();
     _selectedAllergies = data.allergies.toSet();
     _selectedHealthConditions = data.healthConditions.toSet();
   }
 
-  @override
-  void dispose() {
-    _nicknameController.dispose();
-    _heightController.dispose();
-    _weightController.dispose();
-    _muscleController.dispose();
-    _fatController.dispose();
-    _bmrController.dispose();
-    _inbodyScoreController.dispose();
-    _budgetController.dispose();
-    super.dispose();
-  }
-
-  // 수정 모드 켜기 (현재 데이터 백업)
   void _enableEditMode() {
     _bkNickname = _nicknameController.text;
     _bkGender = _selectedGender;
@@ -239,13 +208,9 @@ class _MyPageScreenState extends State<MyPageScreen> {
     _bkFoodPreferences = Set.from(_selectedFoodPreferences);
     _bkAllergies = Set.from(_selectedAllergies);
     _bkHealthConditions = Set.from(_selectedHealthConditions);
-
-    setState(() {
-      _isEditMode = true;
-    });
+    setState(() => _isEditMode = true);
   }
 
-  // 수정 취소하기 (백업 데이터로 원상 복구)
   void _cancelEdit() {
     _nicknameController.text = _bkNickname;
     _selectedGender = _bkGender;
@@ -262,21 +227,14 @@ class _MyPageScreenState extends State<MyPageScreen> {
     _selectedFoodPreferences = Set.from(_bkFoodPreferences);
     _selectedAllergies = Set.from(_bkAllergies);
     _selectedHealthConditions = Set.from(_bkHealthConditions);
-
-    setState(() {
-      _isEditMode = false;
-    });
-
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(const SnackBar(content: Text('수정이 취소되었습니다.')));
+    setState(() => _isEditMode = false);
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('수정이 취소되었습니다.')));
   }
 
-  // 변경사항 저장하기
   Future<void> _saveProfile() async {
     if (_isLoading) return;
     if (!_formKey.currentState!.validate()) return;
-
     setState(() => _isLoading = true);
     try {
       final request = UserProfileRequest(
@@ -298,28 +256,22 @@ class _MyPageScreenState extends State<MyPageScreen> {
         allergies: _selectedAllergies.toList(),
         healthConditions: _selectedHealthConditions.toList(),
       );
-
       final result = await UserProfileService.updateProfile(request: request);
       if (!mounted) return;
-
       if (!result.success) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(result.error ?? '프로필 저장에 실패했습니다.')),
         );
         return;
       }
-
       setState(() => _isEditMode = false);
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('프로필 정보가 성공적으로 업데이트되었습니다!')));
-      
-      // 로컬 닉네임/성별 정보도 업데이트
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('프로필 정보가 성공적으로 업데이트되었습니다!')),
+      );
       await TokenStorage.saveNickname(_nicknameController.text);
       if (_selectedGender != null) {
         await TokenStorage.saveGender(_selectedGender!);
       }
-
     } finally {
       if (mounted) setState(() => _isLoading = false);
     }
@@ -331,7 +283,6 @@ class _MyPageScreenState extends State<MyPageScreen> {
     return null;
   }
 
-  // 💡 데이터가 변경되었는지 확인하는 함수 추가
   bool get _hasChanges {
     if (!_isEditMode) return false;
     return _nicknameController.text != _bkNickname ||
@@ -353,404 +304,578 @@ class _MyPageScreenState extends State<MyPageScreen> {
         _selectedHealthConditions.length != _bkHealthConditions.length ||
         !_selectedHealthConditions.containsAll(_bkHealthConditions);
   }
+
+  // ── 피드백 탭 로직 ────────────────────────────────
+
+  Future<void> _loadFeedbacks() async {
+    setState(() => _feedbackLoading = true);
+    try {
+      final jwt = await TokenStorage.getAccessToken();
+      final items = await RecommendationService.fetchMyFeedbacks(jwt);
+      if (!mounted) return;
+      setState(() => _feedbackItems = items);
+    } finally {
+      if (mounted) setState(() => _feedbackLoading = false);
+    }
+  }
+
+  Future<void> _confirmDeleteFeedback(FeedbackHistoryItem item) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('피드백 삭제'),
+        content: Text('"${item.menuName}" 피드백을 삭제할까요?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('삭제', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) await _deleteFeedback(item.id);
+  }
+
+  Future<void> _deleteFeedback(int logId) async {
+    final jwt = await TokenStorage.getAccessToken();
+    final success = await RecommendationService.deleteFeedback(logId, jwt);
+    if (!mounted) return;
+    if (success) {
+      setState(() => _feedbackItems.removeWhere((i) => i.id == logId));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('피드백이 삭제되었습니다.')));
+    } else {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('삭제에 실패했습니다.')));
+    }
+  }
+
+  // ── 빌드 ─────────────────────────────────────────
+
   @override
   Widget build(BuildContext context) {
+    final isProfileTab = _tabController.index == 0;
     return Scaffold(
       appBar: AppBar(
-        title: const Text(
-          '마이페이지',
-          style: TextStyle(fontWeight: FontWeight.bold),
-        ),
+        title: const Text('마이페이지',
+            style: TextStyle(fontWeight: FontWeight.bold)),
         centerTitle: true,
         elevation: 0,
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-                actions: [
-          if (!_isEditMode)
-            TextButton(
-              onPressed: _enableEditMode,
-              child: const Text(
-                '수정',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  fontSize: 16,
-                  color: AppTheme.primaryColor,
-                ),
-              ),
-            )
-          else ...[
-            TextButton(
-              onPressed: _cancelEdit,
-              child: const Text(
-                '취소',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  fontSize: 16,
-                  color: Colors.grey,
-                ),
-              ),
-            ),
-            TextButton(
-              // 💡 변경된 게 없거나 로딩 중이면 버튼 기능 비활성화(null)
-              onPressed: (_hasChanges && !_isLoading) ? _saveProfile : null,
-              child: Text(
-                '저장',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  fontSize: 16,
-                  // 💡 변경사항이 있으면 파란색, 없으면 회색으로 표시
-                  color: (_hasChanges && !_isLoading) 
-                      ? AppTheme.primaryColor 
-                      : Colors.grey.shade400,
-                ),
-              ),
-            ),
+        actions: isProfileTab
+            ? [
+                if (!_isEditMode)
+                  TextButton(
+                    onPressed: _enableEditMode,
+                    child: const Text('수정',
+                        style: TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 16,
+                            color: AppTheme.primaryColor)),
+                  )
+                else ...[
+                  TextButton(
+                    onPressed: _cancelEdit,
+                    child: const Text('취소',
+                        style: TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 16,
+                            color: Colors.grey)),
+                  ),
+                  TextButton(
+                    onPressed: (_hasChanges && !_isLoading) ? _saveProfile : null,
+                    child: Text('저장',
+                        style: TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 16,
+                            color: (_hasChanges && !_isLoading)
+                                ? AppTheme.primaryColor
+                                : Colors.grey.shade400)),
+                  ),
+                ],
+              ]
+            : null,
+        bottom: TabBar(
+          controller: _tabController,
+          labelColor: AppTheme.primaryColor,
+          unselectedLabelColor: Colors.grey,
+          indicatorColor: AppTheme.primaryColor,
+          tabs: const [
+            Tab(text: '프로필'),
+            Tab(text: '피드백'),
           ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          _buildProfileTab(),
+          _buildFeedbackTab(),
         ],
       ),
-      body: SafeArea(
-        child: Form(
-          key: _formKey,
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.all(20.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _buildSectionTitle('1. 기본 정보'),
-                _buildTextField(_nicknameController, '닉네임', isNumber: false),
-                const SizedBox(height: 16),
-                DropdownButtonFormField<String>(
-                  decoration: InputDecoration(
-                    labelText: '성별',
-                    filled: true,
-                    fillColor: _isEditMode
-                        ? Colors.white
-                        : Colors.grey.shade100,
-                  ),
-                  value: _selectedGender,
-                  onChanged: _isEditMode
-                      ? (v) => setState(() => _selectedGender = v!)
-                      : null,
-                  items: ['남성', '여성']
-                      .map((s) => DropdownMenuItem(value: s, child: Text(s)))
-                      .toList(),
-                ),
-                const SizedBox(height: 32),
+    );
+  }
 
-                _buildSectionTitle('2. 체성분 (InBody) 정보'),
-                Row(
+  // ── 프로필 탭 ─────────────────────────────────────
+
+  Widget _buildProfileTab() {
+    return SafeArea(
+      child: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(20.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildSectionTitle('1. 기본 정보'),
+              _buildTextField(_nicknameController, '닉네임', isNumber: false),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<String>(
+                decoration: InputDecoration(
+                  labelText: '성별',
+                  filled: true,
+                  fillColor:
+                      _isEditMode ? Colors.white : Colors.grey.shade100,
+                ),
+                value: _selectedGender,
+                onChanged: _isEditMode
+                    ? (v) => setState(() => _selectedGender = v!)
+                    : null,
+                items: ['남성', '여성']
+                    .map((s) => DropdownMenuItem(value: s, child: Text(s)))
+                    .toList(),
+              ),
+              const SizedBox(height: 32),
+
+              _buildSectionTitle('2. 체성분 (InBody) 정보'),
+              Row(
+                children: [
+                  Expanded(
+                      child:
+                          _buildTextField(_heightController, '키', suffix: 'cm')),
+                  const SizedBox(width: 12),
+                  Expanded(
+                      child: _buildTextField(_weightController, '몸무게',
+                          suffix: 'kg')),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                      child: _buildTextField(_muscleController, '골격근량',
+                          suffix: 'kg')),
+                  const SizedBox(width: 12),
+                  Expanded(
+                      child: _buildTextField(_fatController, '체지방률',
+                          suffix: '%')),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                      child: _buildTextField(_bmrController, '기초대사량',
+                          suffix: 'kcal')),
+                  const SizedBox(width: 12),
+                  Expanded(
+                      child: _buildTextField(_inbodyScoreController, '인바디 점수',
+                          suffix: '점')),
+                ],
+              ),
+              const SizedBox(height: 32),
+
+              _buildSectionTitle('3. 식습관 및 예산 설정'),
+              _buildTextField(_budgetController, '끼니당 허용 예산', suffix: '원'),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<String>(
+                decoration: InputDecoration(
+                  labelText: '채식 유형 선택',
+                  filled: true,
+                  fillColor:
+                      _isEditMode ? Colors.white : Colors.grey.shade100,
+                ),
+                value: _selectedVegType,
+                onChanged: _isEditMode
+                    ? (v) => setState(() => _selectedVegType = v!)
+                    : null,
+                items: _vegOptions.entries
+                    .map((e) => DropdownMenuItem(
+                        value: e.key, child: Text(e.value)))
+                    .toList(),
+              ),
+              const SizedBox(height: 24),
+              Opacity(
+                opacity: _isEditMode ? 1.0 : 0.5,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Expanded(
-                      child: _buildTextField(
-                        _heightController,
-                        '키',
-                        suffix: 'cm',
-                      ),
+                    Text(
+                      '매운맛 선호도 (${_spicyLevel.toInt()}단계)',
+                      style: const TextStyle(fontWeight: FontWeight.bold),
                     ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: _buildTextField(
-                        _weightController,
-                        '몸무게',
-                        suffix: 'kg',
-                      ),
+                    Slider(
+                      value: _spicyLevel,
+                      min: 1,
+                      max: 5,
+                      divisions: 4,
+                      activeColor: AppTheme.primaryColor,
+                      onChanged: _isEditMode
+                          ? (v) => setState(() => _spicyLevel = v)
+                          : null,
                     ),
                   ],
                 ),
-                const SizedBox(height: 12),
-                Row(
-                  children: [
-                    Expanded(
-                      child: _buildTextField(
-                        _muscleController,
-                        '골격근량',
-                        suffix: 'kg',
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: _buildTextField(
-                        _fatController,
-                        '체지방률',
-                        suffix: '%',
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 12),
-                Row(
-                  children: [
-                    Expanded(
-                      child: _buildTextField(
-                        _bmrController,
-                        '기초대사량',
-                        suffix: 'kcal',
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: _buildTextField(
-                        _inbodyScoreController,
-                        '인바디 점수',
-                        suffix: '점',
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 32),
-
-                _buildSectionTitle('3. 식습관 및 예산 설정'),
-                _buildTextField(_budgetController, '끼니당 허용 예산', suffix: '원'),
-                const SizedBox(height: 16),
-                DropdownButtonFormField<String>(
-                  decoration: InputDecoration(
-                    labelText: '채식 유형 선택',
-                    filled: true,
-                    fillColor: _isEditMode
-                        ? Colors.white
-                        : Colors.grey.shade100,
-                  ),
-                  value: _selectedVegType,
-                  onChanged: _isEditMode
-                      ? (v) => setState(() => _selectedVegType = v!)
-                      : null,
-                  items: _vegOptions.entries
-                      .map(
-                        (e) => DropdownMenuItem(
-                          value: e.key,
-                          child: Text(e.value),
-                        ),
-                      )
-                      .toList(),
-                ),
-                const SizedBox(height: 24),
-
-                Opacity(
+              ),
+              const SizedBox(height: 24),
+              const Text('식단 목표',
+                  style: TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              IgnorePointer(
+                ignoring: !_isEditMode,
+                child: Opacity(
                   opacity: _isEditMode ? 1.0 : 0.5,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        '매운맛 선호도 (${_spicyLevel.toInt()}단계)',
-                        style: const TextStyle(fontWeight: FontWeight.bold),
-                      ),
-                      Slider(
-                        value: _spicyLevel,
-                        min: 1,
-                        max: 5,
-                        divisions: 4,
-                        activeColor: AppTheme.primaryColor,
-                        onChanged: _isEditMode
-                            ? (v) => setState(() => _spicyLevel = v)
-                            : null,
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 24),
-
-                const Text('식단 목표', style: TextStyle(fontWeight: FontWeight.bold)),
-                const SizedBox(height: 8),
-                IgnorePointer(
-                  ignoring: !_isEditMode,
-                  child: Opacity(
-                    opacity: _isEditMode ? 1.0 : 0.5,
-                    child: Wrap(
-                      spacing: 8.0,
-                      runSpacing: 8.0,
-                      children: _fitnessGoalOptions.entries.map((e) {
-                        final isSelected = _selectedFitnessGoal == e.key;
-                        return ChoiceChip(
-                          label: Text(
-                            e.value,
+                  child: Wrap(
+                    spacing: 8.0,
+                    runSpacing: 8.0,
+                    children: _fitnessGoalOptions.entries.map((e) {
+                      final isSelected = _selectedFitnessGoal == e.key;
+                      return ChoiceChip(
+                        label: Text(e.value,
                             style: TextStyle(
-                              color: _isEditMode ? Colors.black87 : Colors.grey.shade600,
-                            ),
-                          ),
-                          selected: isSelected,
-                          selectedColor: _isEditMode
-                              ? AppTheme.primaryColor.withOpacity(0.2)
-                              : Colors.grey.shade300,
-                          checkmarkColor: _isEditMode ? AppTheme.primaryColor : Colors.grey.shade600,
-                          shape: RoundedRectangleBorder(
-                            side: BorderSide(
-                              color: _isEditMode ? Colors.grey.shade300 : Colors.transparent,
-                            ),
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          onSelected: (_) => setState(() => _selectedFitnessGoal = e.key),
-                        );
-                      }).toList(),
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 24),
-
-                const Text('선호하는 음식 스타일 (복수 선택 가능)', style: TextStyle(fontWeight: FontWeight.bold)),
-                const SizedBox(height: 8),
-                Container(
-                  width: double.infinity,
-                  padding: EdgeInsets.all(_isEditMode ? 0 : 16.0),
-                  decoration: BoxDecoration(
-                    color: _isEditMode ? Colors.transparent : Colors.grey.shade100,
-                    borderRadius: BorderRadius.circular(16),
-                    border: _isEditMode ? null : Border.all(color: Colors.grey.shade300),
-                  ),
-                  child: IgnorePointer(
-                    ignoring: !_isEditMode,
-                    child: Wrap(
-                      spacing: 8.0,
-                      runSpacing: 8.0,
-                      children: _foodPreferenceOptions.map((pref) {
-                        final isSelected = _selectedFoodPreferences.contains(pref);
-                        return FilterChip(
-                          label: Text(
-                            pref,
-                            style: TextStyle(
-                              color: _isEditMode ? Colors.black87 : Colors.grey.shade600,
-                            ),
-                          ),
-                          selected: isSelected,
-                          backgroundColor: _isEditMode ? Colors.white : Colors.grey.shade200,
-                          selectedColor: _isEditMode
-                              ? AppTheme.primaryColor.withOpacity(0.2)
-                              : Colors.grey.shade300,
-                          checkmarkColor: _isEditMode ? AppTheme.primaryColor : Colors.grey.shade600,
-                          shape: RoundedRectangleBorder(
-                            side: BorderSide(
-                              color: _isEditMode ? Colors.grey.shade300 : Colors.transparent,
-                            ),
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          onSelected: (bool selected) {
-                            setState(() {
-                              selected
-                                  ? _selectedFoodPreferences.add(pref)
-                                  : _selectedFoodPreferences.remove(pref);
-                            });
-                          },
-                        );
-                      }).toList(),
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 32),
-
-                _buildSectionTitle('4. 건강 상태'),
-                Container(
-                  width: double.infinity,
-                  padding: EdgeInsets.all(_isEditMode ? 0 : 16.0),
-                  decoration: BoxDecoration(
-                    color: _isEditMode ? Colors.transparent : Colors.grey.shade100,
-                    borderRadius: BorderRadius.circular(16),
-                    border: _isEditMode ? null : Border.all(color: Colors.grey.shade300),
-                  ),
-                  child: IgnorePointer(
-                    ignoring: !_isEditMode,
-                    child: Wrap(
-                      spacing: 8.0,
-                      runSpacing: 8.0,
-                      children: _healthConditionOptions.map((cond) {
-                        final isSelected = _selectedHealthConditions.contains(cond);
-                        return FilterChip(
-                          label: Text(
-                            cond,
-                            style: TextStyle(
-                              color: _isEditMode ? Colors.black87 : Colors.grey.shade600,
-                            ),
-                          ),
-                          selected: isSelected,
-                          backgroundColor: _isEditMode ? Colors.white : Colors.grey.shade200,
-                          selectedColor: _isEditMode
-                              ? AppTheme.primaryColor.withValues(alpha: 0.2)
-                              : Colors.grey.shade300,
-                          checkmarkColor: _isEditMode ? AppTheme.primaryColor : Colors.grey.shade600,
-                          shape: RoundedRectangleBorder(
-                            side: BorderSide(
-                              color: _isEditMode ? Colors.grey.shade300 : Colors.transparent,
-                            ),
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          onSelected: (bool selected) {
-                            setState(() {
-                              selected
-                                  ? _selectedHealthConditions.add(cond)
-                                  : _selectedHealthConditions.remove(cond);
-                            });
-                          },
-                        );
-                      }).toList(),
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 32),
-
-                _buildSectionTitle('5. 알레르기 유발 물질'),
-                Container(
-                  width: double.infinity,
-                  padding: EdgeInsets.all(_isEditMode ? 0 : 16.0),
-                  decoration: BoxDecoration(
-                    color: _isEditMode
-                        ? Colors.transparent
-                        : Colors.grey.shade100,
-                    borderRadius: BorderRadius.circular(16), // 💡 16px로 맞춤
-                    border: _isEditMode
-                        ? null
-                        : Border.all(color: Colors.grey.shade300),
-                  ),
-                  child: IgnorePointer(
-                    ignoring: !_isEditMode,
-                    child: Wrap(
-                      spacing: 8.0,
-                      runSpacing: 8.0,
-                      children: _allergyOptions.map((allergy) {
-                        final isSelected = _selectedAllergies.contains(allergy);
-                        return FilterChip(
-                          label: Text(
-                            allergy,
-                            style: TextStyle(
-                              color: _isEditMode
-                                  ? Colors.black87
-                                  : Colors.grey.shade600,
-                            ),
-                          ),
-                          selected: isSelected,
-                          backgroundColor: _isEditMode
-                              ? Colors.white
-                              : Colors.grey.shade200,
-                          selectedColor: _isEditMode
-                              ? AppTheme.primaryColor.withOpacity(0.2) // 💡 선택 색상 변경
-                              : Colors.grey.shade300,
-                          checkmarkColor: _isEditMode
-                              ? AppTheme.primaryColor // 💡 체크 아이콘 색상 변경
-                              : Colors.grey.shade600,
-                          shape: RoundedRectangleBorder(
-                            side: BorderSide(
+                                color: _isEditMode
+                                    ? Colors.black87
+                                    : Colors.grey.shade600)),
+                        selected: isSelected,
+                        selectedColor: _isEditMode
+                            ? AppTheme.primaryColor.withValues(alpha: 0.2)
+                            : Colors.grey.shade300,
+                        checkmarkColor: _isEditMode
+                            ? AppTheme.primaryColor
+                            : Colors.grey.shade600,
+                        shape: RoundedRectangleBorder(
+                          side: BorderSide(
                               color: _isEditMode
                                   ? Colors.grey.shade300
-                                  : Colors.transparent,
-                            ),
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          onSelected: (bool selected) {
-                            setState(() {
-                              selected
-                                  ? _selectedAllergies.add(allergy)
-                                  : _selectedAllergies.remove(allergy);
-                            });
-                          },
-                        );
-                      }).toList(),
-                    ),
+                                  : Colors.transparent),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        onSelected: (_) =>
+                            setState(() => _selectedFitnessGoal = e.key),
+                      );
+                    }).toList(),
                   ),
                 ),
-                const SizedBox(height: 40),
-              ],
-            ),
+              ),
+              const SizedBox(height: 24),
+              const Text('선호하는 음식 스타일 (복수 선택 가능)',
+                  style: TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              _buildChipBox(
+                children: _foodPreferenceOptions.map((pref) {
+                  final isSelected = _selectedFoodPreferences.contains(pref);
+                  return FilterChip(
+                    label: Text(pref,
+                        style: TextStyle(
+                            color: _isEditMode
+                                ? Colors.black87
+                                : Colors.grey.shade600)),
+                    selected: isSelected,
+                    backgroundColor:
+                        _isEditMode ? Colors.white : Colors.grey.shade200,
+                    selectedColor: _isEditMode
+                        ? AppTheme.primaryColor.withValues(alpha: 0.2)
+                        : Colors.grey.shade300,
+                    checkmarkColor: _isEditMode
+                        ? AppTheme.primaryColor
+                        : Colors.grey.shade600,
+                    shape: RoundedRectangleBorder(
+                      side: BorderSide(
+                          color: _isEditMode
+                              ? Colors.grey.shade300
+                              : Colors.transparent),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    onSelected: (selected) => setState(() => selected
+                        ? _selectedFoodPreferences.add(pref)
+                        : _selectedFoodPreferences.remove(pref)),
+                  );
+                }).toList(),
+              ),
+              const SizedBox(height: 32),
+
+              _buildSectionTitle('4. 건강 상태'),
+              _buildChipBox(
+                children: _healthConditionOptions.map((cond) {
+                  final isSelected = _selectedHealthConditions.contains(cond);
+                  return FilterChip(
+                    label: Text(cond,
+                        style: TextStyle(
+                            color: _isEditMode
+                                ? Colors.black87
+                                : Colors.grey.shade600)),
+                    selected: isSelected,
+                    backgroundColor:
+                        _isEditMode ? Colors.white : Colors.grey.shade200,
+                    selectedColor: _isEditMode
+                        ? AppTheme.primaryColor.withValues(alpha: 0.2)
+                        : Colors.grey.shade300,
+                    checkmarkColor: _isEditMode
+                        ? AppTheme.primaryColor
+                        : Colors.grey.shade600,
+                    shape: RoundedRectangleBorder(
+                      side: BorderSide(
+                          color: _isEditMode
+                              ? Colors.grey.shade300
+                              : Colors.transparent),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    onSelected: (selected) => setState(() => selected
+                        ? _selectedHealthConditions.add(cond)
+                        : _selectedHealthConditions.remove(cond)),
+                  );
+                }).toList(),
+              ),
+              const SizedBox(height: 32),
+
+              _buildSectionTitle('5. 알레르기 유발 물질'),
+              _buildChipBox(
+                children: _allergyOptions.map((allergy) {
+                  final isSelected = _selectedAllergies.contains(allergy);
+                  return FilterChip(
+                    label: Text(allergy,
+                        style: TextStyle(
+                            color: _isEditMode
+                                ? Colors.black87
+                                : Colors.grey.shade600)),
+                    selected: isSelected,
+                    backgroundColor:
+                        _isEditMode ? Colors.white : Colors.grey.shade200,
+                    selectedColor: _isEditMode
+                        ? AppTheme.primaryColor.withValues(alpha: 0.2)
+                        : Colors.grey.shade300,
+                    checkmarkColor: _isEditMode
+                        ? AppTheme.primaryColor
+                        : Colors.grey.shade600,
+                    shape: RoundedRectangleBorder(
+                      side: BorderSide(
+                          color: _isEditMode
+                              ? Colors.grey.shade300
+                              : Colors.transparent),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    onSelected: (selected) => setState(() => selected
+                        ? _selectedAllergies.add(allergy)
+                        : _selectedAllergies.remove(allergy)),
+                  );
+                }).toList(),
+              ),
+              const SizedBox(height: 40),
+            ],
           ),
         ),
       ),
     );
   }
+
+  // ── 피드백 탭 ─────────────────────────────────────
+
+  Widget _buildFeedbackTab() {
+    if (_feedbackLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final filtered = _searchQuery.isEmpty
+        ? _feedbackItems
+        : _feedbackItems
+            .where((item) => item.menuName.contains(_searchQuery))
+            .toList();
+
+    final liked = filtered.where((i) => i.feedbackScore == 1).toList();
+    final disliked = filtered.where((i) => i.feedbackScore == -1).toList();
+    final activeItems = _showLiked ? liked : disliked;
+
+    final likedTotal = _feedbackItems.where((i) => i.feedbackScore == 1).length;
+    final dislikedTotal =
+        _feedbackItems.where((i) => i.feedbackScore == -1).length;
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+          child: TextField(
+            controller: _searchController,
+            onChanged: (v) => setState(() => _searchQuery = v),
+            decoration: InputDecoration(
+              hintText: '메뉴 이름으로 검색',
+              prefixIcon: const Icon(Icons.search, size: 20),
+              suffixIcon: _searchQuery.isNotEmpty
+                  ? IconButton(
+                      icon: const Icon(Icons.clear, size: 20),
+                      onPressed: () {
+                        _searchController.clear();
+                        setState(() => _searchQuery = '');
+                      },
+                    )
+                  : null,
+              filled: true,
+              fillColor: Colors.grey.shade100,
+              contentPadding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
+            children: [
+              Expanded(
+                child: _buildToggleButton(
+                  label: '좋아요',
+                  count: likedTotal,
+                  icon: Icons.thumb_up,
+                  isActive: _showLiked,
+                  activeColor: AppTheme.primaryColor,
+                  onTap: () => setState(() => _showLiked = true),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _buildToggleButton(
+                  label: '싫어요',
+                  count: dislikedTotal,
+                  icon: Icons.thumb_down,
+                  isActive: !_showLiked,
+                  activeColor: Colors.redAccent,
+                  onTap: () => setState(() => _showLiked = false),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: RefreshIndicator(
+            onRefresh: _loadFeedbacks,
+            child: activeItems.isEmpty
+                ? ListView(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.only(top: 80),
+                        child: Center(
+                          child: Text(
+                            _searchQuery.isEmpty
+                                ? '아직 피드백한 메뉴가 없습니다.'
+                                : '검색 결과가 없습니다.',
+                            style: TextStyle(color: Colors.grey.shade500),
+                          ),
+                        ),
+                      ),
+                    ],
+                  )
+                : ListView.builder(
+                    itemCount: activeItems.length,
+                    itemBuilder: (_, i) => _buildFeedbackItem(activeItems[i]),
+                  ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildToggleButton({
+    required String label,
+    required int count,
+    required IconData icon,
+    required bool isActive,
+    required Color activeColor,
+    required VoidCallback onTap,
+  }) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        padding: const EdgeInsets.symmetric(vertical: 10),
+        decoration: BoxDecoration(
+          color: isActive ? activeColor.withValues(alpha: 0.1) : Colors.grey.shade100,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(
+            color: isActive ? activeColor : Colors.grey.shade300,
+            width: isActive ? 1.5 : 1,
+          ),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon,
+                size: 16,
+                color: isActive ? activeColor : Colors.grey.shade500),
+            const SizedBox(width: 6),
+            Text(
+              label,
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: isActive ? activeColor : Colors.grey.shade500,
+              ),
+            ),
+            const SizedBox(width: 4),
+            Text(
+              '$count',
+              style: TextStyle(
+                fontSize: 12,
+                color: isActive ? activeColor : Colors.grey.shade400,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFeedbackItem(FeedbackHistoryItem item) {
+    return ListTile(
+      contentPadding:
+          const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      leading: ClipRRect(
+        borderRadius: BorderRadius.circular(8),
+        child: item.menuImageUrl != null && item.menuImageUrl!.isNotEmpty
+            ? Image.network(
+                item.menuImageUrl!,
+                width: 48,
+                height: 48,
+                fit: BoxFit.cover,
+                errorBuilder: (context, error, stackTrace) => _defaultMenuIcon(),
+              )
+            : _defaultMenuIcon(),
+      ),
+      title: Text(item.menuName,
+          style: const TextStyle(fontWeight: FontWeight.w500)),
+      subtitle: item.createdAt != null
+          ? Text(item.createdAt!,
+              style:
+                  TextStyle(fontSize: 12, color: Colors.grey.shade500))
+          : null,
+      trailing: IconButton(
+        icon: Icon(Icons.delete_outline, color: Colors.grey.shade400),
+        onPressed: () => _confirmDeleteFeedback(item),
+      ),
+    );
+  }
+
+  Widget _defaultMenuIcon() => Container(
+        width: 48,
+        height: 48,
+        decoration: BoxDecoration(
+          color: Colors.grey.shade200,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Icon(Icons.restaurant, color: Colors.grey.shade400),
+      );
+
+  // ── 공통 위젯 헬퍼 ────────────────────────────────
 
   Widget _buildSectionTitle(String title) {
     return Padding(
@@ -760,8 +885,25 @@ class _MyPageScreenState extends State<MyPageScreen> {
         style: const TextStyle(
           fontSize: 18,
           fontWeight: FontWeight.w900,
-          color: AppTheme.primaryColor, // 💡 섹션 타이틀 색상 변경
+          color: AppTheme.primaryColor,
         ),
+      ),
+    );
+  }
+
+  Widget _buildChipBox({required List<Widget> children}) {
+    return Container(
+      width: double.infinity,
+      padding: EdgeInsets.all(_isEditMode ? 0 : 16.0),
+      decoration: BoxDecoration(
+        color: _isEditMode ? Colors.transparent : Colors.grey.shade100,
+        borderRadius: BorderRadius.circular(16),
+        border:
+            _isEditMode ? null : Border.all(color: Colors.grey.shade300),
+      ),
+      child: IgnorePointer(
+        ignoring: !_isEditMode,
+        child: Wrap(spacing: 8.0, runSpacing: 8.0, children: children),
       ),
     );
   }
@@ -778,16 +920,14 @@ class _MyPageScreenState extends State<MyPageScreen> {
       keyboardType: isNumber
           ? const TextInputType.numberWithOptions(decimal: true)
           : TextInputType.text,
-      // 💡 키보드 입력 시 실시간으로 화면을 갱신해 저장 버튼 활성화 여부를 업데이트함
-      onChanged: (value) {
-        if (_isEditMode) setState(() {}); 
+      onChanged: (_) {
+        if (_isEditMode) setState(() {});
       },
       decoration: InputDecoration(
         labelText: label,
         suffixText: suffix,
         filled: true,
         fillColor: _isEditMode ? Colors.white : Colors.grey.shade100,
-        // 💡 텍스트필드 공통 라운딩(16px)은 theme.dart에서 적용됨
       ),
       validator: (value) {
         if (value == null || value.isEmpty) return '필수 입력 항목입니다.';

--- a/flutter_app/lib/services/recommendation_service.dart
+++ b/flutter_app/lib/services/recommendation_service.dart
@@ -97,6 +97,42 @@ class RecommendationService {
     } catch (_) {}
   }
 
+  static Future<List<FeedbackHistoryItem>> fetchMyFeedbacks(String? jwt) async {
+    if (jwt == null || jwt.isEmpty) return [];
+    final uri = Uri.parse('${ApiConfig.baseUrl}/api/recommendation-logs/my');
+    try {
+      final response = await http.get(
+        uri,
+        headers: {'Authorization': 'Bearer $jwt'},
+      ).timeout(const Duration(seconds: 10));
+      if (response.statusCode != 200) return [];
+      final json = jsonDecode(utf8.decode(response.bodyBytes));
+      if (json['success'] != true || json['data'] == null) return [];
+      return (json['data'] as List)
+          .map((e) => FeedbackHistoryItem.fromJson(e))
+          .toList();
+    } catch (_) {
+      return [];
+    }
+  }
+
+  static Future<bool> deleteFeedback(int logId, String? jwt) async {
+    if (jwt == null || jwt.isEmpty) return false;
+    final uri =
+        Uri.parse('${ApiConfig.baseUrl}/api/recommendation-logs/$logId');
+    try {
+      final response = await http.delete(
+        uri,
+        headers: {'Authorization': 'Bearer $jwt'},
+      ).timeout(const Duration(seconds: 10));
+      if (response.statusCode != 200) return false;
+      final json = jsonDecode(utf8.decode(response.bodyBytes));
+      return json['success'] == true;
+    } catch (_) {
+      return false;
+    }
+  }
+
   static Future<MenuDetail?> fetchMenuDetail(int id, String? jwt) async {
     final uri = Uri.parse('${ApiConfig.baseUrl}/api/menus/$id');
     final headers = <String, String>{};


### PR DESCRIPTION
## Summary
- 마이페이지에 **프로필 / 피드백** 탭 구조 추가
- 피드백 탭에서 후보 메뉴에 남긴 좋아요·싫어요 이력 조회 및 삭제 가능
- 상단 토글 버튼으로 좋아요·싫어요 목록 전환, 검색바로 메뉴명 필터링

## Changes
### Backend
- `RecommendationLogResponse` DTO 신규 추가 (날짜 `yyyy-MM-dd` 형식)
- `GET /api/recommendation-logs/my` — 내 피드백 이력 조회
- `DELETE /api/recommendation-logs/{id}` — 피드백 삭제 (본인 소유 검증)

### Flutter
- `mypage_screen.dart` — `TabBar` 구조로 개편, 프로필 탭 AppBar 액션 유지
- `recommendation_service.dart` — `fetchMyFeedbacks()`, `deleteFeedback()` 추가
- `recommendation_models.dart` — `FeedbackHistoryItem` 모델 추가

## Test plan
- [ ] 피드백 탭 진입 시 좋아요·싫어요 이력 정상 로드
- [ ] 토글 버튼으로 좋아요·싫어요 목록 전환 확인
- [ ] 메뉴명 검색 필터링 동작 확인
- [ ] 삭제 다이얼로그 → 삭제 후 목록에서 즉시 제거 확인
- [ ] 프로필 탭 수정·저장·취소 기존 동작 정상 확인