### PR TITLE
feat: 전체 재료 기준가격 일괄 적재 및 AI 에이전트 가격 데이터 주기적 갱신 구조 개선 (#113)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ __pycache__/
 
 # Claude Code local settings
 .claude/settings.local.json
+
+# ChromaDB runtime data
+user_history_db/

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientRepository.java
@@ -3,11 +3,16 @@ package capstone.ai_meal_assistant_batch.domain.ingredient.repository;
 
 import capstone.ai_meal_assistant_batch.domain.ingredient.entity.Ingredient;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 // 식재료
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
 
     Optional<Ingredient> findByName(String name); // 파이프라인에서 중복 저장 방지용
+
+    @Query("SELECT i FROM Ingredient i WHERE i.id NOT IN (SELECT DISTINCT ip.ingredient.id FROM IngredientPrice ip)")
+    List<Ingredient> findIngredientsWithoutAnyPrice();
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisMappedPriceCommand.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisMappedPriceCommand.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.context.ApplicationContext;
 
 import capstone.ai_meal_assistant_batch.global.log.BatchLog;
+import capstone.ai_meal_assistant_batch.job.price.DefaultPriceFillResult;
+import capstone.ai_meal_assistant_batch.job.price.DefaultPriceFillService;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -21,6 +23,7 @@ public class KamisMappedPriceCommand implements ApplicationRunner {
 	private static final String JOB_NAME = "kamisMappedPriceUpdate";
 
 	private final KamisPriceUpdateService service;
+	private final DefaultPriceFillService defaultPriceFillService;
 	private final ApplicationContext applicationContext;
 
 	@Override
@@ -29,11 +32,20 @@ public class KamisMappedPriceCommand implements ApplicationRunner {
 		try {
 			KamisPriceUpdateResult result = service.updateTodayPrices(false, false);
 			BatchLog.success(JOB_NAME, start, result);
-			int exitCode = SpringApplication.exit(applicationContext, () -> 0);
-			System.exit(exitCode);
 		} catch (Exception e) {
 			BatchLog.fail(JOB_NAME, start, e);
 			throw e;
 		}
+
+		Instant fillStart = BatchLog.start("defaultPriceFill");
+		try {
+			DefaultPriceFillResult fillResult = defaultPriceFillService.fillMissingPrices();
+			BatchLog.success("defaultPriceFill", fillStart, fillResult);
+		} catch (Exception e) {
+			BatchLog.fail("defaultPriceFill", fillStart, e);
+		}
+
+		int exitCode = SpringApplication.exit(applicationContext, () -> 0);
+		System.exit(exitCode);
 	}
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisPriceScheduler.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisPriceScheduler.java
@@ -9,6 +9,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import capstone.ai_meal_assistant_batch.global.log.BatchLog;
+import capstone.ai_meal_assistant_batch.job.price.DefaultPriceFillResult;
+import capstone.ai_meal_assistant_batch.job.price.DefaultPriceFillService;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -19,6 +21,7 @@ public class KamisPriceScheduler {
 	private static final String JOB_NAME = "kamisPriceUpdate";
 
 	private final KamisPriceUpdateService service;
+	private final DefaultPriceFillService defaultPriceFillService;
 
 	@EventListener(ApplicationReadyEvent.class)
 	public void runOnStartup() {
@@ -29,6 +32,7 @@ public class KamisPriceScheduler {
 		} catch (Exception e) {
 			BatchLog.fail(JOB_NAME + ".startup", start, e);
 		}
+		fillDefaultPrices();
 	}
 
 	@Scheduled(cron = "${batch.kamis.cron}")
@@ -40,6 +44,17 @@ public class KamisPriceScheduler {
 		} catch (Exception e) {
 			BatchLog.fail(JOB_NAME, start, e);
 			throw e;
+		}
+		fillDefaultPrices();
+	}
+
+	private void fillDefaultPrices() {
+		Instant start = BatchLog.start("defaultPriceFill");
+		try {
+			DefaultPriceFillResult result = defaultPriceFillService.fillMissingPrices();
+			BatchLog.success("defaultPriceFill", start, result);
+		} catch (Exception e) {
+			BatchLog.fail("defaultPriceFill", start, e);
 		}
 	}
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/price/DefaultPriceFillResult.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/price/DefaultPriceFillResult.java
@@ -1,0 +1,4 @@
+package capstone.ai_meal_assistant_batch.job.price;
+
+public record DefaultPriceFillResult(int filled, int skipped) {
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/price/DefaultPriceFillService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/price/DefaultPriceFillService.java
@@ -1,0 +1,47 @@
+package capstone.ai_meal_assistant_batch.job.price;
+
+import capstone.ai_meal_assistant_batch.domain.ingredient.entity.Ingredient;
+import capstone.ai_meal_assistant_batch.domain.ingredient.entity.IngredientPrice;
+import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientPriceRepository;
+import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DefaultPriceFillService {
+
+    private static final String SOURCE_API = "DEFAULT";
+    private static final String DEFAULT_UNIT = "100g";
+
+    private final IngredientRepository ingredientRepository;
+    private final IngredientPriceRepository ingredientPriceRepository;
+
+    @Transactional
+    public DefaultPriceFillResult fillMissingPrices() {
+        List<Ingredient> missing = ingredientRepository.findIngredientsWithoutAnyPrice();
+        if (missing.isEmpty()) {
+            return new DefaultPriceFillResult(0, 0);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        List<IngredientPrice> records = missing.stream()
+                .map(ingredient -> IngredientPrice.builder()
+                        .ingredient(ingredient)
+                        .sourceApi(SOURCE_API)
+                        .pricePerGram(0.0)
+                        .originalPrice(0)
+                        .originalUnit(DEFAULT_UNIT)
+                        .baseDate(now)
+                        .lastSyncAt(now)
+                        .build())
+                .toList();
+
+        ingredientPriceRepository.saveAll(records);
+        return new DefaultPriceFillResult(records.size(), 0);
+    }
+}

--- a/ai_agent_app/GetMarketPrices.py
+++ b/ai_agent_app/GetMarketPrices.py
@@ -4,11 +4,14 @@ from collections import defaultdict
 
 class GetMarketPrices:
     def __init__(self, price_list: List[Dict]):
+        self._build_index(price_list)
+
+    def _build_index(self, price_list: List[Dict]):
         self.price_data_by_district = defaultdict(list)
         for item in price_list:
             district = item.get('M_GU_NAME')
             self.price_data_by_district[district].append(item)
-        
+
         self.index_by_district: Dict[str, Dict[str, Dict]] = {
             district: {p['PRDLST_NM']: p for p in items}
             for district, items in self.price_data_by_district.items()
@@ -18,7 +21,7 @@ class GetMarketPrices:
         for items in self.price_data_by_district.values():
             all_items.extend(items)
         self._national_pool = all_items
-        
+
         # 상품명별로 가격 모아서 평균 계산
         price_groups = defaultdict(list)
         for p in all_items:
@@ -33,6 +36,9 @@ class GetMarketPrices:
             }
             for name, items in price_groups.items()
         }
+
+    def reload(self, price_list: List[Dict]):
+        self._build_index(price_list)
         
     def _get_target_pool(self, user_district: str = None) -> Tuple[List[Dict], Dict[str, Dict]]:
             # [변경] user_district가 None이면 국가 풀 사용

--- a/ai_agent_app/server.py
+++ b/ai_agent_app/server.py
@@ -1,9 +1,12 @@
+from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from typing import List, Optional
+import asyncio
 import os
 import json
+import requests
 from langchain_openai import ChatOpenAI
 from dotenv import load_dotenv
 
@@ -26,8 +29,6 @@ from ai_agent_app.WeatherAdvisor import WeatherAdvisor
 # 초기화
 # =====================================================================
 load_dotenv()
-app = FastAPI(title="Recipe AI API")
-
 
 # Spring 백엔드 연동
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8080")
@@ -63,6 +64,61 @@ recommendation_engine = RecommendationEngine(graph_builder)
 recommendation_service = RecommendationService(
     recommendation_engine, session_manager
 )
+
+# =====================================================================
+# 가격 데이터 로드 (백엔드 → GetMarketPrices)
+# =====================================================================
+PRICE_RELOAD_INTERVAL_SEC = 86400  # 24시간
+
+
+def _to_market_price_item(p: dict) -> dict:
+    return {
+        "PRDLST_NM": p.get("ingredientName", ""),
+        "A_PRICE": str(p.get("originalPrice") or 0),
+        "UNIT": p.get("originalUnit") or "100g",
+        "M_GU_NAME": p.get("marketName") or "",
+    }
+
+
+def _fetch_prices() -> list:
+    url = f"{BACKEND_URL}/api/v1/ingredients/prices/all"
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        body = resp.json()
+        if body.get("success") and body.get("data"):
+            items = [
+                _to_market_price_item(p)
+                for p in body["data"]
+                if (p.get("originalPrice") or 0) > 0
+            ]
+            print(f"[price-loader] 가격 데이터 로드 완료: {len(items)}개")
+            return items
+    except Exception as e:
+        print(f"[price-loader] 가격 로드 실패 (기존 데이터 유지): {e}")
+    return []
+
+
+async def _price_reload_loop():
+    while True:
+        await asyncio.sleep(PRICE_RELOAD_INTERVAL_SEC)
+        items = await asyncio.to_thread(_fetch_prices)
+        if items:
+            get_market_prices.reload(items)
+            print(f"[price-loader] 가격 데이터 갱신 완료: {len(items)}개")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    items = await asyncio.to_thread(_fetch_prices)
+    if items:
+        get_market_prices.reload(items)
+    reload_task = asyncio.create_task(_price_reload_loop())
+    yield
+    reload_task.cancel()
+
+
+app = FastAPI(title="Recipe AI API", lifespan=lifespan)
 
 # =====================================================================
 # Pydantic 모델


### PR DESCRIPTION
## 개요

`GetMarketPrices`가 빈 리스트 `[]`로 초기화되어 AI 추천 시 가격 정보가
항상 없던 문제를 해결합니다.
또한 KAMIS 매핑된 재료만 `ingredient_prices`에 존재하던 커버리지 문제를 해소합니다.

## 변경 사항

### 배치 서버
- `DefaultPriceFillService` 추가
  - `ingredient_prices` 레코드가 없는 재료에 `sourceApi=DEFAULT`, `pricePerGram=0` 기본값 삽입
  - 멱등 보장 (ON DUPLICATE KEY 방지)
- `KamisPriceScheduler`, `KamisMappedPriceCommand` 양쪽에서
  KAMIS 가격 수집 완료 후 `fillMissingPrices()` 자동 호출

### AI 에이전트
- `GetMarketPrices.reload(price_list)` 메서드 추가 (인플레이스 갱신)
- `server.py` lifespan 훅에서 시작 시 `/api/v1/ingredients/prices/all` 초기 로드
- 24시간 주기 백그라운드 재로드 태스크 추가

### 기타
- `user_history_db/` (ChromaDB 런타임 파일) `.gitignore` 추가

## 효과

- AI 추천 파이프라인이 실제 KAMIS 가격 데이터를 활용
- KAMIS 미매핑 재료도 `pricePerGram=0`으로 파이프라인 정상 처리
- 서버 재시작 없이 가격 데이터 24시간 자동 갱신

## 테스트 방법

1. 배치 서버 시작 → 로그에 `[DefaultPriceFillService] filled N rows` 확인
2. AI 에이전트 서버 시작 → 로그에 `[lifespan] market prices loaded: N items` 확인
3. AI 추천 요청 → 응답 `market_prices` 필드에 실제 가격 데이터 포함 여부 확인