### PR TITLE
feat: 시세 탭 관심 재료 즐겨찾기 및 가격 동향 중심 UX 개편 (#114)

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/controller/UserFavoriteIngredientController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/controller/UserFavoriteIngredientController.java
@@ -1,0 +1,71 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.controller;
+
+import capstone.ai_meal_assistant_backend.domain.ingredient.service.UserFavoriteIngredientService;
+import capstone.ai_meal_assistant_backend.global.security.JwtUtil;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
+
+@RestController
+@RequestMapping("/api/v1/ingredients/favorites")
+@RequiredArgsConstructor
+public class UserFavoriteIngredientController {
+
+    private final UserFavoriteIngredientService favoriteService;
+    private final JwtUtil jwtUtil;
+
+    @Getter
+    @AllArgsConstructor
+    private static class ApiResponse<T> {
+        private boolean success;
+        private T data;
+        private String error;
+
+        static <T> ApiResponse<T> ok(T data) {
+            return new ApiResponse<>(true, data, null);
+        }
+
+        static <T> ApiResponse<T> fail(String error) {
+            return new ApiResponse<>(false, null, error);
+        }
+    }
+
+    /** GET /api/v1/ingredients/favorites/ids — 관심 재료 ID 목록 */
+    @GetMapping("/ids")
+    public ResponseEntity<ApiResponse<Set<Long>>> getFavoriteIds(
+            @RequestHeader("Authorization") String authHeader) {
+        String email = extractEmail(authHeader);
+        return ResponseEntity.ok(ApiResponse.ok(favoriteService.getFavoriteIds(email)));
+    }
+
+    /** POST /api/v1/ingredients/favorites/{ingredientId} — 관심 재료 추가 */
+    @PostMapping("/{ingredientId}")
+    public ResponseEntity<ApiResponse<Void>> addFavorite(
+            @RequestHeader("Authorization") String authHeader,
+            @PathVariable Long ingredientId) {
+        String email = extractEmail(authHeader);
+        favoriteService.addFavorite(email, ingredientId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    /** DELETE /api/v1/ingredients/favorites/{ingredientId} — 관심 재료 제거 */
+    @DeleteMapping("/{ingredientId}")
+    public ResponseEntity<ApiResponse<Void>> removeFavorite(
+            @RequestHeader("Authorization") String authHeader,
+            @PathVariable Long ingredientId) {
+        String email = extractEmail(authHeader);
+        favoriteService.removeFavorite(email, ingredientId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    private String extractEmail(String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new IllegalArgumentException("유효하지 않은 인증 헤더입니다.");
+        }
+        return jwtUtil.getEmailFromToken(authHeader.substring(7));
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/entity/UserFavoriteIngredient.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/entity/UserFavoriteIngredient.java
@@ -1,0 +1,30 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.entity;
+
+import capstone.ai_meal_assistant_backend.domain.user.entity.User;
+import capstone.ai_meal_assistant_backend.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "user_favorite_ingredients",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "ingredient_id"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserFavoriteIngredient extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ingredient_id", nullable = false)
+    private Ingredient ingredient;
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/IngredientRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/IngredientRepository.java
@@ -1,0 +1,7 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.repository;
+
+import capstone.ai_meal_assistant_backend.domain.ingredient.entity.Ingredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/UserFavoriteIngredientRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/UserFavoriteIngredientRepository.java
@@ -1,0 +1,18 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.repository;
+
+import capstone.ai_meal_assistant_backend.domain.ingredient.entity.UserFavoriteIngredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface UserFavoriteIngredientRepository extends JpaRepository<UserFavoriteIngredient, Long> {
+
+    boolean existsByUserIdAndIngredientId(Long userId, Long ingredientId);
+
+    void deleteByUserIdAndIngredientId(Long userId, Long ingredientId);
+
+    @Query("SELECT f.ingredient.id FROM UserFavoriteIngredient f WHERE f.user.id = :userId")
+    List<Long> findIngredientIdsByUserId(@Param("userId") Long userId);
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/service/UserFavoriteIngredientService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/service/UserFavoriteIngredientService.java
@@ -1,0 +1,49 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.service;
+
+import capstone.ai_meal_assistant_backend.domain.ingredient.entity.Ingredient;
+import capstone.ai_meal_assistant_backend.domain.ingredient.entity.UserFavoriteIngredient;
+import capstone.ai_meal_assistant_backend.domain.ingredient.repository.IngredientRepository;
+import capstone.ai_meal_assistant_backend.domain.ingredient.repository.UserFavoriteIngredientRepository;
+import capstone.ai_meal_assistant_backend.domain.user.entity.User;
+import capstone.ai_meal_assistant_backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class UserFavoriteIngredientService {
+
+    private final UserFavoriteIngredientRepository favoriteRepository;
+    private final UserRepository userRepository;
+    private final IngredientRepository ingredientRepository;
+
+    @Transactional(readOnly = true)
+    public Set<Long> getFavoriteIds(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        return Set.copyOf(favoriteRepository.findIngredientIdsByUserId(user.getId()));
+    }
+
+    @Transactional
+    public void addFavorite(String email, Long ingredientId) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        if (favoriteRepository.existsByUserIdAndIngredientId(user.getId(), ingredientId)) return;
+        Ingredient ingredient = ingredientRepository.findById(ingredientId)
+                .orElseThrow(() -> new IllegalArgumentException("재료를 찾을 수 없습니다: " + ingredientId));
+        favoriteRepository.save(UserFavoriteIngredient.builder()
+                .user(user)
+                .ingredient(ingredient)
+                .build());
+    }
+
+    @Transactional
+    public void removeFavorite(String email, Long ingredientId) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        favoriteRepository.deleteByUserIdAndIngredientId(user.getId(), ingredientId);
+    }
+}

--- a/flutter_app/lib/models/market_price_models.dart
+++ b/flutter_app/lib/models/market_price_models.dart
@@ -1,4 +1,5 @@
 class IngredientPriceModel {
+  final int? ingredientId;
   final String ingredientName;
   final double pricePerGram;
   final int? originalPrice;
@@ -11,6 +12,7 @@ class IngredientPriceModel {
   final double? monthChangeRate;
 
   const IngredientPriceModel({
+    this.ingredientId,
     required this.ingredientName,
     required this.pricePerGram,
     this.originalPrice,
@@ -25,6 +27,7 @@ class IngredientPriceModel {
 
   factory IngredientPriceModel.fromJson(Map<String, dynamic> json) {
     return IngredientPriceModel(
+      ingredientId: json['ingredientId'] as int?,
       ingredientName: json['ingredientName'] as String,
       pricePerGram: (json['pricePerGram'] as num).toDouble(),
       originalPrice: json['originalPrice'] as int?,

--- a/flutter_app/lib/screens/market_price_detail_screen.dart
+++ b/flutter_app/lib/screens/market_price_detail_screen.dart
@@ -2,10 +2,35 @@ import 'package:flutter/material.dart';
 import 'package:flutter_app/models/market_price_models.dart';
 import 'package:flutter_app/theme.dart';
 
-class MarketPriceDetailScreen extends StatelessWidget {
+class MarketPriceDetailScreen extends StatefulWidget {
   final IngredientPriceModel price;
+  final bool isFavorite;
+  final VoidCallback? onFavoriteToggle;
 
-  const MarketPriceDetailScreen({super.key, required this.price});
+  const MarketPriceDetailScreen({
+    super.key,
+    required this.price,
+    this.isFavorite = false,
+    this.onFavoriteToggle,
+  });
+
+  @override
+  State<MarketPriceDetailScreen> createState() => _MarketPriceDetailScreenState();
+}
+
+class _MarketPriceDetailScreenState extends State<MarketPriceDetailScreen> {
+  late bool _isFavorite;
+
+  @override
+  void initState() {
+    super.initState();
+    _isFavorite = widget.isFavorite;
+  }
+
+  void _handleFavoriteToggle() {
+    setState(() => _isFavorite = !_isFavorite);
+    widget.onFavoriteToggle?.call();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -38,7 +63,7 @@ class MarketPriceDetailScreen extends StatelessWidget {
 
   Widget _buildTopBar(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(8, 12, 24, 4),
+      padding: const EdgeInsets.fromLTRB(8, 12, 8, 4),
       child: Row(
         children: [
           IconButton(
@@ -47,10 +72,18 @@ class MarketPriceDetailScreen extends StatelessWidget {
           ),
           Expanded(
             child: Text(
-              price.ingredientName,
+              widget.price.ingredientName,
               style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w800),
             ),
           ),
+          if (widget.onFavoriteToggle != null)
+            IconButton(
+              icon: Icon(
+                _isFavorite ? Icons.favorite : Icons.favorite_border,
+                color: _isFavorite ? Colors.redAccent : Colors.grey[400],
+              ),
+              onPressed: _handleFavoriteToggle,
+            ),
         ],
       ),
     );
@@ -76,7 +109,7 @@ class MarketPriceDetailScreen extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           Text(
-            price.displayPrice,
+            widget.price.displayPrice,
             style: const TextStyle(
               fontSize: 26,
               fontWeight: FontWeight.w900,
@@ -85,7 +118,7 @@ class MarketPriceDetailScreen extends StatelessWidget {
           ),
           const SizedBox(height: 6),
           Text(
-            price.displayDate,
+            widget.price.displayDate,
             style: TextStyle(
               fontSize: 12,
               color: Colors.white.withValues(alpha: 0.75),
@@ -97,9 +130,8 @@ class MarketPriceDetailScreen extends StatelessWidget {
   }
 
   Widget _buildChangeRatesCard() {
-    final hasAny = price.dayChangeRate != null ||
-        price.weekChangeRate != null ||
-        price.monthChangeRate != null;
+    final p = widget.price;
+    final hasAny = p.dayChangeRate != null || p.weekChangeRate != null || p.monthChangeRate != null;
     if (!hasAny) return const SizedBox.shrink();
 
     return Container(
@@ -120,22 +152,17 @@ class MarketPriceDetailScreen extends StatelessWidget {
         children: [
           const Text(
             '가격 변동률',
-            style: TextStyle(
-              fontSize: 14,
-              fontWeight: FontWeight.w700,
-              color: Colors.black87,
-            ),
+            style: TextStyle(fontSize: 14, fontWeight: FontWeight.w700, color: Colors.black87),
           ),
           const SizedBox(height: 16),
-          if (price.dayChangeRate != null)
-            _buildRateBar('전일 대비', price.dayChangeRate!),
-          if (price.weekChangeRate != null) ...[
+          if (p.dayChangeRate != null) _buildRateBar('전일 대비', p.dayChangeRate!),
+          if (p.weekChangeRate != null) ...[
             const SizedBox(height: 14),
-            _buildRateBar('1주일 전 대비', price.weekChangeRate!),
+            _buildRateBar('1주일 전 대비', p.weekChangeRate!),
           ],
-          if (price.monthChangeRate != null) ...[
+          if (p.monthChangeRate != null) ...[
             const SizedBox(height: 14),
-            _buildRateBar('1개월 전 대비', price.monthChangeRate!),
+            _buildRateBar('1개월 전 대비', p.monthChangeRate!),
           ],
         ],
       ),
@@ -156,19 +183,10 @@ class MarketPriceDetailScreen extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
+            Text(label, style: const TextStyle(fontSize: 12, color: Colors.black54)),
             Text(
-              label,
-              style: const TextStyle(fontSize: 12, color: Colors.black54),
-            ),
-            Text(
-              isZero
-                  ? '변동 없음'
-                  : '${isPositive ? '+' : ''}${rate.toStringAsFixed(1)}%',
-              style: TextStyle(
-                fontSize: 13,
-                fontWeight: FontWeight.w700,
-                color: color,
-              ),
+              isZero ? '변동 없음' : '${isPositive ? '+' : ''}${rate.toStringAsFixed(1)}%',
+              style: TextStyle(fontSize: 13, fontWeight: FontWeight.w700, color: color),
             ),
           ],
         ),
@@ -187,9 +205,8 @@ class MarketPriceDetailScreen extends StatelessWidget {
   }
 
   Widget _buildMarketInfoCard() {
-    if (price.marketName == null && price.marketType == null) {
-      return const SizedBox.shrink();
-    }
+    final p = widget.price;
+    if (p.marketName == null && p.marketType == null) return const SizedBox.shrink();
 
     return Container(
       padding: const EdgeInsets.all(20),
@@ -209,20 +226,16 @@ class MarketPriceDetailScreen extends StatelessWidget {
         children: [
           const Text(
             '시장 정보',
-            style: TextStyle(
-              fontSize: 14,
-              fontWeight: FontWeight.w700,
-              color: Colors.black87,
-            ),
+            style: TextStyle(fontSize: 14, fontWeight: FontWeight.w700, color: Colors.black87),
           ),
           const SizedBox(height: 14),
-          if (price.marketName != null) _buildInfoRow('시장명', price.marketName!),
-          if (price.marketType != null) ...[
+          if (p.marketName != null) _buildInfoRow('시장명', p.marketName!),
+          if (p.marketType != null) ...[
             const SizedBox(height: 10),
-            _buildInfoRow('유형', price.marketType!),
+            _buildInfoRow('유형', p.marketType!),
           ],
           const SizedBox(height: 10),
-          _buildInfoRow('기준일', price.displayDate),
+          _buildInfoRow('기준일', p.displayDate),
         ],
       ),
     );
@@ -234,10 +247,7 @@ class MarketPriceDetailScreen extends StatelessWidget {
       children: [
         SizedBox(
           width: 64,
-          child: Text(
-            label,
-            style: const TextStyle(fontSize: 13, color: Colors.black54),
-          ),
+          child: Text(label, style: const TextStyle(fontSize: 13, color: Colors.black54)),
         ),
         Expanded(
           child: Text(

--- a/flutter_app/lib/screens/market_price_detail_screen.dart
+++ b/flutter_app/lib/screens/market_price_detail_screen.dart
@@ -49,8 +49,6 @@ class _MarketPriceDetailScreenState extends State<MarketPriceDetailScreen> {
                     _buildPriceHeroCard(),
                     const SizedBox(height: 16),
                     _buildChangeRatesCard(),
-                    const SizedBox(height: 16),
-                    _buildMarketInfoCard(),
                   ],
                 ),
               ),
@@ -123,6 +121,21 @@ class _MarketPriceDetailScreenState extends State<MarketPriceDetailScreen> {
               fontSize: 12,
               color: Colors.white.withValues(alpha: 0.75),
             ),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Icon(Icons.verified_outlined,
+                  size: 12, color: Colors.white.withValues(alpha: 0.6)),
+              const SizedBox(width: 4),
+              Text(
+                'KAMIS 한국농수산식품유통공사 제공',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: Colors.white.withValues(alpha: 0.6),
+                ),
+              ),
+            ],
           ),
         ],
       ),
@@ -204,62 +217,4 @@ class _MarketPriceDetailScreenState extends State<MarketPriceDetailScreen> {
     );
   }
 
-  Widget _buildMarketInfoCard() {
-    final p = widget.price;
-    if (p.marketName == null && p.marketType == null) return const SizedBox.shrink();
-
-    return Container(
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.04),
-            blurRadius: 8,
-            offset: const Offset(0, 2),
-          ),
-        ],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const Text(
-            '시장 정보',
-            style: TextStyle(fontSize: 14, fontWeight: FontWeight.w700, color: Colors.black87),
-          ),
-          const SizedBox(height: 14),
-          if (p.marketName != null) _buildInfoRow('시장명', p.marketName!),
-          if (p.marketType != null) ...[
-            const SizedBox(height: 10),
-            _buildInfoRow('유형', p.marketType!),
-          ],
-          const SizedBox(height: 10),
-          _buildInfoRow('기준일', p.displayDate),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildInfoRow(String label, String value) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        SizedBox(
-          width: 64,
-          child: Text(label, style: const TextStyle(fontSize: 13, color: Colors.black54)),
-        ),
-        Expanded(
-          child: Text(
-            value,
-            style: const TextStyle(
-              fontSize: 13,
-              fontWeight: FontWeight.w600,
-              color: Colors.black87,
-            ),
-          ),
-        ),
-      ],
-    );
-  }
 }

--- a/flutter_app/lib/screens/market_price_screen.dart
+++ b/flutter_app/lib/screens/market_price_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_app/models/market_price_models.dart';
 import 'package:flutter_app/screens/market_price_detail_screen.dart';
+import 'package:flutter_app/services/favorite_ingredient_service.dart';
 import 'package:flutter_app/services/market_price_service.dart';
 import 'package:flutter_app/theme.dart';
 
@@ -14,14 +15,16 @@ class MarketPriceScreen extends StatefulWidget {
 class _MarketPriceScreenState extends State<MarketPriceScreen> {
   List<IngredientPriceModel> _allPrices = [];
   List<IngredientPriceModel> _filtered = [];
+  Set<int> _favoriteIds = {};
   bool _isLoading = true;
   String? _error;
+  bool _showFavoritesOnly = false;
   final TextEditingController _searchController = TextEditingController();
 
   @override
   void initState() {
     super.initState();
-    _loadPrices();
+    _loadAll();
   }
 
   @override
@@ -30,16 +33,22 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
     super.dispose();
   }
 
-  Future<void> _loadPrices() async {
+  Future<void> _loadAll() async {
     setState(() {
       _isLoading = true;
       _error = null;
     });
     try {
-      final prices = await MarketPriceService.getAllPrices();
+      final results = await Future.wait([
+        MarketPriceService.getAllPrices(),
+        FavoriteIngredientService.getFavoriteIds(),
+      ]);
+      final prices = results[0] as List<IngredientPriceModel>;
+      final favIds = results[1] as Set<int>;
       setState(() {
         _allPrices = prices;
-        _filtered = prices;
+        _favoriteIds = favIds;
+        _filtered = _applyFilter(prices);
         _isLoading = false;
       });
     } catch (e) {
@@ -50,15 +59,57 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
     }
   }
 
+  List<IngredientPriceModel> _applyFilter(List<IngredientPriceModel> source) {
+    final q = _searchController.text.trim();
+    var list = _showFavoritesOnly
+        ? source.where((p) => p.ingredientId != null && _favoriteIds.contains(p.ingredientId)).toList()
+        : source;
+    if (q.isNotEmpty) {
+      list = list.where((p) => p.ingredientName.contains(q)).toList();
+    }
+    return list;
+  }
+
   void _onSearch(String query) {
-    final q = query.trim();
+    setState(() => _filtered = _applyFilter(_allPrices));
+  }
+
+  void _onTabChanged(bool favoritesOnly) {
     setState(() {
-      _filtered = q.isEmpty
-          ? _allPrices
-          : _allPrices
-              .where((p) => p.ingredientName.contains(q))
-              .toList();
+      _showFavoritesOnly = favoritesOnly;
+      _filtered = _applyFilter(_allPrices);
     });
+  }
+
+  Future<void> _toggleFavorite(IngredientPriceModel price) async {
+    final id = price.ingredientId;
+    if (id == null) return;
+    final isFav = _favoriteIds.contains(id);
+    setState(() {
+      if (isFav) {
+        _favoriteIds = Set.from(_favoriteIds)..remove(id);
+      } else {
+        _favoriteIds = Set.from(_favoriteIds)..add(id);
+      }
+      _filtered = _applyFilter(_allPrices);
+    });
+    try {
+      if (isFav) {
+        await FavoriteIngredientService.removeFavorite(id);
+      } else {
+        await FavoriteIngredientService.addFavorite(id);
+      }
+    } catch (_) {
+      // 실패 시 롤백
+      setState(() {
+        if (isFav) {
+          _favoriteIds = Set.from(_favoriteIds)..add(id);
+        } else {
+          _favoriteIds = Set.from(_favoriteIds)..remove(id);
+        }
+        _filtered = _applyFilter(_allPrices);
+      });
+    }
   }
 
   @override
@@ -70,6 +121,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _buildHeader(),
+            _buildTabRow(),
             _buildSearchBar(),
             Expanded(child: _buildBody()),
           ],
@@ -102,6 +154,44 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
     );
   }
 
+  Widget _buildTabRow() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 0, 24, 4),
+      child: Row(
+        children: [
+          _buildTabChip('전체', !_showFavoritesOnly, () => _onTabChanged(false)),
+          const SizedBox(width: 8),
+          _buildTabChip('관심 재료', _showFavoritesOnly, () => _onTabChanged(true)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTabChip(String label, bool selected, VoidCallback onTap) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 180),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 7),
+        decoration: BoxDecoration(
+          color: selected ? AppTheme.primaryColor : Colors.transparent,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: selected ? AppTheme.primaryColor : Colors.grey.shade300,
+          ),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: selected ? Colors.white : Colors.grey[600],
+          ),
+        ),
+      ),
+    );
+  }
+
   Widget _buildSearchBar() {
     return Padding(
       padding: const EdgeInsets.fromLTRB(24, 8, 24, 16),
@@ -129,9 +219,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
   Widget _buildBody() {
     if (_isLoading) {
       return const Center(
-        child: CircularProgressIndicator(
-          color: AppTheme.primaryColor,
-        ),
+        child: CircularProgressIndicator(color: AppTheme.primaryColor),
       );
     }
 
@@ -147,10 +235,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
               style: TextStyle(color: Colors.grey[600], fontSize: 15),
             ),
             const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: _loadPrices,
-              child: const Text('다시 시도'),
-            ),
+            ElevatedButton(onPressed: _loadAll, child: const Text('다시 시도')),
           ],
         ),
       );
@@ -161,24 +246,33 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.search_off, size: 48, color: Colors.grey[400]),
+            Icon(
+              _showFavoritesOnly ? Icons.favorite_border : Icons.search_off,
+              size: 48,
+              color: Colors.grey[400],
+            ),
             const SizedBox(height: 12),
             Text(
-              _searchController.text.isNotEmpty
-                  ? "'${_searchController.text}'에 대한 시세 정보가 없습니다"
-                  : '시세 정보가 없습니다',
-              style: TextStyle(color: Colors.grey[600], fontSize: 15),
+              _showFavoritesOnly
+                  ? '관심 재료를 추가해보세요\n시세 카드의 하트를 눌러 저장할 수 있어요'
+                  : (_searchController.text.isNotEmpty
+                      ? "'${_searchController.text}'에 대한 시세 정보가 없습니다"
+                      : '시세 정보가 없습니다'),
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Colors.grey[600], fontSize: 15, height: 1.5),
             ),
           ],
         ),
       );
     }
 
-    final bool showSummary = _allPrices.any((p) => p.dayChangeRate != null);
+    final bool showSummary = !_showFavoritesOnly &&
+        _searchController.text.isEmpty &&
+        _allPrices.any((p) => p.dayChangeRate != null);
 
     return RefreshIndicator(
       color: AppTheme.primaryColor,
-      onRefresh: _loadPrices,
+      onRefresh: _loadAll,
       child: ListView.builder(
         padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
         itemCount: _filtered.length + (showSummary ? 1 : 0),
@@ -288,12 +382,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
     final icon = isUp ? Icons.arrow_upward : Icons.arrow_downward;
     final rate = price.dayChangeRate!.abs().toStringAsFixed(1);
     return GestureDetector(
-      onTap: () => Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (_) => MarketPriceDetailScreen(price: price),
-        ),
-      ),
+      onTap: () => _pushDetail(price),
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
         decoration: BoxDecoration(
@@ -330,87 +419,109 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
   }
 
   Widget _buildPriceCard(IngredientPriceModel price) {
+    final isFav = price.ingredientId != null && _favoriteIds.contains(price.ingredientId);
     return GestureDetector(
-      onTap: () => Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (_) => MarketPriceDetailScreen(price: price),
-        ),
-      ),
+      onTap: () => _pushDetail(price),
       child: Container(
-      margin: const EdgeInsets.only(bottom: 10),
-      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.04),
-            blurRadius: 8,
-            offset: const Offset(0, 2),
-          ),
-        ],
-      ),
-      child: Row(
-        children: [
-          Container(
-            width: 40,
-            height: 40,
-            decoration: BoxDecoration(
-              color: AppTheme.primaryColor.withValues(alpha: 0.1),
-              borderRadius: BorderRadius.circular(10),
+        margin: const EdgeInsets.only(bottom: 10),
+        padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.04),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
             ),
-            child: const Icon(
-              Icons.storefront_outlined,
-              color: AppTheme.primaryColor,
-              size: 20,
+          ],
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                color: AppTheme.primaryColor.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: const Icon(
+                Icons.storefront_outlined,
+                color: AppTheme.primaryColor,
+                size: 20,
+              ),
             ),
-          ),
-          const SizedBox(width: 14),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    price.ingredientName,
+                    style: const TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.black87,
+                    ),
+                  ),
+                  const SizedBox(height: 3),
+                  Text(
+                    price.marketName ?? '',
+                    style: TextStyle(fontSize: 12, color: Colors.grey[500]),
+                  ),
+                ],
+              ),
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
               children: [
                 Text(
-                  price.ingredientName,
+                  price.displayPrice,
                   style: const TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.w600,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
                     color: Colors.black87,
                   ),
                 ),
                 const SizedBox(height: 3),
