### PR TITLE
feat: 대시보드 중간 섹션 스와이프 카드 3종 추가 (#129)

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
@@ -49,6 +49,19 @@ public class RecommendationLogController {
         return ResponseEntity.ok(Map.of("success", true, "data", feedbacks));
     }
 
+    @GetMapping("/ai-picks")
+    public ResponseEntity<?> getMyAiPicks(
+            @RequestHeader(value = "Authorization", required = false) String authHeader) {
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return ResponseEntity.status(401).body(Map.of("success", false, "error", "인증이 필요합니다."));
+        }
+
+        String email = jwtUtil.getEmailFromToken(authHeader.substring(7));
+        List<RecommendationLogResponse> picks = recommendationLogService.getUserAiPickHistory(email);
+        return ResponseEntity.ok(Map.of("success", true, "data", picks));
+    }
+
     @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteFeedback(
             @RequestHeader(value = "Authorization", required = false) String authHeader,

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/dto/RecommendationLogResponse.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/dto/RecommendationLogResponse.java
@@ -14,6 +14,8 @@ public class RecommendationLogResponse {
     private String menuName;
     private String menuImageUrl;
     private Integer feedbackScore;
+    private Integer starRating;
+    private String feedbackReason;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDateTime createdAt;

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/repository/RecommendationLogRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/repository/RecommendationLogRepository.java
@@ -18,4 +18,7 @@ public interface RecommendationLogRepository extends JpaRepository<Recommendatio
 
     @Query("SELECT r FROM RecommendationLog r WHERE r.user = :user AND r.feedbackScore IS NOT NULL ORDER BY r.createdAt DESC")
     List<RecommendationLog> findFeedbacksByUser(@Param("user") User user);
+
+    @Query("SELECT r FROM RecommendationLog r WHERE r.user = :user AND r.starRating IS NOT NULL ORDER BY r.createdAt DESC")
+    List<RecommendationLog> findAiPicksByUser(@Param("user") User user);
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
@@ -60,6 +60,23 @@ public class RecommendationLogService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
+    public List<RecommendationLogResponse> getUserAiPickHistory(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        return recommendationLogRepository.findAiPicksByUser(user).stream()
+                .map(log -> RecommendationLogResponse.builder()
+                        .id(log.getId())
+                        .menuId(log.getSelectedMenu().getId())
+                        .menuName(log.getSelectedMenu().getName())
+                        .menuImageUrl(log.getSelectedMenu().getMainImageUrl())
+                        .starRating(log.getStarRating())
+                        .feedbackReason(log.getFeedbackReason())
+                        .createdAt(log.getCreatedAt())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
     @Transactional
     public void deleteFeedback(String email, Long logId) {
         User user = userRepository.findByEmail(email)

--- a/flutter_app/lib/models/recommendation_models.dart
+++ b/flutter_app/lib/models/recommendation_models.dart
@@ -300,6 +300,36 @@ class FeedbackHistoryItem {
       );
 }
 
+class AiPickItem {
+  final int id;
+  final int menuId;
+  final String menuName;
+  final String? menuImageUrl;
+  final int? starRating;
+  final String? feedbackReason;
+  final String? createdAt;
+
+  const AiPickItem({
+    required this.id,
+    required this.menuId,
+    required this.menuName,
+    this.menuImageUrl,
+    this.starRating,
+    this.feedbackReason,
+    this.createdAt,
+  });
+
+  factory AiPickItem.fromJson(Map<String, dynamic> json) => AiPickItem(
+        id: (json['id'] as num).toInt(),
+        menuId: (json['menuId'] as num).toInt(),
+        menuName: json['menuName'] ?? '',
+        menuImageUrl: json['menuImageUrl'],
+        starRating: (json['starRating'] as num?)?.toInt(),
+        feedbackReason: json['feedbackReason'],
+        createdAt: json['createdAt'],
+      );
+}
+
 class MenuDetail {
   final int id;
   final String name;

--- a/flutter_app/lib/screens/dashboard_screen.dart
+++ b/flutter_app/lib/screens/dashboard_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_app/models/market_price_models.dart';
 import 'package:flutter_app/models/recommendation_models.dart';
 import 'package:flutter_app/models/user_profile_models.dart';
+import 'package:flutter_app/services/market_price_service.dart';
 import 'package:flutter_app/services/recommendation_service.dart';
 import 'package:flutter_app/services/token_storage.dart';
 import 'package:flutter_app/services/user_profile_service.dart';
@@ -26,16 +28,36 @@ class _DashboardScreenState extends State<DashboardScreen>
   String _locationName = '현재위치';
   static String? _aiBriefing;
 
+  // ── 정보 카드 공통 ────────────────────────────────
+  final PageController _infoCardController = PageController();
+  int _infoCardIndex = 0;
+
+  // ── 카드 1: 저렴한 재료 ───────────────────────────
+  List<IngredientPriceModel> _priceDrops = [];
+  bool _isPriceLoading = true;
+
+  // ── 카드 2: AI 픽 이력 ────────────────────────────
+  List<AiPickItem> _aiPicks = [];
+  bool _isAiPickLoading = true;
+
+  // ── 카드 3: 프로필 요약 ───────────────────────────
+  UserProfileData? _profileData;
+  bool _isProfileLoading = true;
+
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     _loadWeather();
+    _loadPriceDrops();
+    _loadAiPicks();
+    _loadDashboardProfile();
   }
 
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    _infoCardController.dispose();
     super.dispose();
   }
 
@@ -122,6 +144,53 @@ class _DashboardScreenState extends State<DashboardScreen>
           _isWeatherLoading = false;
         });
       }
