### PR TITLE
feat: 후보 메뉴 직접 선택 시 단일 AI 분석 기능 (#98)

### DIFF
--- a/ai_agent_app/RecipeGraph.py
+++ b/ai_agent_app/RecipeGraph.py
@@ -101,6 +101,25 @@ class RecipeGraphBuilder:
         }
 
     # ------------------------------------------------------------------
+    # fetch_price_for: 단일 레시피 가격 조회 (price_node / 단일 분석 공용)
+    # ------------------------------------------------------------------
+    async def fetch_price_for(self, recipe: Dict, location):
+        """레시피 1개의 가격 정보와 추정 1인분 비용을 조회."""
+        try:
+            p_info = await asyncio.to_thread(
+                self.get_market_prices.get_market_prices,
+                recipe["RCP_PARTS_DTLS"],
+                location,
+            )
+            rough_cost = self.get_market_prices.estimate_serving_cost(
+                recipe["RCP_PARTS_DTLS"], p_info
+            )
+        except Exception:
+            p_info = "가격 데이터 조회 실패"
+            rough_cost = 0
+        return p_info, rough_cost
+
+    # ------------------------------------------------------------------
     # price_node: MENU_ID로 룩업 + 가격 조회 (병렬)
     # ------------------------------------------------------------------
     async def price_node(self, state: GraphState) -> GraphState:
@@ -110,18 +129,7 @@ class RecipeGraphBuilder:
 
         async def fetch_one(seq: str):
             r = recipes_by_seq[seq]
-            try:
-                p_info = await asyncio.to_thread(
-                    self.get_market_prices.get_market_prices,
-                    r["RCP_PARTS_DTLS"],
-                    location,
-                )
-                rough_cost = self.get_market_prices.estimate_serving_cost(
-                    r["RCP_PARTS_DTLS"], p_info
-                )
-            except Exception:
-                p_info = "가격 데이터 조회 실패"
-                rough_cost = 0
+            p_info, rough_cost = await self.fetch_price_for(r, location)
             return seq, r, p_info, rough_cost
 
         results = await asyncio.gather(*[fetch_one(seq) for seq in state["candidate_ids"]])

--- a/ai_agent_app/server.py
+++ b/ai_agent_app/server.py
@@ -162,6 +162,22 @@ class UserRequest(BaseModel):
     )
 
 
+class SelectMenuRequest(BaseModel):
+    """사용자가 후보 중 직접 선택한 메뉴 1개의 상세 분석 요청"""
+    selected_menu_id: int = Field(..., example=104, description="사용자가 선택한 메뉴 MENU_ID")
+    height_cm: float = Field(..., gt=0, example=180.5)
+    weight_kg: float = Field(..., gt=0, example=85.0)
+    location: str = Field(default="서울", example="서울")
+    budget: Optional[float] = Field(default=None, gt=0, example=8000)
+    health_conditions: List[str] = Field(default_factory=list, example=["고혈압"])
+    fitness_goal: str = Field(default="일반식단", example="근력운동")
+    allergies: List[str] = Field(default_factory=list, example=["견과류"])
+    preferences: List[str] = Field(default_factory=list, example=["매운맛"])
+    jwt_token: Optional[str] = Field(default=None, description="Spring 백엔드 JWT")
+    weather_temp: Optional[float] = Field(default=None, example=31.5, description="현재 기온(°C)")
+    weather_condition: Optional[str] = Field(default=None, example="맑음", description="현재 날씨 상태")
+
+
 class HistoryRequest(BaseModel):
     jwt_token: Optional[str] = Field(default=None, description="Spring 백엔드 JWT")
     recipe_id: str = Field(..., description="먹은 레시피 MENU_ID")