-                Text(
-                  price.marketName != null ? price.marketName! : '',
-                  style: TextStyle(fontSize: 12, color: Colors.grey[500]),
-                ),
+                if (price.dayChangeRate != null)
+                  _buildChangeRateBadge(price.dayChangeRate!)
+                else
+                  Text(
+                    price.displayDate,
+                    style: TextStyle(fontSize: 11, color: Colors.grey[400]),
+                  ),
               ],
             ),
-          ),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              Text(
-                price.displayPrice,
-                style: const TextStyle(
-                  fontSize: 14,
-                  fontWeight: FontWeight.w700,
-                  color: Colors.black87,
+            const SizedBox(width: 4),
+            GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () => _toggleFavorite(price),
+              child: Padding(
+                padding: const EdgeInsets.all(4),
+                child: Icon(
+                  isFav ? Icons.favorite : Icons.favorite_border,
+                  size: 20,
+                  color: isFav ? Colors.redAccent : Colors.grey[400],
                 ),
               ),
-              const SizedBox(height: 3),
-              if (price.dayChangeRate != null)
-                _buildChangeRateBadge(price.dayChangeRate!)
-              else
-                Text(
-                  price.displayDate,
-                  style: TextStyle(fontSize: 11, color: Colors.grey[400]),
-                ),
-            ],
-          ),
-        ],
+            ),
+          ],
+        ),
       ),
