### PR TITLE
feat: 네이버쇼핑 재료 단가 수집 및 KAMIS 시세 테이블 분리 (#123)

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/controller/IngredientKamisPriceController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/controller/IngredientKamisPriceController.java
@@ -1,0 +1,38 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.controller;
+
+import capstone.ai_meal_assistant_backend.domain.ingredient.dto.IngredientPriceResponse;
+import capstone.ai_meal_assistant_backend.domain.ingredient.service.IngredientKamisPriceService;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/ingredients/kamis-prices")
+@RequiredArgsConstructor
+public class IngredientKamisPriceController {
+
+    private final IngredientKamisPriceService service;
+
+    @Getter
+    @AllArgsConstructor
+    private static class ApiResponse<T> {
+        private boolean success;
+        private T data;
+        private String error;
+
+        static <T> ApiResponse<T> ok(T data) {
+            return new ApiResponse<>(true, data, null);
+        }
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<ApiResponse<List<IngredientPriceResponse>>> getAllPrices() {
+        return ResponseEntity.ok(ApiResponse.ok(service.getAllLatest()));
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/IngredientPriceResponse.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/dto/IngredientPriceResponse.java
@@ -1,5 +1,6 @@
 package capstone.ai_meal_assistant_backend.domain.ingredient.dto;
 
+import capstone.ai_meal_assistant_backend.domain.ingredient.entity.IngredientKamisPrice;
 import capstone.ai_meal_assistant_backend.domain.ingredient.entity.IngredientPrice;
 
 import java.time.LocalDateTime;
@@ -21,6 +22,22 @@ public record IngredientPriceResponse(
         return new IngredientPriceResponse(
                 price.getIngredient().getId(),
                 price.getIngredient().getName(),
+                price.getPricePerGram(),
+                price.getOriginalPrice(),
+                price.getOriginalUnit(),
+                price.getMarketName(),
+                price.getMarketType(),
+                price.getBaseDate(),
+                calcChangeRate(price.getOriginalPrice(), price.getPrevDayPrice()),
+                calcChangeRate(price.getOriginalPrice(), price.getPrevWeekPrice()),
+                calcChangeRate(price.getOriginalPrice(), price.getPrevMonthPrice())
+        );
+    }
+
+    public static IngredientPriceResponse fromKamis(IngredientKamisPrice price) {
+        return new IngredientPriceResponse(
+                null,
+                price.getKamisItemName(),
                 price.getPricePerGram(),
                 price.getOriginalPrice(),
                 price.getOriginalUnit(),

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/entity/IngredientKamisPrice.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/entity/IngredientKamisPrice.java
@@ -1,0 +1,45 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.entity;
+
+import capstone.ai_meal_assistant_backend.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ingredient_kamis_prices")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IngredientKamisPrice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "kamis_item_code", nullable = false)
+    private String kamisItemCode;
+
+    @Column(name = "kamis_item_name", nullable = false)
+    private String kamisItemName;
+
+    @Column(nullable = false)
+    private Double pricePerGram;
+
+    @Column(nullable = false)
+    private String sourceApi;
+
+    private Integer originalPrice;
+    private String originalUnit;
+
+    private String marketName;
+    private String marketType;
+
+    @Column(nullable = false)
+    private LocalDateTime baseDate;
+
+    private Integer prevDayPrice;
+    private Integer prevWeekPrice;
+    private Integer prevMonthPrice;
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/IngredientKamisPriceRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/IngredientKamisPriceRepository.java
@@ -1,0 +1,20 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.repository;
+
+import capstone.ai_meal_assistant_backend.domain.ingredient.entity.IngredientKamisPrice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface IngredientKamisPriceRepository extends JpaRepository<IngredientKamisPrice, Long> {
+
+    @Query("""
+            SELECT kp FROM IngredientKamisPrice kp
+            WHERE kp.id IN (
+                SELECT MAX(kp2.id) FROM IngredientKamisPrice kp2
+                GROUP BY kp2.kamisItemCode
+            )
+            ORDER BY kp.kamisItemName ASC
+            """)
+    List<IngredientKamisPrice> findAllLatest();
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/IngredientPriceRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/IngredientPriceRepository.java
@@ -23,6 +23,7 @@ public interface IngredientPriceRepository extends JpaRepository<IngredientPrice
             JOIN FETCH ip.ingredient i
             WHERE ip.id IN (
                 SELECT MAX(ip2.id) FROM IngredientPrice ip2
+                WHERE ip2.sourceApi = 'NAVER_SHOPPING'
                 GROUP BY ip2.ingredient.id
             )
             ORDER BY i.name ASC

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/service/IngredientKamisPriceService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/service/IngredientKamisPriceService.java
@@ -1,0 +1,23 @@
+package capstone.ai_meal_assistant_backend.domain.ingredient.service;
+
+import capstone.ai_meal_assistant_backend.domain.ingredient.dto.IngredientPriceResponse;
+import capstone.ai_meal_assistant_backend.domain.ingredient.repository.IngredientKamisPriceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class IngredientKamisPriceService {
+
+    private final IngredientKamisPriceRepository repository;
+
+    public List<IngredientPriceResponse> getAllLatest() {
+        return repository.findAllLatest().stream()
+                .map(IngredientPriceResponse::fromKamis)
+                .toList();
+    }
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/entity/IngredientKamisPrice.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/entity/IngredientKamisPrice.java
@@ -1,0 +1,61 @@
+package capstone.ai_meal_assistant_batch.domain.ingredient.entity;
+
+import capstone.ai_meal_assistant_batch.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ingredient_kamis_prices", indexes = {
+        @Index(name = "idx_kamis_price_code_date", columnList = "kamis_item_code, base_date DESC")
+})
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class IngredientKamisPrice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "kamis_item_code", nullable = false)
+    private String kamisItemCode;
+
+    @Column(name = "kamis_item_name", nullable = false)
+    private String kamisItemName;
+
+    @Column(nullable = false)
+    private Double pricePerGram;
+
+    @Column(nullable = false)
+    private String sourceApi;
+
+    private Integer originalPrice;
+    private String originalUnit;
+
+    private String marketName;
+    private String marketType;
+
+    @Column(nullable = false)
+    private LocalDateTime baseDate;
+
+    @Column(name = "last_sync_at")
+    private LocalDateTime lastSyncAt;
+
+    private Integer prevDayPrice;
+    private Integer prevWeekPrice;
+    private Integer prevMonthPrice;
+
+    public void updatePrice(double pricePerGram, Integer originalPrice, String originalUnit,
+                            Integer prevDayPrice, Integer prevWeekPrice, Integer prevMonthPrice) {
+        this.pricePerGram = pricePerGram;
+        this.originalPrice = originalPrice;
+        this.originalUnit = originalUnit;
+        this.prevDayPrice = prevDayPrice;
+        this.prevWeekPrice = prevWeekPrice;
+        this.prevMonthPrice = prevMonthPrice;
+        this.lastSyncAt = LocalDateTime.now();
+    }
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/entity/IngredientPrice.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/entity/IngredientPrice.java
@@ -68,4 +68,12 @@ public class IngredientPrice extends BaseEntity {
         this.prevMonthPrice = prevMonthPrice;
         this.lastSyncAt = LocalDateTime.now();
     }
+
+    public void updateNaverPrice(double pricePerGram, Integer originalPrice, String originalUnit, LocalDateTime syncAt) {
+        this.pricePerGram = pricePerGram;
+        this.originalPrice = originalPrice;
+        this.originalUnit = originalUnit;
+        this.baseDate = syncAt;
+        this.lastSyncAt = syncAt;
+    }
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientKamisPriceRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientKamisPriceRepository.java
@@ -1,0 +1,18 @@
+package capstone.ai_meal_assistant_batch.domain.ingredient.repository;
+
+import capstone.ai_meal_assistant_batch.domain.ingredient.entity.IngredientKamisPrice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface IngredientKamisPriceRepository extends JpaRepository<IngredientKamisPrice, Long> {
+
+    Optional<IngredientKamisPrice> findByKamisItemCodeAndMarketNameAndMarketTypeAndOriginalUnitAndBaseDate(
+            String kamisItemCode,
+            String marketName,
+            String marketType,
+            String originalUnit,
+            LocalDateTime baseDate
+    );
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientPriceRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientPriceRepository.java
@@ -12,12 +12,5 @@ public interface IngredientPriceRepository extends JpaRepository<IngredientPrice
     // 특정 식재료(예: 양파)의 가장 최근(날짜 내림차순) 가격 1개만 가져옴
     Optional<IngredientPrice> findTopByIngredientIdOrderByBaseDateDesc(Long ingredientId);
 
-    Optional<IngredientPrice> findByIngredientIdAndSourceApiAndMarketNameAndMarketTypeAndOriginalUnitAndBaseDate(
-            Long ingredientId,
-            String sourceApi,
-            String marketName,
-            String marketType,
-            String originalUnit,
-            LocalDateTime baseDate
-    );
+    Optional<IngredientPrice> findTopByIngredientIdAndSourceApi(Long ingredientId, String sourceApi);
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisMappedPriceCommand.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisMappedPriceCommand.java
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.context.ApplicationContext;
 
 import capstone.ai_meal_assistant_batch.global.log.BatchLog;
-import capstone.ai_meal_assistant_batch.job.price.DefaultPriceFillResult;
-import capstone.ai_meal_assistant_batch.job.price.DefaultPriceFillService;
+import capstone.ai_meal_assistant_batch.job.naver.NaverShoppingPriceResult;
+import capstone.ai_meal_assistant_batch.job.naver.NaverShoppingPriceService;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -23,7 +23,7 @@ public class KamisMappedPriceCommand implements ApplicationRunner {
 	private static final String JOB_NAME = "kamisMappedPriceUpdate";
 
 	private final KamisPriceUpdateService service;
-	private final DefaultPriceFillService defaultPriceFillService;
+	private final NaverShoppingPriceService naverShoppingPriceService;
 	private final ApplicationContext applicationContext;
 
 	@Override
@@ -34,15 +34,14 @@ public class KamisMappedPriceCommand implements ApplicationRunner {
 			BatchLog.success(JOB_NAME, start, result);
 		} catch (Exception e) {
 			BatchLog.fail(JOB_NAME, start, e);
-			throw e;
 		}
 
-		Instant fillStart = BatchLog.start("defaultPriceFill");
+		Instant naverStart = BatchLog.start("naverShoppingPriceFetch");
 		try {
-			DefaultPriceFillResult fillResult = defaultPriceFillService.fillMissingPrices();
-			BatchLog.success("defaultPriceFill", fillStart, fillResult);
+			NaverShoppingPriceResult naverResult = naverShoppingPriceService.updateAllPrices();
+			BatchLog.success("naverShoppingPriceFetch", naverStart, naverResult);
 		} catch (Exception e) {
-			BatchLog.fail("defaultPriceFill", fillStart, e);
+			BatchLog.fail("naverShoppingPriceFetch", naverStart, e);
 		}
 
 		int exitCode = SpringApplication.exit(applicationContext, () -> 0);

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisPriceScheduler.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisPriceScheduler.java
@@ -9,8 +9,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import capstone.ai_meal_assistant_batch.global.log.BatchLog;
-import capstone.ai_meal_assistant_batch.job.price.DefaultPriceFillResult;
-import capstone.ai_meal_assistant_batch.job.price.DefaultPriceFillService;
+import capstone.ai_meal_assistant_batch.job.naver.NaverShoppingPriceResult;
+import capstone.ai_meal_assistant_batch.job.naver.NaverShoppingPriceService;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -21,7 +21,7 @@ public class KamisPriceScheduler {
 	private static final String JOB_NAME = "kamisPriceUpdate";
 
 	private final KamisPriceUpdateService service;
-	private final DefaultPriceFillService defaultPriceFillService;
+	private final NaverShoppingPriceService naverShoppingPriceService;
 
 	@EventListener(ApplicationReadyEvent.class)
 	public void runOnStartup() {
@@ -32,7 +32,7 @@ public class KamisPriceScheduler {
 		} catch (Exception e) {
 			BatchLog.fail(JOB_NAME + ".startup", start, e);
 		}
-		fillDefaultPrices();
+		fetchNaverShoppingPrices();
 	}
 
 	@Scheduled(cron = "${batch.kamis.cron}")
@@ -45,16 +45,16 @@ public class KamisPriceScheduler {
 			BatchLog.fail(JOB_NAME, start, e);
 			throw e;
 		}
-		fillDefaultPrices();
+		fetchNaverShoppingPrices();
 	}
 
-	private void fillDefaultPrices() {
-		Instant start = BatchLog.start("defaultPriceFill");
+	private void fetchNaverShoppingPrices() {
+		Instant start = BatchLog.start("naverShoppingPriceFetch");
 		try {
-			DefaultPriceFillResult result = defaultPriceFillService.fillMissingPrices();
-			BatchLog.success("defaultPriceFill", start, result);
+			NaverShoppingPriceResult result = naverShoppingPriceService.updateAllPrices();
+			BatchLog.success("naverShoppingPriceFetch", start, result);
 		} catch (Exception e) {
-			BatchLog.fail("defaultPriceFill", start, e);
+			BatchLog.fail("naverShoppingPriceFetch", start, e);
 		}
 	}
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisPriceUpdateService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/kamis/KamisPriceUpdateService.java
@@ -4,19 +4,13 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import capstone.ai_meal_assistant_batch.domain.ingredient.entity.Ingredient;
-import capstone.ai_meal_assistant_batch.domain.ingredient.entity.IngredientKamisMapping;
-import capstone.ai_meal_assistant_batch.domain.ingredient.entity.IngredientPrice;
-import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientKamisMappingRepository;
-import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientPriceRepository;
+import capstone.ai_meal_assistant_batch.domain.ingredient.entity.IngredientKamisPrice;
+import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientKamisPriceRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -25,8 +19,7 @@ public class KamisPriceUpdateService {
 
     private static final String SOURCE_API = "KAMIS_DAILY_SALES";
 
-    private final IngredientPriceRepository ingredientPriceRepository;
-    private final IngredientKamisMappingRepository mappingRepository;
+    private final IngredientKamisPriceRepository ingredientKamisPriceRepository;
     private final KamisNaturePriceListClient client;
     private final KamisNaturePriceListXmlParser parser;
 
@@ -63,58 +56,30 @@ public class KamisPriceUpdateService {
 
         totalFetched = parsed.items().size();
 
-        Map<String, List<KamisNaturePriceListXmlParser.KamisDailySalesItem>> itemsByCode = parsed.items().stream()
-                .filter(item -> item.productno() != null)
-                .collect(Collectors.groupingBy(KamisNaturePriceListXmlParser.KamisDailySalesItem::productno));
-
-        List<IngredientKamisMapping> mappings = mappingRepository.findAllByConfirmedTrue();
-
-        for (IngredientKamisMapping mapping : mappings) {
-            List<KamisNaturePriceListXmlParser.KamisDailySalesItem> matchedItems =
-                    itemsByCode.get(mapping.getKamisItemCode());
-
-            if (matchedItems == null || matchedItems.isEmpty()) {
+        for (var item : parsed.items()) {
+            NormalizedRow row = normalize(item);
+            if (row == null) {
                 skipped++;
                 continue;
             }
 
-            for (var item : matchedItems) {
-                NormalizedRow row = normalize(mapping.getIngredient(), item);
-                if (row == null) {
-                    skipped++;
-                    continue;
-                }
+            if (dryRun) {
+                skipped++;
+                continue;
+            }
 
-                if (dryRun) {
-                    skipped++;
-                    continue;
-                }
-
-                UpsertOutcome outcome = upsertPrice(
-                        row.ingredient(),
-                        row.pricePerGram(),
-                        row.originalPrice(),
-                        row.originalUnit(),
-                        row.marketName(),
-                        row.marketType(),
-                        row.baseDate(),
-                        row.prevDayPrice(),
-                        row.prevWeekPrice(),
-                        row.prevMonthPrice(),
-                        forceUpdate);
-
-                switch (outcome) {
-                    case INSERTED -> inserted++;
-                    case UPDATED -> updated++;
-                    case SKIPPED -> skipped++;
-                }
+            UpsertOutcome outcome = upsertPrice(row, forceUpdate);
+            switch (outcome) {
+                case INSERTED -> inserted++;
+                case UPDATED -> updated++;
+                case SKIPPED -> skipped++;
             }
         }
 
         return new KamisPriceUpdateResult(totalFetched, inserted, updated, skipped);
     }
 
-    private NormalizedRow normalize(Ingredient ingredient, KamisNaturePriceListXmlParser.KamisDailySalesItem item) {
+    private NormalizedRow normalize(KamisNaturePriceListXmlParser.KamisDailySalesItem item) {
         Integer originalPrice = parsePrice(item.dpr1());
         if (originalPrice == null) return null;
 
@@ -122,6 +87,10 @@ public class KamisPriceUpdateService {
         Double pricePerGram = convertToPricePerGram(originalPrice, originalUnit);
         if (pricePerGram == null) return null;
 
+        String kamisItemCode = item.productno();
+        String kamisItemName = (item.itemName() != null && !item.itemName().isBlank())
+                ? item.itemName()
+                : kamisItemCode;
         LocalDateTime baseDate = parseKamisDate(item.lastestDay());
         String marketName = item.productClsName();
         String marketType = item.categoryName();
@@ -129,8 +98,8 @@ public class KamisPriceUpdateService {
         Integer prevWeekPrice = parsePrice(item.dpr3());
         Integer prevMonthPrice = parsePrice(item.dpr5());
 
-        return new NormalizedRow(ingredient, pricePerGram, originalPrice, originalUnit,
-                marketName, marketType, baseDate, prevDayPrice, prevWeekPrice, prevMonthPrice);
+        return new NormalizedRow(kamisItemCode, kamisItemName, pricePerGram, originalPrice,
+                originalUnit, marketName, marketType, baseDate, prevDayPrice, prevWeekPrice, prevMonthPrice);
     }
 
     private LocalDateTime parseKamisDate(String day1) {
@@ -178,7 +147,8 @@ public class KamisPriceUpdateService {
     }
 
     private record NormalizedRow(
-            Ingredient ingredient,
+            String kamisItemCode,
+            String kamisItemName,
             double pricePerGram,
             Integer originalPrice,
             String originalUnit,
@@ -191,52 +161,42 @@ public class KamisPriceUpdateService {
 
     private enum UpsertOutcome { INSERTED, UPDATED, SKIPPED }
 
-    private UpsertOutcome upsertPrice(
-            Ingredient ingredient,
-            double pricePerGram,
-            Integer originalPrice,
-            String originalUnit,
-            String marketName,
-            String marketType,
-            LocalDateTime baseDate,
-            Integer prevDayPrice,
-            Integer prevWeekPrice,
-            Integer prevMonthPrice,
-            boolean forceUpdate) {
-
-        var existing = ingredientPriceRepository
-                .findByIngredientIdAndSourceApiAndMarketNameAndMarketTypeAndOriginalUnitAndBaseDate(
-                        ingredient.getId(),
-                        SOURCE_API,
-                        marketName,
-                        marketType,
-                        originalUnit,
-                        baseDate);
+    private UpsertOutcome upsertPrice(NormalizedRow row, boolean forceUpdate) {
+        var existing = ingredientKamisPriceRepository
+                .findByKamisItemCodeAndMarketNameAndMarketTypeAndOriginalUnitAndBaseDate(
+                        row.kamisItemCode(),
+                        row.marketName(),
+                        row.marketType(),
+                        row.originalUnit(),
+                        row.baseDate());
 
         if (existing.isEmpty()) {
-            ingredientPriceRepository.save(IngredientPrice.builder()
-                    .ingredient(ingredient)
-                    .pricePerGram(pricePerGram)
+            ingredientKamisPriceRepository.save(IngredientKamisPrice.builder()
+                    .kamisItemCode(row.kamisItemCode())
+                    .kamisItemName(row.kamisItemName())
+                    .pricePerGram(row.pricePerGram())
                     .sourceApi(SOURCE_API)
-                    .originalPrice(originalPrice)
-                    .originalUnit(originalUnit)
-                    .marketName(marketName)
-                    .marketType(marketType)
-                    .baseDate(baseDate)
-                    .prevDayPrice(prevDayPrice)
-                    .prevWeekPrice(prevWeekPrice)
-                    .prevMonthPrice(prevMonthPrice)
+                    .originalPrice(row.originalPrice())
+                    .originalUnit(row.originalUnit())
+                    .marketName(row.marketName())
+                    .marketType(row.marketType())
+                    .baseDate(row.baseDate())
+                    .prevDayPrice(row.prevDayPrice())
+                    .prevWeekPrice(row.prevWeekPrice())
+                    .prevMonthPrice(row.prevMonthPrice())
                     .build());
             return UpsertOutcome.INSERTED;
         }
 
-        IngredientPrice old = existing.get();
-        if (!forceUpdate && old.getPricePerGram() != null && Double.compare(old.getPricePerGram(), pricePerGram) == 0) {
+        IngredientKamisPrice old = existing.get();
+        if (!forceUpdate && old.getPricePerGram() != null
+                && Double.compare(old.getPricePerGram(), row.pricePerGram()) == 0) {
             return UpsertOutcome.SKIPPED;
         }
 
-        old.updatePrice(pricePerGram, originalPrice, originalUnit, prevDayPrice, prevWeekPrice, prevMonthPrice);
-        ingredientPriceRepository.save(old);
+        old.updatePrice(row.pricePerGram(), row.originalPrice(), row.originalUnit(),
+                row.prevDayPrice(), row.prevWeekPrice(), row.prevMonthPrice());
+        ingredientKamisPriceRepository.save(old);
         return UpsertOutcome.UPDATED;
     }
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/naver/NaverShoppingApiProperties.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/naver/NaverShoppingApiProperties.java
@@ -1,0 +1,22 @@
+package capstone.ai_meal_assistant_batch.job.naver;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "batch.naver.shopping")
+public class NaverShoppingApiProperties {
+
+    private String baseUrl = "https://openapi.naver.com";
+
+    @NotBlank
+    private String clientId;
+
+    @NotBlank
+    private String clientSecret;
+
+    private int displayCount = 10;
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/naver/NaverShoppingClient.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/naver/NaverShoppingClient.java
@@ -1,0 +1,43 @@
+package capstone.ai_meal_assistant_batch.job.naver;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class NaverShoppingClient {
+
+    private final NaverShoppingApiProperties properties;
+    private final RestClient restClient = RestClient.create();
+
+    public List<NaverShoppingItem> search(String query) {
+        URI uri = UriComponentsBuilder
+                .fromUriString(properties.getBaseUrl())
+                .path("/v1/search/shop.json")
+                .queryParam("query", query)
+                .queryParam("display", properties.getDisplayCount())
+                .queryParam("sort", "sim")
+                .build()
+                .encode()
+                .toUri();
+
+        NaverShoppingResponse response = restClient.get()
+                .uri(uri)
+                .header("X-Naver-Client-Id", properties.getClientId())
+                .header("X-Naver-Client-Secret", properties.getClientSecret())
+                .retrieve()
+                .body(NaverShoppingResponse.class);
+
+        if (response == null || response.items() == null) return List.of();
+        return response.items();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record NaverShoppingResponse(int total, List<NaverShoppingItem> items) {}
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/naver/NaverShoppingItem.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/naver/NaverShoppingItem.java
@@ -1,0 +1,6 @@
+package capstone.ai_meal_assistant_batch.job.naver;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record NaverShoppingItem(String title, String lprice) {}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/naver/NaverShoppingPriceResult.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/naver/NaverShoppingPriceResult.java
@@ -1,0 +1,3 @@
+package capstone.ai_meal_assistant_batch.job.naver;
+
+public record NaverShoppingPriceResult(int updated, int skipped) {}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/naver/NaverShoppingPriceService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/naver/NaverShoppingPriceService.java
@@ -1,0 +1,143 @@
+package capstone.ai_meal_assistant_batch.job.naver;
+
+import capstone.ai_meal_assistant_batch.domain.ingredient.entity.Ingredient;
+import capstone.ai_meal_assistant_batch.domain.ingredient.entity.IngredientPrice;
+import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientPriceRepository;
+import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class NaverShoppingPriceService {
+
+    private static final String SOURCE_API = "NAVER_SHOPPING";
+    // kg, g, L, ml 모두 지원 (액체류 커버)
+    private static final Pattern WEIGHT_PATTERN =
+            Pattern.compile("([0-9]+(?:[.,][0-9]+)?)\\s*(kg|ml|g|l)", Pattern.CASE_INSENSITIVE);
+    private static final double MAX_PRICE_PER_GRAM = 1000.0;
+    private static final double MAX_WEIGHT_GRAMS = 30_000.0;
+
+    private final IngredientRepository ingredientRepository;
+    private final IngredientPriceRepository ingredientPriceRepository;
+    private final NaverShoppingClient client;
+
+    private record PriceData(double pricePerGram, int originalPrice, String originalUnit) {}
+
+    @Transactional
+    public NaverShoppingPriceResult updateAllPrices() {
+        List<Ingredient> ingredients = ingredientRepository.findAll();
+        int updated = 0;
+        int skipped = 0;
+
+        for (Ingredient ingredient : ingredients) {
+            try {
+                Optional<PriceData> priceData = fetchPriceData(ingredient.getName());
+                if (priceData.isEmpty()) {
+                    skipped++;
+                    continue;
+                }
+                upsertPrice(ingredient, priceData.get());
+                updated++;
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                skipped++;
+            }
+        }
+
+        return new NaverShoppingPriceResult(updated, skipped);
+    }
+
+    private Optional<PriceData> fetchPriceData(String ingredientName) {
+        // 1차: 재료명 그대로 검색
+        Optional<PriceData> result = parseFromItems(client.search(ingredientName));
+        if (result.isPresent()) return result;
+
+        // 2차: 파싱 실패 시 "재료명 1kg" 으로 재검색 (계란, 개수 단위 상품 대응)
+        return parseFromItems(client.search(ingredientName + " 1kg"));
+    }
+
+    private Optional<PriceData> parseFromItems(List<NaverShoppingItem> items) {
+        List<PriceData> prices = items.stream()
+                .map(item -> calcPriceData(item.title(), item.lprice()))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .filter(p -> p.pricePerGram() > 0 && p.pricePerGram() < MAX_PRICE_PER_GRAM)
+                .sorted(Comparator.comparingDouble(PriceData::pricePerGram))
+                .toList();
+
+        if (prices.isEmpty()) return Optional.empty();
+        return Optional.of(prices.get(prices.size() / 2));
+    }
+
+    private Optional<PriceData> calcPriceData(String rawTitle, String lpriceStr) {
+        try {
+            int lprice = Integer.parseInt(lpriceStr);
+            if (lprice <= 0) return Optional.empty();
+
+            String title = rawTitle.replaceAll("<[^>]+>", "");
+            Matcher m = WEIGHT_PATTERN.matcher(title);
+            while (m.find()) {
+                String num = m.group(1).replace(",", "");
+                double amount = Double.parseDouble(num);
+                String unit = m.group(2).toLowerCase();
+                double grams = toGrams(amount, unit);
+                if (grams > 0 && grams <= MAX_WEIGHT_GRAMS) {
+                    String originalUnit = formatUnit(amount, unit);
+                    return Optional.of(new PriceData(lprice / grams, lprice, originalUnit));
+                }
+            }
+        } catch (Exception ignored) {}
+        return Optional.empty();
+    }
+
+    private static double toGrams(double amount, String unit) {
+        return switch (unit) {
+            case "kg" -> amount * 1000.0;
+            case "l"  -> amount * 1000.0; // 1L ≈ 1000g (밀도 근사)
+            case "ml" -> amount;           // 1ml ≈ 1g
+            default   -> amount;           // g
+        };
+    }
+
+    private static String formatUnit(double amount, String unit) {
+        String num = amount == Math.floor(amount) ? String.valueOf((int) amount) : String.valueOf(amount);
+        return switch (unit) {
+            case "kg" -> num + "kg";
+            case "l"  -> num + "L";
+            case "ml" -> num + "ml";
+            default   -> num + "g";
+        };
+    }
+
+    private void upsertPrice(Ingredient ingredient, PriceData data) {
+        LocalDateTime now = LocalDateTime.now();
+        Optional<IngredientPrice> existing =
+                ingredientPriceRepository.findTopByIngredientIdAndSourceApi(ingredient.getId(), SOURCE_API);
+
+        if (existing.isPresent()) {
+            existing.get().updateNaverPrice(data.pricePerGram(), data.originalPrice(), data.originalUnit(), now);
+        } else {
+            ingredientPriceRepository.save(IngredientPrice.builder()
+                    .ingredient(ingredient)
+                    .pricePerGram(data.pricePerGram())
+                    .sourceApi(SOURCE_API)
+                    .originalPrice(data.originalPrice())
+                    .originalUnit(data.originalUnit())
+                    .baseDate(now)
+                    .lastSyncAt(now)
+                    .build());
+        }
+    }
+}

--- a/flutter_app/lib/screens/market_price_screen.dart
+++ b/flutter_app/lib/screens/market_price_screen.dart
@@ -13,13 +13,19 @@ class MarketPriceScreen extends StatefulWidget {
 }
 
 class _MarketPriceScreenState extends State<MarketPriceScreen> {
-  List<IngredientPriceModel> _allPrices = [];
-  List<IngredientPriceModel> _filtered = [];
+  List<IngredientPriceModel> _kamisPrices = [];
+  List<IngredientPriceModel> _kamisFiltered = [];
+  List<IngredientPriceModel> _naverPrices = [];
+  List<IngredientPriceModel> _naverFiltered = [];
   Set<int> _favoriteIds = {};
   bool _isLoading = true;
   String? _error;
+  bool _showNaverTab = false;
   bool _showFavoritesOnly = false;
   final TextEditingController _searchController = TextEditingController();
+
+  List<IngredientPriceModel> get _currentFiltered =>
+      _showNaverTab ? _naverFiltered : _kamisFiltered;
 
   @override
   void initState() {
@@ -41,14 +47,18 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
     try {
       final results = await Future.wait([
         MarketPriceService.getAllPrices(),
+        MarketPriceService.getNaverShoppingPrices(),
         FavoriteIngredientService.getFavoriteIds(),
       ]);
-      final prices = results[0] as List<IngredientPriceModel>;
-      final favIds = results[1] as Set<int>;
+      final kamisPrices = results[0] as List<IngredientPriceModel>;
+      final naverPrices = results[1] as List<IngredientPriceModel>;
+      final favIds = results[2] as Set<int>;
       setState(() {
-        _allPrices = prices;
+        _kamisPrices = kamisPrices;
+        _naverPrices = naverPrices;
         _favoriteIds = favIds;
-        _filtered = _applyFilter(prices);
+        _kamisFiltered = _applyFilter(kamisPrices);
+        _naverFiltered = _applyFilter(naverPrices);
         _isLoading = false;
       });
     } catch (e) {
@@ -62,7 +72,10 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
   List<IngredientPriceModel> _applyFilter(List<IngredientPriceModel> source) {
     final q = _searchController.text.trim();
     var list = _showFavoritesOnly
-        ? source.where((p) => p.ingredientId != null && _favoriteIds.contains(p.ingredientId)).toList()
+        ? source
+            .where((p) =>
+                p.ingredientId != null && _favoriteIds.contains(p.ingredientId))
+            .toList()
         : source;
     if (q.isNotEmpty) {
       list = list.where((p) => p.ingredientName.contains(q)).toList();
@@ -71,13 +84,23 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
   }
 
   void _onSearch(String query) {
-    setState(() => _filtered = _applyFilter(_allPrices));
+    setState(() {
+      _kamisFiltered = _applyFilter(_kamisPrices);
+      _naverFiltered = _applyFilter(_naverPrices);
+    });
   }
 
-  void _onTabChanged(bool favoritesOnly) {
+  void _onFavoritesTabChanged(bool favoritesOnly) {
     setState(() {
       _showFavoritesOnly = favoritesOnly;
-      _filtered = _applyFilter(_allPrices);
+      _kamisFiltered = _applyFilter(_kamisPrices);
+      _naverFiltered = _applyFilter(_naverPrices);
+    });
+  }
+
+  void _onSourceTabChanged(bool showNaver) {
+    setState(() {
+      _showNaverTab = showNaver;
     });
   }
 
@@ -91,7 +114,8 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
       } else {
         _favoriteIds = Set.from(_favoriteIds)..add(id);
       }
-      _filtered = _applyFilter(_allPrices);
+      _kamisFiltered = _applyFilter(_kamisPrices);
+      _naverFiltered = _applyFilter(_naverPrices);
     });
     try {
       if (isFav) {
@@ -100,14 +124,14 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
         await FavoriteIngredientService.addFavorite(id);
       }
     } catch (_) {
-      // 실패 시 롤백
       setState(() {
         if (isFav) {
           _favoriteIds = Set.from(_favoriteIds)..add(id);
         } else {
           _favoriteIds = Set.from(_favoriteIds)..remove(id);
         }
-        _filtered = _applyFilter(_allPrices);
+        _kamisFiltered = _applyFilter(_kamisPrices);
+        _naverFiltered = _applyFilter(_naverPrices);
       });
     }
   }
@@ -121,7 +145,8 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _buildHeader(),
-            _buildTabRow(),
+            _buildSourceTabRow(),
+            if (!_showNaverTab) const SizedBox(height: 4) else _buildFavoritesTabRow(),
             _buildSearchBar(),
             Expanded(child: _buildBody()),
           ],
@@ -131,6 +156,13 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
   }
 
   Widget _buildHeader() {
+    final subtitle = _showNaverTab
+        ? '네이버쇼핑 기준 실시간 재료 단가'
+        : 'KAMIS 농수산물 전일 대비 등락 정보';
+    final notice = _showNaverTab
+        ? '온라인 쇼핑 기준 가격으로, 실제 마트·시장 판매가와 다를 수 있습니다.'
+        : '도·소매 기준 가격으로, 실제 마트·시장 판매가와 다를 수 있습니다.';
+
     return Padding(
       padding: const EdgeInsets.fromLTRB(24, 24, 24, 8),
       child: Column(
@@ -138,7 +170,8 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
         children: [
           ShaderMask(
             blendMode: BlendMode.srcIn,
-            shaderCallback: (bounds) => AppTheme.aiGradient.createShader(bounds),
+            shaderCallback: (bounds) =>
+                AppTheme.aiGradient.createShader(bounds),
             child: const Text(
               '식재료 가격 동향',
               style: TextStyle(fontSize: 28, fontWeight: FontWeight.w900),
@@ -146,7 +179,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
           ),
           const SizedBox(height: 4),
           Text(
-            'KAMIS 농수산물 전일 대비 등락 정보',
+            subtitle,
             style: TextStyle(fontSize: 14, color: Colors.grey[500]),
           ),
           const SizedBox(height: 10),
@@ -155,15 +188,17 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
             decoration: BoxDecoration(
               color: AppTheme.primaryColor.withValues(alpha: 0.08),
               borderRadius: BorderRadius.circular(8),
-              border: Border.all(color: AppTheme.primaryColor.withValues(alpha: 0.25)),
+              border:
+                  Border.all(color: AppTheme.primaryColor.withValues(alpha: 0.25)),
             ),
             child: Row(
               children: [
-                Icon(Icons.info_outline, size: 13, color: AppTheme.primaryColor),
+                Icon(Icons.info_outline,
+                    size: 13, color: AppTheme.primaryColor),
                 const SizedBox(width: 6),
                 Expanded(
                   child: Text(
-                    '도·소매 기준 가격으로, 실제 마트·시장 판매가와 다를 수 있습니다.',
+                    notice,
                     style: TextStyle(
                       fontSize: 11,
                       color: AppTheme.primaryColor.withValues(alpha: 0.85),
@@ -178,25 +213,51 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
     );
   }
 
-  Widget _buildTabRow() {
+  Widget _buildSourceTabRow() {
     return Padding(
       padding: const EdgeInsets.fromLTRB(24, 0, 24, 4),
       child: Row(
         children: [
-          _buildTabChip('전체', !_showFavoritesOnly, () => _onTabChanged(false)),
+          _buildTabChip(
+            '가격 동향',
+            !_showNaverTab,
+            () => _onSourceTabChanged(false),
+            icon: Icons.trending_up,
+          ),
           const SizedBox(width: 8),
-          _buildTabChip('관심 재료', _showFavoritesOnly, () => _onTabChanged(true)),
+          _buildTabChip(
+            '실시간 가격',
+            _showNaverTab,
+            () => _onSourceTabChanged(true),
+            icon: Icons.shopping_cart_outlined,
+          ),
         ],
       ),
     );
   }
 
-  Widget _buildTabChip(String label, bool selected, VoidCallback onTap) {
+  Widget _buildFavoritesTabRow() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 0, 24, 4),
+      child: Row(
+        children: [
+          _buildTabChip('전체', !_showFavoritesOnly,
+              () => _onFavoritesTabChanged(false)),
+          const SizedBox(width: 8),
+          _buildTabChip('관심 재료', _showFavoritesOnly,
+              () => _onFavoritesTabChanged(true)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTabChip(String label, bool selected, VoidCallback onTap,
+      {IconData? icon}) {
     return GestureDetector(
       onTap: onTap,
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 180),
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 7),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 7),
         decoration: BoxDecoration(
           color: selected ? AppTheme.primaryColor : Colors.transparent,
           borderRadius: BorderRadius.circular(20),
@@ -204,13 +265,24 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
             color: selected ? AppTheme.primaryColor : Colors.grey.shade300,
           ),
         ),
-        child: Text(
-          label,
-          style: TextStyle(
-            fontSize: 13,
-            fontWeight: FontWeight.w600,
-            color: selected ? Colors.white : Colors.grey[600],
-          ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (icon != null) ...[
+              Icon(icon,
+                  size: 13,
+                  color: selected ? Colors.white : Colors.grey[600]),
+              const SizedBox(width: 4),
+            ],
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: selected ? Colors.white : Colors.grey[600],
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -265,7 +337,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
       );
     }
 
-    if (_filtered.isEmpty) {
+    if (_currentFiltered.isEmpty) {
       return Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -283,26 +355,28 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
                       ? "'${_searchController.text}'에 대한 시세 정보가 없습니다"
                       : '시세 정보가 없습니다'),
               textAlign: TextAlign.center,
-              style: TextStyle(color: Colors.grey[600], fontSize: 15, height: 1.5),
+              style:
+                  TextStyle(color: Colors.grey[600], fontSize: 15, height: 1.5),
             ),
           ],
         ),
       );
     }
 
-    final bool showSummary = !_showFavoritesOnly &&
+    final bool showSummary = !_showNaverTab &&
+        !_showFavoritesOnly &&
         _searchController.text.isEmpty &&
-        _allPrices.any((p) => p.dayChangeRate != null);
+        _kamisPrices.any((p) => p.dayChangeRate != null);
 
     return RefreshIndicator(
       color: AppTheme.primaryColor,
       onRefresh: _loadAll,
       child: ListView.builder(
         padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
-        itemCount: _filtered.length + (showSummary ? 1 : 0),
+        itemCount: _currentFiltered.length + (showSummary ? 1 : 0),
         itemBuilder: (context, index) {
           if (showSummary && index == 0) return _buildSummarySection();
-          final item = _filtered[showSummary ? index - 1 : index];
+          final item = _currentFiltered[showSummary ? index - 1 : index];
           return _buildPriceCard(item);
         },
       ),
@@ -346,7 +420,8 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
   }
 
   Widget _buildSummarySection() {
-    final withRates = _allPrices.where((p) => p.dayChangeRate != null).toList();
+    final withRates =
+        _kamisPrices.where((p) => p.dayChangeRate != null).toList();
     final topUp = (withRates.where((p) => p.dayChangeRate! > 0).toList()
           ..sort((a, b) => b.dayChangeRate!.compareTo(a.dayChangeRate!)))
         .take(3)
@@ -395,7 +470,8 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
             Wrap(
               spacing: 6,
               runSpacing: 6,
-              children: topDown.map((p) => _buildSummaryChip(p, false)).toList(),
+              children:
+                  topDown.map((p) => _buildSummaryChip(p, false)).toList(),
             ),
         ],
       ),
@@ -403,7 +479,8 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
   }
 
   Widget _buildSummaryChip(IngredientPriceModel price, bool isUp) {
-    final color = isUp ? const Color(0xFFE53935) : const Color(0xFF1E88E5);
+    final color =
+        isUp ? const Color(0xFFE53935) : const Color(0xFF1E88E5);
     final icon = isUp ? Icons.arrow_upward : Icons.arrow_downward;
     final rate = price.dayChangeRate!.abs().toStringAsFixed(1);
     return GestureDetector(
@@ -444,7 +521,10 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
   }
 
   Widget _buildPriceCard(IngredientPriceModel price) {
-    final isFav = price.ingredientId != null && _favoriteIds.contains(price.ingredientId);
+    final isFav =
+        price.ingredientId != null && _favoriteIds.contains(price.ingredientId);
+    final sourceLabel = _showNaverTab ? '네이버쇼핑' : 'KAMIS';
+
     return GestureDetector(
       onTap: () => _pushDetail(price),
       child: Container(
@@ -489,11 +569,13 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
                       color: Colors.black87,
                     ),
                   ),
-                  if (price.originalPrice != null && price.originalUnit != null) ...[
+                  if (price.originalPrice != null &&
+                      price.originalUnit != null) ...[
                     const SizedBox(height: 3),
                     Text(
-                      '${price.displayPrice} · KAMIS',
-                      style: TextStyle(fontSize: 11, color: Colors.grey[400]),
+                      '${price.displayPrice} · $sourceLabel',
+                      style:
+                          TextStyle(fontSize: 11, color: Colors.grey[400]),
                     ),
                   ],
                 ],
@@ -501,19 +583,21 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
             ),
             if (price.dayChangeRate != null)
               _buildChangeRateColumn(price.dayChangeRate!),
-            const SizedBox(width: 8),
-            GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap: () => _toggleFavorite(price),
-              child: Padding(
-                padding: const EdgeInsets.all(4),
-                child: Icon(
-                  isFav ? Icons.favorite : Icons.favorite_border,
-                  size: 20,
-                  color: isFav ? Colors.redAccent : Colors.grey[400],
+            if (!_showNaverTab) const SizedBox(width: 4) else ...[
+              const SizedBox(width: 8),
+              GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => _toggleFavorite(price),
+                child: Padding(
+                  padding: const EdgeInsets.all(4),
+                  child: Icon(
+                    isFav ? Icons.favorite : Icons.favorite_border,
+                    size: 20,
+                    color: isFav ? Colors.redAccent : Colors.grey[400],
+                  ),
                 ),
               ),
-            ),
+            ],
           ],
         ),
       ),
@@ -526,8 +610,11 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
       MaterialPageRoute(
         builder: (_) => MarketPriceDetailScreen(
           price: price,
-          isFavorite: price.ingredientId != null && _favoriteIds.contains(price.ingredientId),
-          onFavoriteToggle: price.ingredientId != null ? () => _toggleFavorite(price) : null,
+          isFavorite: price.ingredientId != null &&
+              _favoriteIds.contains(price.ingredientId),
+          onFavoriteToggle: price.ingredientId != null
+              ? () => _toggleFavorite(price)
+              : null,
         ),
       ),
     );

--- a/flutter_app/lib/services/market_price_service.dart
+++ b/flutter_app/lib/services/market_price_service.dart
@@ -6,7 +6,7 @@ import 'package:flutter_app/services/token_storage.dart';
 import 'package:http/http.dart' as http;
 
 class MarketPriceService {
-  static const String _basePath = '/api/v1/ingredients/prices';
+  static const String _basePath = '/api/v1/ingredients/kamis-prices';
 
   static Future<Map<String, String>> _headers() async {
     final headers = <String, String>{'Content-Type': 'application/json'};
@@ -30,5 +30,20 @@ class MarketPriceService {
           .toList();
     }
     throw Exception('시세 데이터를 불러오지 못했습니다.');
+  }
+
+  static Future<List<IngredientPriceModel>> getNaverShoppingPrices() async {
+    final uri = Uri.parse('${ApiConfig.baseUrl}/api/v1/ingredients/prices/all');
+    final response = await http
+        .get(uri, headers: await _headers())
+        .timeout(const Duration(seconds: 10));
+    if (response.statusCode == 200) {
+      final body = jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>;
+      final data = body['data'] as List<dynamic>;
+      return data
+          .map((e) => IngredientPriceModel.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    throw Exception('실시간 가격 데이터를 불러오지 못했습니다.');
   }
 }


### PR DESCRIPTION
## Summary

### 배경
기존 `ingredient_prices` 테이블은 KAMIS 매핑된 재료(~243건)는 도소매 가격, 나머지는 `pricePerGram=0`으로 채워져 AI 식재료비 추정에 사실상 미동작 상태였음.
KAMIS 변동률 데이터(도소매가 + 전일/주간/월간 대비)는 가격 동향 기능에 더 적합하므로, 데이터 소스를 목적에 맞게 분리함.

### 최종 데이터 구조
| 테이블 | 데이터 소스 | 용도 |
|---|---|---|
| `ingredient_prices` | 네이버쇼핑 | AI 식재료비 추정, 시세탭 실시간 가격 |
| `ingredient_kamis_prices` | KAMIS 전체 품목 | 시세탭 가격 동향 (변동률) |

---
## Summary

### 배경
기존 `ingredient_prices` 테이블은 KAMIS 매핑된 재료(~243건)는 도소매 가격, 나머지는 `pricePerGram=0`으로 채워져 AI 식재료비 추정에 사실상 미동작 상태였음.
KAMIS 변동률 데이터(도소매가 + 전일/주간/월간 대비)는 가격 동향 기능에 더 적합하므로, 데이터 소스를 목적에 맞게 분리함.

### 최종 데이터 구조
| 테이블 | 데이터 소스 | 용도 |
|---|---|---|
| `ingredient_prices` | 네이버쇼핑 | AI 식재료비 추정, 시세탭 실시간 가격 |
| `ingredient_kamis_prices` | KAMIS 전체 품목 | 시세탭 가격 동향 (변동률) |

---

## 변경 내용

### [배치] ingredient_kamis_prices 신규 테이블
- `IngredientKamisPrice` 엔티티 추가 — `ingredient_id` FK 없이 `kamis_item_code` / `kamis_item_name` 으로 저장
- KAMIS 배치가 기존 `ingredient_kamis_mappings` confirmed 필터 없이 API 응답 **전체 품목**을 저장하도록 변경
- `KamisPriceUpdateService` 전sMappingRepository` 의존 제거

### [배치] 네이버쇼핑 가격 수
- `NaverShoppingApiProperties` — `batch.naver.shopping.client-id / client-secret` 바인딩
- `NaverShoppingClient` — `GET
- `NaverShoppingPriceService` — 재료명 검색 후 단가 파싱 및 upsert
  - 지원 단위: `kg`, `g`, `ml`
  - 파싱 실패 시 `"{재료명} 1kg"` 재검색 (계란 등 개수 단위 상품 대응)
  - 파싱 성공 결과의 **중앙값*
  - 재료 1224개 중 **1215개 (99.3%) 커버**
- `KamisPriceScheduler` / `KamultPriceFillService` 제거,`NaverShoppingPriceService` 연결

### [백엔드] KAMIS 가격 조회 API 추가
- `GET /api/v1/ingredients/kamkamis_prices`에서 품목별 최신1건 조회 (변동률 포함)
- `GET /api/v1/ingredients/priource 전용 필터 적용 (기존KAMIS/DEFAULT 레코드 노출 차단)
- `IngredientPriceResponse.fro

### [Flutter] 시세탭 탭 구조
- 상단 소스 탭 추가: **가격 동향** (KAMIS 변동률) / **실시간 가격** (네이버쇼핑 단가)
- 두 탭 데이터를 동시 로드 (`F
- 소스 레이블 동적 표시: `· KAMIS` / `· 네이버쇼핑`
- KAMIS 탭: 관심재료 탭row ·  d` null이므로 즐겨찾기 불가)
- 실시간 가격 탭: 관심재료 필터 · 하트 아이콘 정상 동작

---

## ⚠️ 팀원 필수 작업 (머지 후 로컬 세팅)

### 1. application.yml 추가 (배치 서버)
```yaml
batch:
  naver:
    shopping:
      client-id: ${NAVER_CLIEN
      client-secret: ${NAVER_CLIENT_SECRET}
환경변수 NAVER_CLIENT_ID, NAVE .

2. ingredient_kamis_prices 테

기존에 구버전 스키마(ingredien다면 DROP 필요.
서버 재시작 시 ddl-auto: update로 새 스키마 자동 생성됨.
docker exec meal_assistant_mysssistant_123!' meal_assistant \
  -e "DROP TABLE IF EXISTS ingredient_kamis_prices;"

3. 서버 기동 및 배치 실행 순서

1. 백엔드 재시작 → ingredient_kamis_prices 테이블 자동 생성 확인
2. 배치 실행 → KAMIS + 네이버
3. ingredient_kamis_prices: KAMIS 전체 품목 적재 확인
4. ingredient_prices: NAVER_SH

4. AI 서버 재시작

server.py lifespan이 시작 시 /에서 네이버쇼핑 가격 자동 로드.
백엔드 완전 기동 후 AI 서버 재시작 필요.

---
Test plan

- [ ] 배치 실행 로그에서 naverceUpdate.startup SUCCESS 확인
- [ ] GET /api/v1/ingredients/kamis-prices/all — KAMIS 품목 목록 + 변동률 반환 확인
- [ ] GET /api/v1/ingredients/ 코드만 반환 확인 (KAMIS/DEFAULT 미포함)
- [ ] 시세탭 > 가격 동향 탭: K트 없음 확인
- [ ] 시세탭 > 실시간 가격 탭: 네이버쇼핑 단가 표시, 관심재료·하트 정상 동작 확인
- [ ] AI 추천 결과에서 재료별

🤖 Generated with Claude Code de)

**base 브랜치: `dev`**