+    }
+  }
+
+  Future<void> _loadPriceDrops() async {
+    try {
+      final prices = await MarketPriceService.getAllPrices();
+      final drops = prices
+          .where((p) => p.dayChangeRate != null && p.dayChangeRate! < 0)
+          .toList()
+        ..sort((a, b) => a.dayChangeRate!.compareTo(b.dayChangeRate!));
+      if (mounted) {
+        setState(() {
+          _priceDrops = drops.take(3).toList();
+          _isPriceLoading = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) setState(() => _isPriceLoading = false);
+    }
+  }
+
+  Future<void> _loadAiPicks() async {
+    try {
+      final jwt = await TokenStorage.getAccessToken();
+      final items = await RecommendationService.fetchMyAiPicks(jwt);
+      if (mounted) {
+        setState(() {
+          _aiPicks = items.take(3).toList();
+          _isAiPickLoading = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) setState(() => _isAiPickLoading = false);
+    }
+  }
+
+  Future<void> _loadDashboardProfile() async {
+    try {
+      final result = await UserProfileService.getProfile();
+      if (mounted) {
+        setState(() {
+          _profileData = (result.success) ? result.data : null;
+          _isProfileLoading = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) setState(() => _isProfileLoading = false);
     }
   }
 
@@ -227,6 +296,303 @@ class _DashboardScreenState extends State<DashboardScreen>
     );
   }
 
+  // ── 정보 카드 영역 ────────────────────────────────
+
+  Widget _buildInfoCards() {
+    return Column(
+      children: [
+        // PageView: 저렴한 재료 ↔ AI 픽 이력 (2장)
+        SizedBox(
+          height: 175,
+          child: PageView(
+            controller: _infoCardController,
+            onPageChanged: (i) => setState(() => _infoCardIndex = i),
+            children: [
+              _buildPriceDropCard(),
+              _buildAiPickCard(),
+            ],
+          ),
+        ),
+        const SizedBox(height: 10),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: List.generate(2, (i) {
+            final active = _infoCardIndex == i;
+            return AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              margin: const EdgeInsets.symmetric(horizontal: 3),
+              width: active ? 16 : 6,
+              height: 6,
+              decoration: BoxDecoration(
+                color: active ? AppTheme.primaryColor : Colors.grey.shade300,
+                borderRadius: BorderRadius.circular(3),
+              ),
+            );
+          }),
+        ),
+        const SizedBox(height: 12),
+        // 프로필 카드: 항상 표시 (고정 높이로 Expanded 제약 보장)
+        SizedBox(height: 115, child: _buildProfileCard()),
+      ],
+    );
+  }
+
+  Widget _buildInfoCardShell({
+    required IconData icon,
+    required Color iconColor,
+    required String title,
+    required Widget body,
+  }) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 2),
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(icon, size: 15, color: iconColor),
+              const SizedBox(width: 6),
+              Text(
+                title,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: Colors.grey.shade600,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Expanded(child: body),
+        ],
+      ),
+    );
+  }
+
+  // ── 카드 1: 저렴한 재료 ───────────────────────────
+
+  Widget _buildPriceDropCard() {
+    return _buildInfoCardShell(
+      icon: Icons.trending_down_rounded,
+      iconColor: Colors.green.shade600,
+      title: '오늘의 저렴한 재료',
+      body: _isPriceLoading
+          ? const Center(child: CircularProgressIndicator(strokeWidth: 2))
+          : _priceDrops.isEmpty
+              ? Center(
+                  child: Text(
+                    '가격 하락 재료 데이터 없음',
+                    style: TextStyle(fontSize: 13, color: Colors.grey.shade400),
+                  ),
+                )
+              : Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: _priceDrops.map(_buildPriceDropRow).toList(),
+                ),
+    );
+  }
+
+  Widget _buildPriceDropRow(IngredientPriceModel p) {
+    final rate = p.dayChangeRate!;
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            p.ingredientName,
+            style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w500),
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Text(
+          p.displayPrice,
+          style: TextStyle(fontSize: 11, color: Colors.grey.shade500),
+        ),
+        const SizedBox(width: 8),
+        Text(
+          '${rate.toStringAsFixed(1)}%',
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.bold,
+            color: Colors.green.shade600,
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ── 카드 2: AI 픽 이력 ────────────────────────────
+
+  Widget _buildAiPickCard() {
+    return _buildInfoCardShell(
+      icon: Icons.auto_awesome_rounded,
+      iconColor: AppTheme.primaryColor,
+      title: 'AI 픽 이력',
+      body: _isAiPickLoading
+          ? const Center(child: CircularProgressIndicator(strokeWidth: 2))
+          : _aiPicks.isEmpty
+              ? Center(
+                  child: Text(
+                    '아직 AI 픽 이력이 없어요',
+                    style: TextStyle(fontSize: 13, color: Colors.grey.shade400),
+                  ),
+                )
+              : Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: _aiPicks.map(_buildAiPickRow).toList(),
+                ),
+    );
+  }
+
+  Widget _buildAiPickRow(AiPickItem item) {
+    return Row(
+      children: [
+        ClipRRect(
+          borderRadius: BorderRadius.circular(6),
+          child: item.menuImageUrl != null && item.menuImageUrl!.isNotEmpty
+              ? Image.network(
+                  item.menuImageUrl!,
+                  width: 26,
+                  height: 26,
+                  fit: BoxFit.cover,
+                  errorBuilder: (ctx, err, st) => _miniMenuIcon(),
+                )
+              : _miniMenuIcon(),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Text(
+            item.menuName,
+            style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w500),
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        if (item.starRating != null)
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.star_rounded, size: 13, color: Colors.amber),
+              const SizedBox(width: 2),
+              Text(
+                '${item.starRating}',
+                style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600),
+              ),
+            ],
+          ),
+      ],
+    );
+  }
+
+  Widget _miniMenuIcon() => Container(
+        width: 26,
+        height: 26,
+        decoration: BoxDecoration(
+          color: Colors.grey.shade200,
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Icon(Icons.restaurant, color: Colors.grey.shade400, size: 14),
+      );
+
+  // ── 카드 3: 프로필 요약 ───────────────────────────
+
+  Widget _buildProfileCard() {
+    return _buildInfoCardShell(
+      icon: Icons.person_outline_rounded,
+      iconColor: AppTheme.primaryColor,
+      title: '내 식단 프로필',
+      body: _isProfileLoading
+          ? const Center(child: CircularProgressIndicator(strokeWidth: 2))
+          : _profileData == null
+              ? Center(
+                  child: Text(
+                    '프로필을 불러올 수 없습니다',
+                    style: TextStyle(fontSize: 13, color: Colors.grey.shade400),
+                  ),
+                )
+              : Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    _buildProfileKVRow(
+                      '식단 목표',
+                      _fitnessGoalMap[_profileData!.fitnessGoal] ?? '일반식단',
+                    ),
+                    _buildProfileKVRow(
+                      '매운맛',
+                      '${_profileData!.spicyPreference ?? 3}단계',
+                    ),
+                    _buildProfileAllergyRow(_profileData!.allergies),
+                  ],
+                ),
+    );
+  }
+
+  Widget _buildProfileKVRow(String label, String value) {
+    return Row(
+      children: [
+        Text(
+          label,
+          style: TextStyle(fontSize: 12, color: Colors.grey.shade500),
+        ),
+        const Spacer(),
+        Text(
+          value,
+          style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildProfileAllergyRow(List<String> allergies) {
+    return Row(
+      children: [
+        Text(
+          '알레르기',
+          style: TextStyle(fontSize: 12, color: Colors.grey.shade500),
+        ),
+        const Spacer(),
+        if (allergies.isEmpty)
+          const Text(
+            '없음',
+            style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+          )
+        else
+          Row(
+            children: allergies.take(3).map((a) => Container(
+              margin: const EdgeInsets.only(left: 4),
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: Colors.orange.shade50,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: Colors.orange.shade200),
+              ),
+              child: Text(
+                a,
+                style: TextStyle(
+                  fontSize: 10,
+                  color: Colors.orange.shade800,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            )).toList(),
+          ),
+      ],
+    );
+  }
+
+  // ── 빌드 ─────────────────────────────────────────
+
   @override
   Widget build(BuildContext context) {
     return SafeArea(
@@ -313,71 +679,8 @@ class _DashboardScreenState extends State<DashboardScreen>
 
             const SizedBox(height: 16),
 
-            // 예산 카드
-            Container(
-              padding: const EdgeInsets.all(20),
-              decoration: BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.circular(16),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withOpacity(0.05),
-                    blurRadius: 10,
-                    offset: const Offset(0, 4),
-                  ),
-                ],
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Row(
-                    children: [
-                      Container(
-                        padding: const EdgeInsets.all(12),
-                        decoration: BoxDecoration(
-                          color: Theme.of(
-                            context,
-                          ).primaryColor.withOpacity(0.1),
-                          shape: BoxShape.circle,
-                        ),
-                        child: Icon(
-                          Icons.account_balance_wallet,
-                          color: Theme.of(context).primaryColor,
-                          size: 24,
-                        ),
-                      ),
-                      const SizedBox(width: 16),
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            '끼니당 목표 예산',
-                            style: TextStyle(
-                              fontSize: 14,
-                              color: Colors.grey[600],
-                              fontWeight: FontWeight.w500,
-                            ),
-                          ),
-                          const SizedBox(height: 4),
-                          const Text(
-                            '8,000 원',
-                            style: TextStyle(
-                              fontSize: 22,
-                              fontWeight: FontWeight.bold,
-                              color: Colors.black87,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                  IconButton(
-                    onPressed: () {},
-                    icon: const Icon(Icons.edit_outlined, color: Colors.grey),
-                  ),
-                ],
-              ),
-            ),
+            // 정보 카드 (스와이프)
+            _buildInfoCards(),
 
             const Spacer(),
 

--- a/flutter_app/lib/services/recommendation_service.dart
+++ b/flutter_app/lib/services/recommendation_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:flutter_app/models/recommendation_models.dart';
 import 'auth_service.dart';
@@ -100,7 +101,9 @@ class RecommendationService {
             body: jsonEncode({'menuId': menuId, 'feedbackScore': feedbackScore}),
           )
           .timeout(const Duration(seconds: 5));
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('피드백 저장 실패: $e');
+    }
   }
 
   static Future<void> saveDetailedFeedback(
@@ -120,7 +123,9 @@ class RecommendationService {
             body: jsonEncode(body),
           )
           .timeout(const Duration(seconds: 5));
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('상세 피드백 저장 실패: $e');
+    }
   }
 
   static Future<List<FeedbackHistoryItem>> fetchMyFeedbacks(String? jwt) async {
@@ -137,7 +142,8 @@ class RecommendationService {
       return (json['data'] as List)
           .map((e) => FeedbackHistoryItem.fromJson(e))
           .toList();
-    } catch (_) {
+    } catch (e) {
+      debugPrint('피드백 이력 조회 실패: $e');
       return [];
     }
   }
@@ -156,7 +162,8 @@ class RecommendationService {
       return (json['data'] as List)
           .map((e) => AiPickItem.fromJson(e))
           .toList();
-    } catch (_) {
+    } catch (e) {
+      debugPrint('AI Pick 조회 실패: $e');
       return [];
     }
   }
@@ -173,7 +180,8 @@ class RecommendationService {
       if (response.statusCode != 200) return false;
       final json = jsonDecode(utf8.decode(response.bodyBytes));
       return json['success'] == true;
-    } catch (_) {
+    } catch (e) {
+      debugPrint('피드백 삭제 실패: $e');
       return false;
     }
   }