-    ),
+    );
+  }
+
+  void _pushDetail(IngredientPriceModel price) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => MarketPriceDetailScreen(
+          price: price,
+          isFavorite: price.ingredientId != null && _favoriteIds.contains(price.ingredientId),
+          onFavoriteToggle: price.ingredientId != null ? () => _toggleFavorite(price) : null,
+        ),
+      ),
     );
   }
 }

--- a/flutter_app/lib/screens/market_price_screen.dart
+++ b/flutter_app/lib/screens/market_price_screen.dart
@@ -153,18 +153,21 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
             decoration: BoxDecoration(
-              color: Colors.amber.shade50,
+              color: AppTheme.primaryColor.withValues(alpha: 0.08),
               borderRadius: BorderRadius.circular(8),
-              border: Border.all(color: Colors.amber.shade200),
+              border: Border.all(color: AppTheme.primaryColor.withValues(alpha: 0.25)),
             ),
             child: Row(
               children: [
-                Icon(Icons.info_outline, size: 13, color: Colors.amber.shade700),
+                Icon(Icons.info_outline, size: 13, color: AppTheme.primaryColor),
                 const SizedBox(width: 6),
                 Expanded(
                   child: Text(
                     '도·소매 기준 가격으로, 실제 마트·시장 판매가와 다를 수 있습니다.',
-                    style: TextStyle(fontSize: 11, color: Colors.amber.shade800),
+                    style: TextStyle(
+                      fontSize: 11,
+                      color: AppTheme.primaryColor.withValues(alpha: 0.85),
+                    ),
                   ),
                 ),
               ],

--- a/flutter_app/lib/screens/market_price_screen.dart
+++ b/flutter_app/lib/screens/market_price_screen.dart
@@ -149,6 +149,27 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
             'KAMIS 농수산물 전일 대비 등락 정보',
             style: TextStyle(fontSize: 14, color: Colors.grey[500]),
           ),
