### PR TITLE
feat: CloudFront + OAC 서빙 전환 구현

### DIFF
--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/AiMealAssistantBatchApplication.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/AiMealAssistantBatchApplication.java
@@ -3,10 +3,12 @@ package capstone.ai_meal_assistant_batch;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 @ConfigurationPropertiesScan
 public class AiMealAssistantBatchApplication {
 	public static void main(String[] args) {

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/controller/AdminDataController.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/controller/AdminDataController.java
@@ -1,5 +1,6 @@
 package capstone.ai_meal_assistant_batch.domain.etl.controller;
 
+import capstone.ai_meal_assistant_batch.domain.ingredient.service.ImageRecoveryAsyncRunner;
 import capstone.ai_meal_assistant_batch.domain.ingredient.service.RecipeDataSyncService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminDataController {
 
     private final RecipeDataSyncService syncService;
+    private final ImageRecoveryAsyncRunner imageRecoveryAsyncRunner;
 
     @PostMapping("/sync-recipes")
     public ResponseEntity<String> syncRecipes(){
@@ -24,5 +26,16 @@ public class AdminDataController {
     public ResponseEntity<String> syncAllergies(){
         syncService.syncAllergyMappings();
         return ResponseEntity.ok("메뉴-알레르기 매핑이 성공적으로 완료되었습니다!");
+    }
+
+    @PostMapping("/recover-images")
+    public ResponseEntity<String> recoverImages(){
+        boolean started = imageRecoveryAsyncRunner.tryStart();
+        if (!started) {
+            return ResponseEntity.status(409)
+                    .body("손상 이미지 복구 작업이 이미 진행 중입니다. 서버 로그를 확인하세요.");
+        }
+        return ResponseEntity.accepted()
+                .body("손상 이미지 복구 작업을 백그라운드에서 시작했습니다. 진행 상황은 서버 로그를 확인하세요.");
     }
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/ImageRecoveryAsyncRunner.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/ImageRecoveryAsyncRunner.java
@@ -33,11 +33,11 @@ public class ImageRecoveryAsyncRunner {
         try {
             // 다른 빈의 public @Async 메서드 → 프록시 경유 → 백그라운드 스레드에서 실행.
             imageRecoveryTask.run(running);
-        } catch (RuntimeException e) {
-            // 비동기 디스패치 자체가 실패한 경우 플래그가 영구히 잠기지 않도록 해제.
+        } catch (Throwable t) {
+            // 디스패치 실패(스레드 풀 거부, OOM 등 Error 포함) 시 플래그가 영구히 잠기지 않도록 해제.
             running.set(false);
-            log.error("[복구] 비동기 작업 디스패치 실패", e);
-            throw e;
+            log.error("[복구] 비동기 작업 디스패치 실패", t);
+            throw t;
         }
         return true;
     }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/ImageRecoveryAsyncRunner.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/ImageRecoveryAsyncRunner.java
@@ -2,22 +2,24 @@ package capstone.ai_meal_assistant_batch.domain.ingredient.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * 손상 이미지 복구를 백그라운드 스레드에서 비동기 실행한다.
- * 같은 클래스 내부에서 @Async 메서드를 호출하면 Spring 프록시를 거치지 않으므로
- * RecipeDataSyncService와 분리된 별도 빈으로 둔다.
+ * 손상 이미지 복구의 동시 실행을 막는 가드(guard).
+ *
+ * <p>중복 실행 방지 플래그({@link AtomicBoolean})만 소유하고, 실제 비동기 실행은
+ * 별도 빈인 {@link ImageRecoveryTask}에 위임한다. @Async는 프록시를 거쳐 호출될 때만
+ * 동작하므로, 같은 클래스 내부 호출(self-invocation)이 되지 않도록 실행 본체를
+ * 반드시 다른 빈으로 분리해야 한다.
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ImageRecoveryAsyncRunner {
 
-    private final RecipeDataSyncService recipeDataSyncService;
+    private final ImageRecoveryTask imageRecoveryTask;
     private final AtomicBoolean running = new AtomicBoolean(false);
 
     /**
@@ -28,19 +30,15 @@ public class ImageRecoveryAsyncRunner {
             log.info("[복구] 이미 진행 중 — 새 요청 거부");
             return false;
         }
-        runAsync();
-        return true;
-    }
-
-    @Async
-    void runAsync() {
         try {
-            log.info("[복구] 비동기 작업 시작");
-            recipeDataSyncService.recoverCorruptedImages();
-        } catch (Exception e) {
-            log.error("[복구] 비동기 실행 중 오류", e);
-        } finally {
+            // 다른 빈의 public @Async 메서드 → 프록시 경유 → 백그라운드 스레드에서 실행.
+            imageRecoveryTask.run(running);
+        } catch (RuntimeException e) {
+            // 비동기 디스패치 자체가 실패한 경우 플래그가 영구히 잠기지 않도록 해제.
             running.set(false);
+            log.error("[복구] 비동기 작업 디스패치 실패", e);
+            throw e;
         }
+        return true;
     }
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/ImageRecoveryAsyncRunner.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/ImageRecoveryAsyncRunner.java
@@ -1,0 +1,46 @@
+package capstone.ai_meal_assistant_batch.domain.ingredient.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 손상 이미지 복구를 백그라운드 스레드에서 비동기 실행한다.
+ * 같은 클래스 내부에서 @Async 메서드를 호출하면 Spring 프록시를 거치지 않으므로
+ * RecipeDataSyncService와 분리된 별도 빈으로 둔다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ImageRecoveryAsyncRunner {
+
+    private final RecipeDataSyncService recipeDataSyncService;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    /**
+     * @return 새 작업이 시작되었으면 true, 이미 진행 중이라 거부됐으면 false.
+     */
+    public boolean tryStart() {
+        if (!running.compareAndSet(false, true)) {
+            log.info("[복구] 이미 진행 중 — 새 요청 거부");
+            return false;
+        }
+        runAsync();
+        return true;
+    }
+
+    @Async
+    void runAsync() {
+        try {
+            log.info("[복구] 비동기 작업 시작");
+            recipeDataSyncService.recoverCorruptedImages();
+        } catch (Exception e) {
+            log.error("[복구] 비동기 실행 중 오류", e);
+        } finally {
+            running.set(false);
+        }
+    }
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/ImageRecoveryTask.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/ImageRecoveryTask.java
@@ -1,0 +1,41 @@
+package capstone.ai_meal_assistant_batch.domain.ingredient.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 손상 이미지 복구의 실제 비동기 실행 본체.
+ *
+ * <p>@Async는 Spring 프록시를 통해 호출될 때만 동작한다. 따라서 호출자(가드 역할의
+ * {@link ImageRecoveryAsyncRunner})와 반드시 <b>다른 빈</b>에 두고, 메서드는
+ * <b>public</b>으로 선언해야 한다. (같은 클래스 내부 호출 = self-invocation 은 프록시를
+ * 우회하여 @Async 가 무시되고, package-private 메서드는 어드바이스 대상에서 제외된다.)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ImageRecoveryTask {
+
+    private final RecipeDataSyncService recipeDataSyncService;
+
+    /**
+     * 백그라운드 스레드에서 손상 이미지 복구를 수행한다.
+     *
+     * @param running 호출자가 소유한 진행 상태 플래그. 작업 종료 시 false 로 되돌린다.
+     */
+    @Async
+    public void run(AtomicBoolean running) {
+        try {
+            log.info("[복구] 비동기 작업 시작");
+            recipeDataSyncService.recoverCorruptedImages();
+        } catch (Exception e) {
+            log.error("[복구] 비동기 실행 중 오류", e);
+        } finally {
+            running.set(false);
+        }
+    }
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
@@ -47,6 +47,9 @@ public class RecipeDataSyncService {
     private final ObjectMapper objectMapper;
     private final S3ImageUploadService s3ImageUploadService;
 
+    /** 이미지 복구 시 변경분을 끊어 저장하는 청크 크기. */
+    private static final int RECOVERY_SAVE_CHUNK = 100;
+
     @Transactional
     public void syncAllDataFromApi(){
         try{
@@ -200,8 +203,12 @@ public class RecipeDataSyncService {
      *   - S3 객체가 정상이면 URL을 CloudFront(또는 설정된 도메인)로 단순 치환.
      *   - S3 객체가 손상이면 cleaned_recipe_data.json의 원본 URL로 재업로드.
      * - 멱등하고 반복 호출 가능.
+     *
+     * <p>메뉴 수만큼 네트워크 I/O(S3 HEAD/PUT, 원본 이미지 다운로드)를 수행하므로
+     * 메서드 전체를 하나의 트랜잭션으로 묶지 않는다 — 그러면 DB 커넥션을 수십 분간
+     * 점유해 HikariCP 고갈/트랜잭션 타임아웃을 유발한다. 변경분은
+     * {@link #RECOVERY_SAVE_CHUNK}개 단위로 끊어 각자의 짧은 트랜잭션으로 저장한다.
      */
-    @Transactional
     public void recoverCorruptedImages() {
         log.info("[복구] 이미지 URL 점검/복구 시작");
 
@@ -214,23 +221,24 @@ public class RecipeDataSyncService {
         }
         log.info("[복구] 원본 URL 맵 로드 완료: {}건", codeToOriginalUrl.size());
 
+        // 우리 스토리지(S3 직링크 + CloudFront 도메인)에 올라간 메뉴를 모두 검사 대상으로.
+        // amazonaws.com 만 보면 CloudFront 전환 이후 후보가 0개가 되어 재검증이 불가능하다.
         List<Menu> candidates = menuRepository.findAll().stream()
-                .filter(m -> m.getMainImageUrl() != null
-                        && !m.getMainImageUrl().isBlank()
-                        && m.getMainImageUrl().contains("amazonaws.com"))
+                .filter(m -> s3ImageUploadService.isOurStorageUrl(m.getMainImageUrl()))
                 .collect(Collectors.toList());
-        log.info("[복구] 검사 대상(amazonaws.com URL) 메뉴: {}개", candidates.size());
+        log.info("[복구] 검사 대상(S3/CloudFront URL) 메뉴: {}개", candidates.size());
 
         int normalized = 0, corrupt = 0, recovered = 0, missingOrigin = 0, failed = 0;
-        List<Menu> updated = new ArrayList<>();
+        List<Menu> buffer = new ArrayList<>();
         for (Menu menu : candidates) {
             if (s3ImageUploadService.isS3UrlValid(menu.getMainImageUrl())) {
                 String cfUrl = s3ImageUploadService.toCloudFrontUrl(menu.getMainImageUrl());
                 if (!cfUrl.equals(menu.getMainImageUrl())) {
                     menu.updateMainImageUrl(cfUrl);
-                    updated.add(menu);
+                    buffer.add(menu);
                     normalized++;
                 }
+                flushIfFull(buffer);
                 continue;
             }
             corrupt++;
@@ -245,19 +253,28 @@ public class RecipeDataSyncService {
             String newUrl = s3ImageUploadService.uploadFromUrl(originalUrl);
             if (s3ImageUploadService.isOurStorageUrl(newUrl)) {
                 menu.updateMainImageUrl(newUrl);
-                updated.add(menu);
+                buffer.add(menu);
                 recovered++;
             } else {
                 log.warn("[복구] 재업로드 실패: foodCode={}, originalUrl={}", menu.getFoodCode(), originalUrl);
                 failed++;
             }
+            flushIfFull(buffer);
         }
 
-        if (!updated.isEmpty()) {
-            menuRepository.saveAll(updated);
+        if (!buffer.isEmpty()) {
+            menuRepository.saveAll(buffer);
         }
         log.info("[복구] 완료 — URL변경={}, 손상={}, 복구성공={}, 원본URL없음={}, 재업로드실패={}",
                 normalized, corrupt, recovered, missingOrigin, failed);
+    }
+
+    /** 변경 버퍼가 청크 크기에 도달하면 즉시 저장(각자 짧은 트랜잭션)해 커넥션·메모리 부담을 줄인다. */
+    private void flushIfFull(List<Menu> buffer) {
+        if (buffer.size() >= RECOVERY_SAVE_CHUNK) {
+            menuRepository.saveAll(buffer);
+            buffer.clear();
+        }
     }
 
     private Map<String, String> loadOriginalImageUrlMap() throws Exception {

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
@@ -170,28 +170,111 @@ public class RecipeDataSyncService {
             List<Menu> menusToMigrate = menuRepository.findAll().stream()
                     .filter(m -> m.getMainImageUrl() != null
                             && !m.getMainImageUrl().isBlank()
-                            && !m.getMainImageUrl().contains("amazonaws.com"))
+                            && !s3ImageUploadService.isOurStorageUrl(m.getMainImageUrl()))
                     .collect(Collectors.toList());
 
             if (!menusToMigrate.isEmpty()) {
                 log.info("S3 마이그레이션 대상 메뉴: {}개", menusToMigrate.size());
                 int successCount = 0;
                 for (Menu menu : menusToMigrate) {
-                    String s3Url = s3ImageUploadService.uploadFromUrl(menu.getMainImageUrl());
-                    if (s3Url.contains("amazonaws.com")) {
-                        menu.updateMainImageUrl(s3Url);
+                    String newUrl = s3ImageUploadService.uploadFromUrl(menu.getMainImageUrl());
+                    if (s3ImageUploadService.isOurStorageUrl(newUrl)) {
+                        menu.updateMainImageUrl(newUrl);
                         successCount++;
                     }
                 }
                 menuRepository.saveAll(menusToMigrate);
                 log.info("S3 마이그레이션 완료: {}개 성공 / {}개 대상", successCount, menusToMigrate.size());
             } else {
-                log.info("S3 마이그레이션 대상 없음 (이미 모두 S3 URL)");
+                log.info("S3 마이그레이션 대상 없음 (이미 모두 스토리지 URL)");
             }
 
         } catch (Exception e){
             log.error("API 데이터 동기화 중 에러 발생: ", e);
         }
+    }
+
+    /**
+     * 메뉴 이미지 URL을 점검·정리한다.
+     * - amazonaws.com URL인 메뉴를 대상으로:
+     *   - S3 객체가 정상이면 URL을 CloudFront(또는 설정된 도메인)로 단순 치환.
+     *   - S3 객체가 손상이면 cleaned_recipe_data.json의 원본 URL로 재업로드.
+     * - 멱등하고 반복 호출 가능.
+     */
+    @Transactional
+    public void recoverCorruptedImages() {
+        log.info("[복구] 이미지 URL 점검/복구 시작");
+
+        Map<String, String> codeToOriginalUrl;
+        try {
+            codeToOriginalUrl = loadOriginalImageUrlMap();
+        } catch (Exception e) {
+            log.error("[복구] cleaned_recipe_data.json 로드 실패", e);
+            return;
+        }
+        log.info("[복구] 원본 URL 맵 로드 완료: {}건", codeToOriginalUrl.size());
+
+        List<Menu> candidates = menuRepository.findAll().stream()
+                .filter(m -> m.getMainImageUrl() != null
+                        && !m.getMainImageUrl().isBlank()
+                        && m.getMainImageUrl().contains("amazonaws.com"))
+                .collect(Collectors.toList());
+        log.info("[복구] 검사 대상(amazonaws.com URL) 메뉴: {}개", candidates.size());
+
+        int normalized = 0, corrupt = 0, recovered = 0, missingOrigin = 0, failed = 0;
+        List<Menu> updated = new ArrayList<>();
+        for (Menu menu : candidates) {
+            if (s3ImageUploadService.isS3UrlValid(menu.getMainImageUrl())) {
+                String cfUrl = s3ImageUploadService.toCloudFrontUrl(menu.getMainImageUrl());
+                if (!cfUrl.equals(menu.getMainImageUrl())) {
+                    menu.updateMainImageUrl(cfUrl);
+                    updated.add(menu);
+                    normalized++;
+                }
+                continue;
+            }
+            corrupt++;
+
+            String originalUrl = codeToOriginalUrl.get(menu.getFoodCode());
+            if (originalUrl == null || originalUrl.isBlank()) {
+                log.warn("[복구] 원본 URL 없음, 스킵: foodCode={}, name={}", menu.getFoodCode(), menu.getName());
+                missingOrigin++;
+                continue;
+            }
+
+            String newUrl = s3ImageUploadService.uploadFromUrl(originalUrl);
+            if (s3ImageUploadService.isOurStorageUrl(newUrl)) {
+                menu.updateMainImageUrl(newUrl);
+                updated.add(menu);
+                recovered++;
+            } else {
+                log.warn("[복구] 재업로드 실패: foodCode={}, originalUrl={}", menu.getFoodCode(), originalUrl);
+                failed++;
+            }
+        }
+
+        if (!updated.isEmpty()) {
+            menuRepository.saveAll(updated);
+        }
+        log.info("[복구] 완료 — URL변경={}, 손상={}, 복구성공={}, 원본URL없음={}, 재업로드실패={}",
+                normalized, corrupt, recovered, missingOrigin, failed);
+    }
+
+    private Map<String, String> loadOriginalImageUrlMap() throws Exception {
+        ClassPathResource resource = new ClassPathResource("cleaned_recipe_data.json");
+        String rawJson = new String(Files.readAllBytes(Paths.get(resource.getURI())), StandardCharsets.UTF_8);
+        JsonNode rootNode = objectMapper.readTree(rawJson);
+        JsonNode recipeArray = rootNode.isArray() ? rootNode : rootNode.path("COOKRCP01").path("row");
+
+        Map<String, String> map = new HashMap<>();
+        for (JsonNode recipeNode : recipeArray) {
+            String foodCode = recipeNode.path("RCP_SEQ").asText();
+            String url = recipeNode.path("ATT_FILE_NO_MAIN").asText();
+            if (foodCode != null && !foodCode.isBlank() && url != null && !url.isBlank()) {
+                map.put(foodCode, url);
+            }
+        }
+        return map;
     }
 
     /**

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/global/s3/S3ImageUploadService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/global/s3/S3ImageUploadService.java
@@ -125,43 +125,46 @@ public class S3ImageUploadService {
         String currentUrl = originalUrl;
         for (int hop = 0; hop < MAX_REDIRECTS; hop++) {
             HttpURLConnection conn = (HttpURLConnection) URI.create(currentUrl).toURL().openConnection();
-            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
-            conn.setReadTimeout(READ_TIMEOUT_MS);
-            conn.setRequestMethod("GET");
-            conn.setRequestProperty("User-Agent", "Mozilla/5.0 (compatible; NUTRIAgentBatch/1.0)");
-            conn.setRequestProperty("Accept", "image/*,*/*;q=0.8");
-            // http↔https 간 리다이렉트는 기본 false라 직접 추적
-            conn.setInstanceFollowRedirects(false);
+            // 성공/리다이렉트/에러 모든 경로에서 소켓이 정리되도록 finally 에서 disconnect.
+            try {
+                conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+                conn.setReadTimeout(READ_TIMEOUT_MS);
+                conn.setRequestMethod("GET");
+                conn.setRequestProperty("User-Agent", "Mozilla/5.0 (compatible; NUTRIAgentBatch/1.0)");
+                conn.setRequestProperty("Accept", "image/*,*/*;q=0.8");
+                // http↔https 간 리다이렉트는 기본 false라 직접 추적
+                conn.setInstanceFollowRedirects(false);
 
-            int code = conn.getResponseCode();
-            if (code >= 300 && code < 400) {
-                String location = conn.getHeaderField("Location");
-                conn.disconnect();
-                if (location == null || location.isBlank()) {
-                    throw new IOException("리다이렉트 응답에 Location 헤더 없음 (status=" + code + ")");
+                int code = conn.getResponseCode();
+                if (code >= 300 && code < 400) {
+                    String location = conn.getHeaderField("Location");
+                    if (location == null || location.isBlank()) {
+                        throw new IOException("리다이렉트 응답에 Location 헤더 없음 (status=" + code + ")");
+                    }
+                    currentUrl = URI.create(currentUrl).resolve(location).toString();
+                    continue;
                 }
-                currentUrl = URI.create(currentUrl).resolve(location).toString();
-                continue;
-            }
-            if (code < 200 || code >= 300) {
-                conn.disconnect();
-                throw new IOException("HTTP " + code + " " + currentUrl);
-            }
+                if (code < 200 || code >= 300) {
+                    throw new IOException("HTTP " + code + " " + currentUrl);
+                }
 
-            String responseContentType = conn.getContentType();
-            try (InputStream is = conn.getInputStream()) {
-                byte[] bytes = is.readAllBytes();
-                if (bytes.length < MIN_VALID_IMAGE_SIZE) {
-                    throw new IOException("응답 본문이 비정상적으로 작음 (size=" + bytes.length + ")");
+                String responseContentType = conn.getContentType();
+                try (InputStream is = conn.getInputStream()) {
+                    byte[] bytes = is.readAllBytes();
+                    if (bytes.length < MIN_VALID_IMAGE_SIZE) {
+                        throw new IOException("응답 본문이 비정상적으로 작음 (size=" + bytes.length + ")");
+                    }
+                    String contentType = resolveContentType(responseContentType, currentUrl, bytes);
+                    if (!contentType.startsWith("image/")) {
+                        throw new IOException("응답이 이미지가 아님 (header contentType=" + responseContentType + ")");
+                    }
+                    if (!hasImageMagicBytes(bytes)) {
+                        throw new IOException("유효한 이미지 매직 바이트가 아님 (앞 4바이트=" + previewHex(bytes) + ")");
+                    }
+                    return new DownloadedImage(bytes, contentType);
                 }
-                String contentType = resolveContentType(responseContentType, currentUrl, bytes);
-                if (!contentType.startsWith("image/")) {
-                    throw new IOException("응답이 이미지가 아님 (header contentType=" + responseContentType + ")");
-                }
-                if (!hasImageMagicBytes(bytes)) {
-                    throw new IOException("유효한 이미지 매직 바이트가 아님 (앞 4바이트=" + previewHex(bytes) + ")");
-                }
-                return new DownloadedImage(bytes, contentType);
+            } finally {
+                conn.disconnect();
             }
         }
         throw new IOException("리다이렉트 최대 " + MAX_REDIRECTS + "회 초과: " + originalUrl);

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/global/s3/S3ImageUploadService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/global/s3/S3ImageUploadService.java
@@ -7,12 +7,14 @@ import org.springframework.stereotype.Service;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URI;
-import java.net.URL;
 
 @Slf4j
 @Service
@@ -27,61 +29,237 @@ public class S3ImageUploadService {
     @Value("${cloud.aws.region.static}")
     private String region;
 
+    @Value("${cloud.aws.s3.cloudfront-domain:}")
+    private String cloudfrontDomain;
+
+    private static final int CONNECT_TIMEOUT_MS = 10_000;
+    private static final int READ_TIMEOUT_MS = 30_000;
+    private static final int MAX_REDIRECTS = 5;
+    // HTML 에러 페이지/리다이렉트 안내 페이지는 보통 이보다 작음 — 정상 이미지 최소 크기 가드
+    private static final long MIN_VALID_IMAGE_SIZE = 512L;
+
     /**
      * 원본 URL에서 이미지를 다운로드해 S3에 업로드하고 S3 URL을 반환한다.
-     * 빈 URL이면 그대로, 업로드 실패 시 원본 URL을 반환한다.
+     * 응답 상태/Content-Type/매직 바이트를 검증해 손상된 파일이 S3에 올라가지 않도록 한다.
+     * S3에 이미 정상 파일이 있으면 스킵하고, 비정상이면 재업로드한다.
+     * 다운로드/업로드 실패 시 원본 URL을 반환한다.
      */
     public String uploadFromUrl(String originalUrl) {
         if (originalUrl == null || originalUrl.isBlank()) {
             return originalUrl;
         }
-        if (originalUrl.contains("amazonaws.com")) {
+        if (isOurStorageUrl(originalUrl)) {
             return originalUrl;
         }
 
         String fileName = originalUrl.substring(originalUrl.lastIndexOf('/') + 1);
         String key = "images/food/" + fileName;
 
-        if (existsInS3(key)) {
-            log.debug("S3 이미 존재, 스킵: {}", key);
+        if (existsValidInS3(key)) {
+            log.debug("S3 이미 존재(정상), 스킵: {}", key);
             return buildS3Url(key);
         }
 
         try {
-            URL url = URI.create(originalUrl).toURL();
-            try (InputStream is = url.openStream()) {
-                byte[] bytes = is.readAllBytes();
-                String contentType = originalUrl.endsWith(".jpg") || originalUrl.endsWith(".jpeg")
-                        ? "image/jpeg" : "image/png";
-                s3Client.putObject(
-                        PutObjectRequest.builder()
-                                .bucket(bucket)
-                                .key(key)
-                                .contentType(contentType)
-                                .build(),
-                        RequestBody.fromBytes(bytes)
-                );
-                log.info("S3 업로드 성공: {}", key);
-                return buildS3Url(key);
-            }
+            DownloadedImage image = downloadImage(originalUrl);
+            s3Client.putObject(
+                    PutObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(key)
+                            .contentType(image.contentType)
+                            .contentLength((long) image.bytes.length)
+                            .build(),
+                    RequestBody.fromBytes(image.bytes)
+            );
+            log.info("S3 업로드 성공: {} (size={} bytes, contentType={})",
+                    key, image.bytes.length, image.contentType);
+            return buildS3Url(key);
         } catch (Exception e) {
             log.warn("S3 업로드 실패, 원본 URL 사용: {} | 원인: {}", originalUrl, e.getMessage());
             return originalUrl;
         }
     }
 
-    private boolean existsInS3(String key) {
+    /**
+     * 주어진 URL(S3 직링크 또는 CloudFront)이 가리키는 S3 객체가 유효한 이미지인지 확인한다.
+     * (HEAD 1회로 contentType/size를 검사.)
+     */
+    public boolean isS3UrlValid(String url) {
+        String key = extractS3Key(url);
+        if (key == null || key.isBlank()) return false;
+        return existsValidInS3(key);
+    }
+
+    /**
+     * 우리 스토리지(S3 직링크 또는 설정된 CloudFront 도메인)에 속한 URL인지 판별.
+     */
+    public boolean isOurStorageUrl(String url) {
+        if (url == null || url.isBlank()) return false;
+        if (url.contains("amazonaws.com")) return true;
+        if (cloudfrontDomain != null && !cloudfrontDomain.isBlank() && url.contains(cloudfrontDomain)) return true;
+        return false;
+    }
+
+    /**
+     * URL → S3 key. amazonaws.com과 cloudfront 도메인 모두 지원. 매칭 안 되면 null.
+     */
+    private String extractS3Key(String url) {
+        if (url == null || url.isBlank()) return null;
+        if (cloudfrontDomain != null && !cloudfrontDomain.isBlank()) {
+            int idx = url.indexOf(cloudfrontDomain);
+            if (idx >= 0) {
+                int start = idx + cloudfrontDomain.length();
+                if (start < url.length() && url.charAt(start) == '/') {
+                    return url.substring(start + 1);
+                }
+            }
+        }
+        int idx = url.indexOf(".amazonaws.com/");
+        if (idx >= 0) {
+            return url.substring(idx + ".amazonaws.com/".length());
+        }
+        return null;
+    }
+
+    private DownloadedImage downloadImage(String originalUrl) throws IOException {
+        String currentUrl = originalUrl;
+        for (int hop = 0; hop < MAX_REDIRECTS; hop++) {
+            HttpURLConnection conn = (HttpURLConnection) URI.create(currentUrl).toURL().openConnection();
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(READ_TIMEOUT_MS);
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("User-Agent", "Mozilla/5.0 (compatible; NUTRIAgentBatch/1.0)");
+            conn.setRequestProperty("Accept", "image/*,*/*;q=0.8");
+            // http↔https 간 리다이렉트는 기본 false라 직접 추적
+            conn.setInstanceFollowRedirects(false);
+
+            int code = conn.getResponseCode();
+            if (code >= 300 && code < 400) {
+                String location = conn.getHeaderField("Location");
+                conn.disconnect();
+                if (location == null || location.isBlank()) {
+                    throw new IOException("리다이렉트 응답에 Location 헤더 없음 (status=" + code + ")");
+                }
+                currentUrl = URI.create(currentUrl).resolve(location).toString();
+                continue;
+            }
+            if (code < 200 || code >= 300) {
+                conn.disconnect();
+                throw new IOException("HTTP " + code + " " + currentUrl);
+            }
+
+            String responseContentType = conn.getContentType();
+            try (InputStream is = conn.getInputStream()) {
+                byte[] bytes = is.readAllBytes();
+                if (bytes.length < MIN_VALID_IMAGE_SIZE) {
+                    throw new IOException("응답 본문이 비정상적으로 작음 (size=" + bytes.length + ")");
+                }
+                String contentType = resolveContentType(responseContentType, currentUrl, bytes);
+                if (!contentType.startsWith("image/")) {
+                    throw new IOException("응답이 이미지가 아님 (header contentType=" + responseContentType + ")");
+                }
+                if (!hasImageMagicBytes(bytes)) {
+                    throw new IOException("유효한 이미지 매직 바이트가 아님 (앞 4바이트=" + previewHex(bytes) + ")");
+                }
+                return new DownloadedImage(bytes, contentType);
+            }
+        }
+        throw new IOException("리다이렉트 최대 " + MAX_REDIRECTS + "회 초과: " + originalUrl);
+    }
+
+    /**
+     * S3에 이미 객체가 있더라도 contentType이 image/* 가 아니거나 크기가 비정상이면
+     * 손상된 것으로 보고 미존재로 간주해 재업로드를 유도한다.
+     */
+    private boolean existsValidInS3(String key) {
         try {
-            s3Client.headObject(HeadObjectRequest.builder().bucket(bucket).key(key).build());
+            HeadObjectResponse head = s3Client.headObject(
+                    HeadObjectRequest.builder().bucket(bucket).key(key).build());
+            String ct = head.contentType();
+            Long size = head.contentLength();
+            boolean validType = ct != null && ct.toLowerCase().startsWith("image/");
+            boolean validSize = size != null && size >= MIN_VALID_IMAGE_SIZE;
+            if (!validType || !validSize) {
+                log.info("S3 객체 비정상 판단, 재업로드 진행: key={}, contentType={}, size={}",
+                        key, ct, size);
+                return false;
+            }
             return true;
         } catch (NoSuchKeyException e) {
             return false;
         } catch (Exception e) {
+            log.warn("S3 HeadObject 실패, 미존재로 간주: key={}, 원인={}", key, e.getMessage());
             return false;
         }
     }
 
+    private String resolveContentType(String headerContentType, String url, byte[] bytes) {
+        if (headerContentType != null) {
+            String trimmed = headerContentType.toLowerCase();
+            int semi = trimmed.indexOf(';');
+            if (semi > 0) trimmed = trimmed.substring(0, semi).trim();
+            if (trimmed.startsWith("image/")) {
+                return trimmed;
+            }
+        }
+        String fromMagic = guessFromMagicBytes(bytes);
+        if (fromMagic != null) return fromMagic;
+
+        String lower = url.toLowerCase();
+        int q = lower.indexOf('?');
+        if (q > 0) lower = lower.substring(0, q);
+        if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+        if (lower.endsWith(".png")) return "image/png";
+        if (lower.endsWith(".gif")) return "image/gif";
+        if (lower.endsWith(".webp")) return "image/webp";
+        return "application/octet-stream";
+    }
+
+    private String guessFromMagicBytes(byte[] b) {
+        if (b == null || b.length < 4) return null;
+        if ((b[0] & 0xFF) == 0xFF && (b[1] & 0xFF) == 0xD8 && (b[2] & 0xFF) == 0xFF) return "image/jpeg";
+        if ((b[0] & 0xFF) == 0x89 && b[1] == 'P' && b[2] == 'N' && b[3] == 'G') return "image/png";
+        if (b[0] == 'G' && b[1] == 'I' && b[2] == 'F') return "image/gif";
+        if (b.length >= 12 && b[0] == 'R' && b[1] == 'I' && b[2] == 'F' && b[3] == 'F'
+                && b[8] == 'W' && b[9] == 'E' && b[10] == 'B' && b[11] == 'P') return "image/webp";
+        return null;
+    }
+
+    private boolean hasImageMagicBytes(byte[] b) {
+        return guessFromMagicBytes(b) != null;
+    }
+
+    private String previewHex(byte[] b) {
+        int n = Math.min(4, b.length);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < n; i++) sb.append(String.format("%02X ", b[i] & 0xFF));
+        return sb.toString().trim();
+    }
+
     private String buildS3Url(String key) {
+        if (cloudfrontDomain != null && !cloudfrontDomain.isBlank()) {
+            return "https://" + cloudfrontDomain + "/" + key;
+        }
         return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + key;
+    }
+
+    /**
+     * amazonaws.com URL을 CloudFront URL로 치환. CloudFront 도메인이 비어있으면 원본을 그대로 반환.
+     */
+    public String toCloudFrontUrl(String url) {
+        if (url == null || url.isBlank()) return url;
+        if (cloudfrontDomain == null || cloudfrontDomain.isBlank()) return url;
+        String key = extractS3Key(url);
+        if (key == null || key.isBlank()) return url;
+        return "https://" + cloudfrontDomain + "/" + key;
+    }
+
+    private static class DownloadedImage {
+        final byte[] bytes;
+        final String contentType;
+        DownloadedImage(byte[] bytes, String contentType) {
+            this.bytes = bytes;
+            this.contentType = contentType;
+        }
     }
 }


### PR DESCRIPTION
## 배경 / 문제

- S3에 업로드된 일부 식약처 이미지가 손상된 상태로 저장되어 다운로드 시 열리지 않음
  - 응답 검증/매직바이트 확인이 없어 식약처 서버의 HTML 안내 페이지를 이미지로 저장하던 경우 존재
- S3 직링크(`*.amazonaws.com`)는 비공개 버킷 정책상 앱에서 403 → 이미지 미표시
- 이미 손상 상태로 적재된 메뉴들이 STEP 3 마이그레이션 필터(`!contains("amazonaws.com")`)에서 스킵되어 영구히 복구 불가

## 변경 사항

### fix — S3 업로드 안정화 (`S3ImageUploadService`)
- `URL.openStream()` → `HttpURLConnection`으로 교체
  - User-Agent/Accept 헤더, connect 10s / read 30s 타임아웃
  - http↔https 포함 리다이렉트 최대 5회 수동 추적
- HTTP 상태(2xx만 통과) 검증
- 응답 Content-Type이 `image/*`인지 확인 + JPEG/PNG/GIF/WEBP 매직 바이트 검증
- 본문 크기 512바이트 미만은 거부 (HTML 안내 페이지 가드)
- `PutObjectRequest`에 `contentLength` 명시
- `existsInS3` → `existsValidInS3`로 강화: HeadObject의 contentType/size가 비정상이면 미존재로 간주 → 자동 재업로드

### feat — CloudFront URL 통일
- `application.yml`: `cloud.aws.s3.cloudfront-domain: ${AWS_CLOUDFRONT_DOMAIN:}` 추가 (빈 값이면 기존 S3 URL 폴백 — 역호환)
- `S3ImageUploadService`:
  - `buildS3Url(key)` → CloudFront 도메인이 있으면 `https://<cf>/<key>` 반환
  - `isOurStorageUrl(url)` / `extractS3Key(url)` / `toCloudFrontUrl(url)` 헬퍼 추가 (amazonaws.com·CloudFront 양쪽 도메인 처리)
  - `uploadFromUrl` early-return을 `isOurStorageUrl` 기반으로 변경
- `RecipeDataSyncService`:
  - STEP 3 필터: `!contains("amazonaws.com")` → `!isOurStorageUrl(url)`
  - 결과적으로 신규/마이그레이션 메뉴 모두 CloudFront URL로 저장

### feat — 손상 이미지 복구 + URL 일괄 정리 엔드포인트
- `POST /api/admin/data/recover-images` 신설 (`AdminDataController`)
- `RecipeDataSyncService.recoverCorruptedImages()`:
  - DB의 amazonaws.com URL 메뉴 대상으로 HEAD 검사
  - 정상 → CloudFront URL로 단순 치환 (다운로드 없음)
  - 손상 → `cleaned_recipe_data.json`의 원본 URL로 재업로드 (CloudFront URL 반환)
  - 멱등: 정상 파일은 스킵되므로 반복 호출 안전
  - 로그: `[복구] 완료 — URL변경=N, 손상=N, 복구성공=N, 원본URL없음=N, 재업로드실패=N`
- `ImageRecoveryAsyncRunner` 신규: `@Async` 백그라운드 실행 + `AtomicBoolean` 중복 실행 방지
  - 동기 HTTP 응답에 묶일 때 graceful shutdown 30s 초과로 `Thread was interrupted` 발생하는 문제 해결
  - 컨트롤러는 즉시 `202 Accepted`, 진행 중 재요청은 `409 Conflict`
- `AiMealAssistantBatchApplication`에 `@EnableAsync` 추가

운영 절차 (1회성 복구·통일)

# 배치 서버가 일회성 자살 모드라 잠깐 토글
cd ai-meal-assistant-batch
./gradlew bootRun --args='--batch.kamis.run-once=false'

# 다른 터미널에서
curl -X POST http://localhost:8080/api/admin/data/recover-images
# → 202 Accepted

# 서버 로그에서 다음 라인 확인 후 종료
# [복구] 완료 — URL변경=..., 손상=..., 복구성공=..., ...