@@ -192,7 +200,8 @@ class RecommendationService {
       final json = jsonDecode(utf8.decode(response.bodyBytes));
       if (json['success'] != true || json['data'] == null) return null;
       return MenuDetail.fromJson(json['data'] as Map<String, dynamic>);
-    } catch (_) {
+    } catch (e) {
+      debugPrint('메뉴 상세 조회 실패: $e');
       return null;
     }
   }

--- a/flutter_app/lib/services/recommendation_service.dart
+++ b/flutter_app/lib/services/recommendation_service.dart
@@ -142,6 +142,25 @@ class RecommendationService {
     }
   }
 
+  static Future<List<AiPickItem>> fetchMyAiPicks(String? jwt) async {
+    if (jwt == null || jwt.isEmpty) return [];
+    final uri = Uri.parse('${ApiConfig.baseUrl}/api/recommendation-logs/ai-picks');
+    try {
+      final response = await http.get(
+        uri,
+        headers: {'Authorization': 'Bearer $jwt'},
+      ).timeout(const Duration(seconds: 10));
+      if (response.statusCode != 200) return [];
+      final json = jsonDecode(utf8.decode(response.bodyBytes));
+      if (json['success'] != true || json['data'] == null) return [];
+      return (json['data'] as List)
+          .map((e) => AiPickItem.fromJson(e))
+          .toList();
+    } catch (_) {
+      return [];
+    }
+  }
+
   static Future<bool> deleteFeedback(int logId, String? jwt) async {
     if (jwt == null || jwt.isEmpty) return false;
     final uri =


### PR DESCRIPTION
## 변경 배경

대시보드에 날씨 카드와 추천 버튼 사이의 빈 공간을 활용하고,
마이페이지와 중복인 예산 카드를 정리했습니다.

## 변경 사항

### 제거
- 끼니당 목표 예산 카드 (마이페이지 프로필에서 이미 설정 가능)

### Flutter 추가
- **스와이프 카드 1 — 오늘의 저렴한 재료**
  - `MarketPriceService.getAllPrices()` 재활용, dayChangeRate 오름차순 상위 3개 표시
- **스와이프 카드 2 — AI 픽 이력**
  - 별점을 남긴 AI 추천 메뉴 최근 3건 (메뉴 이미지 + 이름 + 별점)
  - 기존 fetchMyFeedbacks(후보 좋아요/싫어요)와 별도 API 사용
- **고정 카드 — 내 식단 프로필 요약**
  - 식단 목표 / 매운맛 단계 / 알레르기 태그 항상 표시
- `AiPickItem` 모델 추가
- `RecommendationService.fetchMyAiPicks()` 메서드 추가

### 백엔드 추가
- `GET /api/recommendation-logs/ai-picks`
  - `starRating IS NOT NULL` 조건으로 AI 픽 피드백만 조회
  - 기존 `GET /api/recommendation-logs/my` (후보 좋아요/싫어요) 동작 유지
- `RecommendationLogResponse`에 `starRating`, `feedbackReason` 필드 추가

## 기존 기능 영향 없음

- 날씨 로직, AI 브리핑, 메뉴 추천 버튼 동작 변경 없음
- 마이페이지 피드백 탭 (`/api/recommendation-logs/my`) 동작 변경 없음
- 카드 데이터 로딩 실패 시 각 카드 내 안내 메시지 표시 (앱 전체에 영향 없음)