+          const SizedBox(height: 10),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+            decoration: BoxDecoration(
+              color: Colors.amber.shade50,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: Colors.amber.shade200),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.info_outline, size: 13, color: Colors.amber.shade700),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    '도·소매 기준 가격으로, 실제 마트·시장 판매가와 다를 수 있습니다.',
+                    style: TextStyle(fontSize: 11, color: Colors.amber.shade800),
+                  ),
+                ),
+              ],
+            ),
+          ),
         ],
       ),
     );

--- a/flutter_app/lib/screens/market_price_screen.dart
+++ b/flutter_app/lib/screens/market_price_screen.dart
@@ -140,13 +140,13 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
             blendMode: BlendMode.srcIn,
             shaderCallback: (bounds) => AppTheme.aiGradient.createShader(bounds),
             child: const Text(
-              '오늘의 시세',
+              '식재료 가격 동향',
               style: TextStyle(fontSize: 28, fontWeight: FontWeight.w900),
             ),
           ),
           const SizedBox(height: 4),
           Text(
-            'KAMIS 실시간 농수산물 가격 정보',
+            'KAMIS 농수산물 전일 대비 등락 정보',
             style: TextStyle(fontSize: 14, color: Colors.grey[500]),
           ),
         ],
@@ -285,7 +285,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
     );
   }
 