@@ -269,6 +285,34 @@ async def get_recommendation(user_input: UserRequest):
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"AI 에이전트 실행 중 오류 발생: {str(e)}")
+
+
+@app.post("/recommend/select")
+async def analyze_selected_menu(req: SelectMenuRequest):
+    """사용자가 후보 중 직접 선택한 메뉴 1개의 AI 상세 분석 (단일 JSON 반환).
+
+    candidate/rank 단계를 건너뛰고 선택 메뉴만 가격 조회 + 분석.
+    응답 형식은 /recommend의 분석 아이템과 동일.
+    """
+    try:
+        recipes = menu_fetcher.fetch_candidates_by_ids([req.selected_menu_id], req.jwt_token)
+        if not recipes:
+            raise HTTPException(status_code=404, detail="선택한 메뉴를 찾을 수 없습니다.")
+        recipe = recipes[0]
+
+        user_query = req.dict(exclude={"jwt_token", "selected_menu_id"})
+        result = await recommendation_engine.analyze_single(recipe, user_query)
+
+        rid = result.get("recipe_id") or result.get("menu_id")
+        try:
+            result["menu_id"] = int(rid) if rid is not None else 0
+        except (TypeError, ValueError):
+            result["menu_id"] = 0
+        return result
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"단일 메뉴 분석 중 오류: {str(e)}")
 
 
 @app.post("/history")

--- a/ai_agent_app/services/recommendation_engine.py
+++ b/ai_agent_app/services/recommendation_engine.py
@@ -92,3 +92,33 @@ class RecommendationEngine:
 
         async for result in self.graph_builder.stream_analyze(state):
             yield result
+
+    async def analyze_single(
+        self,
+        recipe: Dict,
+        user_query: Dict,
+    ) -> Dict[str, Any]:
+        """사용자가 직접 고른 메뉴 1개만 가격 조회 + 상세 분석 (candidate/rank 생략).
+
+        Args:
+            recipe: 선택된 메뉴 1개의 레시피 dict (Spring 포맷, MENU_ID 포함)
+            user_query: 사용자 입력 정보
+
+        Returns:
+            analyze 결과 dict (초기 추천 아이템과 동일한 형식)
+        """
+        print("[RecommendationEngine] 단일 메뉴 분석 시작")
+
+        seq = str(recipe.get("MENU_ID", "")).strip()
+        if not seq:
+            raise ValueError("선택한 메뉴의 MENU_ID가 없습니다.")
+
+        location = user_query.get("location")
+        p_info, _ = await self.graph_builder.fetch_price_for(recipe, location)
+
+        state = {
+            "recipes_by_seq": {seq: recipe},
+            "user_query": user_query,
+            "price_cache": {seq: p_info},
+        }
+        return await self.graph_builder._analyze_one(seq, state)

--- a/flutter_app/lib/models/recommendation_models.dart
+++ b/flutter_app/lib/models/recommendation_models.dart
@@ -60,6 +60,71 @@ class RecommendationRequest {
   };
 }
 
+class SelectMenuRequest {
+  final int selectedMenuId;
+  final double heightCm;
+  final double weightKg;
+  final String location;
+  final double? budget;
+  final List<String> healthConditions;
+  final String fitnessGoal;
+  final List<String> allergies;
+  final List<String> preferences;
+  final String? jwtToken;
+  final double? weatherTemp;
+  final String? weatherCondition;
+
+  const SelectMenuRequest({
+    required this.selectedMenuId,
+    required this.heightCm,
+    required this.weightKg,
+    required this.location,
+    this.budget,
+    required this.fitnessGoal,
+    this.healthConditions = const [],
+    this.allergies = const [],
+    this.preferences = const [],
+    this.jwtToken,
+    this.weatherTemp,
+    this.weatherCondition,
+  });
+
+  /// 추천 요청의 사용자 컨텍스트를 재사용해 단일 분석 요청 생성
+  factory SelectMenuRequest.fromRecommendation(
+    RecommendationRequest req,
+    int menuId,
+  ) =>
+      SelectMenuRequest(
+        selectedMenuId: menuId,
+        heightCm: req.heightCm,
+        weightKg: req.weightKg,
+        location: req.location,
+        budget: req.budget,
+        fitnessGoal: req.fitnessGoal,
+        healthConditions: req.healthConditions,
+        allergies: req.allergies,
+        preferences: req.preferences,
+        jwtToken: req.jwtToken,
+        weatherTemp: req.weatherTemp,
+        weatherCondition: req.weatherCondition,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'selected_menu_id': selectedMenuId,
+        'height_cm': heightCm,
+        'weight_kg': weightKg,
+        'location': location,
+        if (budget != null) 'budget': budget,
+        'health_conditions': healthConditions,
+        'fitness_goal': fitnessGoal,
+        'allergies': allergies,
+        'preferences': preferences,
+        if (jwtToken != null) 'jwt_token': jwtToken,
+        if (weatherTemp != null) 'weather_temp': weatherTemp,
+        if (weatherCondition != null) 'weather_condition': weatherCondition,
+      };
+}
+
 class MenuCandidate {
   final int id;
   final String name;

--- a/flutter_app/lib/screens/menu_detail_screen.dart
+++ b/flutter_app/lib/screens/menu_detail_screen.dart
@@ -7,12 +7,14 @@ class MenuDetailScreen extends StatefulWidget {
   final MenuCandidate? candidate;
   final RecommendationResult? aiResult;
   final String? jwt;
+  final RecommendationRequest? request; // 단일 AI 분석용 사용자 컨텍스트
 
   const MenuDetailScreen({
     super.key,
     this.candidate,
     this.aiResult,
     this.jwt,
+    this.request,
   });
 
   @override
@@ -23,6 +25,11 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
   MenuDetail? _detail;
   bool _loading = false;
   String? _error;
+
+  // ── 단일 AI 분석 상태 ──
+  RecommendationResult? _aiAnalysis;
+  bool _aiLoading = false;
+  String? _aiError;
 
   bool get _isAiPick => widget.aiResult != null;
 
@@ -45,11 +52,26 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
     }
   }
 