-  Widget _buildChangeRateBadge(double rate) {
+  Widget _buildChangeRateColumn(double rate) {
     final isPositive = rate > 0;
     final isZero = rate == 0;
     final color = isZero
@@ -294,29 +294,30 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
     final icon = isZero
         ? Icons.remove
         : (isPositive ? Icons.arrow_upward : Icons.arrow_downward);
-    final label = isZero ? '변동없음' : '${rate.abs().toStringAsFixed(1)}% 전일대비';
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.1),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 10, color: color),
-          const SizedBox(width: 2),
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: 10,
-              color: color,
-              fontWeight: FontWeight.w600,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 13, color: color),
+            const SizedBox(width: 2),
+            Text(
+              isZero ? '0%' : '${rate.abs().toStringAsFixed(1)}%',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w800,
+                color: color,
+              ),
             ),
-          ),
-        ],
-      ),
+          ],
+        ),
+        Text(
+          '전일 대비',
+          style: TextStyle(fontSize: 10, color: Colors.grey[400]),
+        ),
+      ],
     );
   }
 
@@ -464,36 +465,19 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
                       color: Colors.black87,
                     ),
                   ),
-                  const SizedBox(height: 3),
-                  Text(
-                    price.marketName ?? '',
-                    style: TextStyle(fontSize: 12, color: Colors.grey[500]),
-                  ),
+                  if (price.originalPrice != null && price.originalUnit != null) ...[
+                    const SizedBox(height: 3),
+                    Text(
+                      '${price.displayPrice} · KAMIS',
+                      style: TextStyle(fontSize: 11, color: Colors.grey[400]),
+                    ),
+                  ],
                 ],
               ),
             ),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                Text(
-                  price.displayPrice,
-                  style: const TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.w700,
-                    color: Colors.black87,
-                  ),
-                ),
-                const SizedBox(height: 3),
-                if (price.dayChangeRate != null)
-                  _buildChangeRateBadge(price.dayChangeRate!)
-                else
-                  Text(
-                    price.displayDate,
-                    style: TextStyle(fontSize: 11, color: Colors.grey[400]),
-                  ),
-              ],
-            ),
-            const SizedBox(width: 4),
+            if (price.dayChangeRate != null)
+              _buildChangeRateColumn(price.dayChangeRate!),
+            const SizedBox(width: 8),
             GestureDetector(
               behavior: HitTestBehavior.opaque,
               onTap: () => _toggleFavorite(price),

--- a/flutter_app/lib/services/favorite_ingredient_service.dart
+++ b/flutter_app/lib/services/favorite_ingredient_service.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+
+import 'package:flutter_app/services/auth_service.dart';
+import 'package:flutter_app/services/token_storage.dart';
+import 'package:http/http.dart' as http;
+
+class FavoriteIngredientService {
+  static const String _basePath = '/api/v1/ingredients/favorites';
+
+  static Future<Map<String, String>> _headers() async {
+    final token = await TokenStorage.getAccessToken();
+    return {
+      'Content-Type': 'application/json',
+      if (token != null && token.isNotEmpty) 'Authorization': 'Bearer $token',
+    };
+  }
+
+  static Future<Set<int>> getFavoriteIds() async {
+    final uri = Uri.parse('${ApiConfig.baseUrl}$_basePath/ids');
+    final response = await http
+        .get(uri, headers: await _headers())
+        .timeout(const Duration(seconds: 10));
+    if (response.statusCode == 200) {
+      final body = jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>;
+      final data = body['data'] as List<dynamic>;
+      return data.map((e) => e as int).toSet();
+    }
+    return {};
+  }
+
+  static Future<void> addFavorite(int ingredientId) async {
+    final uri = Uri.parse('${ApiConfig.baseUrl}$_basePath/$ingredientId');
+    await http
+        .post(uri, headers: await _headers())
+        .timeout(const Duration(seconds: 10));
+  }
+
+  static Future<void> removeFavorite(int ingredientId) async {
+    final uri = Uri.parse('${ApiConfig.baseUrl}$_basePath/$ingredientId');
+    await http
+        .delete(uri, headers: await _headers())
+        .timeout(const Duration(seconds: 10));
+  }
+}


### PR DESCRIPTION
## 개요

feat-#113에서 전체 재료 가격이 일괄 적재되어 시세 탭 재료 수가 급증함에 따라
탐색성 개선과 UX 방향 재정의를 진행했습니다.

## 변경 사항

### 백엔드
- `UserFavoriteIngredient` 엔티티 추가 (`user_favorite_ingredients` 테이블)
- `IngredientRepository` 추가
- 관심 재료 CRUD API 추가
  - `GET  /api/v1/ingredients/favorites/ids`
  - `POST /api/v1/ingredients/favorites/{ingredientId}`
  - `DELETE /api/v1/ingredients/favorites/{ingredientId}`

### Flutter
- `IngredientPriceModel`에 `ingredientId` 필드 추가
- `FavoriteIngredientService` 추가 (낙관적 업데이트)
- 시세 탭 `[전체] / [관심 재료]` 탭 전환
- 시세 카드 및 상세 화면 하트 토글 버튼
- 탭 헤더 "오늘의 시세" → "식재료 가
- 카드 등락률을 16px 컬러 텍스트로 시각적 메인 요소화
- 시세 카드에서 시장명 제거, 가격은
- 상세 화면 "시장 정보" 섹션 제거, 히어로 카드에 KAMIS 출처 표기 추가
- 헤더에 도·소매 기준 가격 안내 문구

### 기타
- `user_history_db/` (ChromaDB 런타임) `.gitignore` 추가

## 테스트 방법
1. 시세 탭 진입 → 등락률이 카드 우측
2. 하트 버튼 탭 → 즉시 토글, 앱 재시작 후에도 유지되는지 확인
3. `[관심 재료]` 탭 → 즐겨찾기 목록
4. 상세 화면 → KAMIS 출처 표기 및 하트 버튼 확인
5. 헤더 안내 문구 → 스카이블루 계열