+  Future<void> _requestAiAnalysis() async {
+    if (widget.request == null || widget.candidate == null) return;
+    setState(() { _aiLoading = true; _aiError = null; });
+    try {
+      final result = await RecommendationService.analyzeSelected(
+        SelectMenuRequest.fromRecommendation(
+            widget.request!, widget.candidate!.id),
+      );
+      if (!mounted) return;
+      setState(() { _aiAnalysis = result; _aiLoading = false; });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() { _aiLoading = false; _aiError = e.toString(); });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    final title = _isAiPick
-        ? widget.aiResult!.menuName
-        : (widget.candidate?.name ?? '메뉴 상세');
+    final shownAi = widget.aiResult ?? _aiAnalysis;
+    final title = shownAi?.menuName ?? (widget.candidate?.name ?? '메뉴 상세');
 
     return Scaffold(
       appBar: AppBar(
@@ -59,7 +81,7 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
         centerTitle: true,
         elevation: 0,
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        actions: _isAiPick
+        actions: shownAi != null
             ? [
                 Container(
                   margin: const EdgeInsets.only(right: 16),
@@ -85,14 +107,18 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
               ]
             : null,
       ),
-      body: _isAiPick
-          ? _AiPickBody(result: widget.aiResult!)
+      body: shownAi != null
+          ? _AiPickBody(result: shownAi)
           : _CandidateBody(
               candidate: widget.candidate!,
               detail: _detail,
               loading: _loading,
               error: _error,
               onRetry: _fetchDetail,
+              canRequestAi: widget.request != null,
+              aiLoading: _aiLoading,
+              aiError: _aiError,
+              onRequestAi: _requestAiAnalysis,
             ),
     );
   }
@@ -163,6 +189,11 @@ class _CandidateBody extends StatelessWidget {
   final bool loading;
   final String? error;
   final VoidCallback onRetry;
+  // ── AI 분석 관련 ──
+  final bool canRequestAi;
+  final bool aiLoading;
+  final String? aiError;
+  final VoidCallback onRequestAi;
 
   const _CandidateBody({
     required this.candidate,
@@ -170,6 +201,10 @@ class _CandidateBody extends StatelessWidget {
     required this.loading,
     required this.error,
     required this.onRetry,
+    required this.canRequestAi,
+    required this.aiLoading,
+    required this.aiError,
+    required this.onRequestAi,
   });
 
   @override
@@ -184,6 +219,15 @@ class _CandidateBody extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                if (canRequestAi) ...[
+                  _AiAnalyzeButton(loading: aiLoading, onPressed: onRequestAi),
+                  if (aiError != null) ...[
+                    const SizedBox(height: 8),
+                    Text(aiError!,
+                        style: TextStyle(color: Colors.red[400], fontSize: 12)),
+                  ],
+                  const SizedBox(height: 16),
+                ],
                 if (detail != null) ...[
                   if ((detail!.category ?? '').isNotEmpty ||
                       (detail!.cookingMethod ?? '').isNotEmpty)
@@ -731,6 +775,60 @@ class _ErrorSection extends StatelessWidget {
           child: const Text('다시 시도'),
         ),
       ],
+    );
+  }
+}
+
+// ── 이 메뉴 AI 분석 받기 버튼 ─────────────────────────────────
+class _AiAnalyzeButton extends StatelessWidget {
+  final bool loading;
+  final VoidCallback onPressed;
+  const _AiAnalyzeButton({required this.loading, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      height: 52,
+      decoration: BoxDecoration(
+        gradient: AppTheme.aiGradient,
+        borderRadius: BorderRadius.circular(26),
+      ),
+      child: ElevatedButton(
+        onPressed: loading ? null : onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: Colors.transparent,
+          shadowColor: Colors.transparent,
+          shape: const StadiumBorder(),
+        ),
+        child: loading
+            ? const Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(
+                          color: Colors.white, strokeWidth: 2.2)),
+                  SizedBox(width: 10),
+                  Text('AI가 이 메뉴를 분석 중...',
+                      style: TextStyle(
+                          color: Colors.white, fontWeight: FontWeight.bold)),
+                ],
+              )
+            : const Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.auto_awesome, color: Colors.white, size: 18),
+                  SizedBox(width: 8),
+                  Text('이 메뉴 AI 분석 받기',
+                      style: TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 15)),
+                ],
+              ),
+      ),
     );
   }
 }

--- a/flutter_app/lib/screens/recommendation_screen.dart
+++ b/flutter_app/lib/screens/recommendation_screen.dart
@@ -307,6 +307,7 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
                                   builder: (_) => MenuDetailScreen(
                                     candidate: c,
                                     jwt: widget.request.jwtToken,
+                                    request: _currentRequest,
                                   ),
                                 ),
                               ),

--- a/flutter_app/lib/services/recommendation_service.dart
+++ b/flutter_app/lib/services/recommendation_service.dart
@@ -60,6 +60,32 @@ class RecommendationService {
     }
   }
 
+  /// 후보 중 선택한 메뉴 1개를 AI 분석 (단일 JSON 응답)
+  static Future<RecommendationResult> analyzeSelected(
+      SelectMenuRequest request) async {
+    final uri = Uri.parse('${ApiConfig.aiBaseUrl}/recommend/select');
+    final response = await http
+        .post(
+          uri,
+          headers: {'Content-Type': 'application/json; charset=utf-8'},
+          body: jsonEncode(request.toJson()),
+        )
+        .timeout(
+          const Duration(seconds: 60),
+          onTimeout: () => throw Exception('AI 서버 응답 시간 초과 (60초)'),
+        );
+
+    if (response.statusCode != 200) {
+      final decoded = jsonDecode(utf8.decode(response.bodyBytes));
+      throw Exception(decoded['detail'] ?? 'AI 분석 실패 (${response.statusCode})');
+    }
+
+    final decoded =
+        jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>;
+    if (decoded.containsKey('error')) throw Exception(decoded['error']);
+    return RecommendationResult.fromJson(decoded);
+  }
+
   static Future<void> saveFeedback(int menuId, int feedbackScore, String? jwt) async {
     if (jwt == null || jwt.isEmpty) return;
     final uri = Uri.parse('${ApiConfig.baseUrl}/api/recommendation-logs');


### PR DESCRIPTION
- [AI] server.py: POST /recommend/select 엔드포인트 + SelectMenuRequest 추가
- [AI] recommendation_engine.py: analyze_single() (candidate/rank 생략, 단일 분석)
- [AI] RecipeGraph.py: 단일 가격 조회 fetch_price_for() 분리(재사용)
- [Flutter] 후보 상세 화면에 "이 메뉴 AI 분석 받기" 버튼 → /recommend/select 호출
- [Flutter] SelectMenuRequest 모델 + analyzeSelected() 서비스 추가

