### PR TITLE
fix: 즐겨찾기 추가/제거 API 500 에러 수정 (#134)

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/controller/UserFavoriteIngredientController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/controller/UserFavoriteIngredientController.java
@@ -46,7 +46,7 @@ public class UserFavoriteIngredientController {
     @PostMapping("/{ingredientId}")
     public ResponseEntity<ApiResponse<Void>> addFavorite(
             @RequestHeader("Authorization") String authHeader,
-            @PathVariable Long ingredientId) {
+            @PathVariable("ingredientId") Long ingredientId) {
         String email = extractEmail(authHeader);
         favoriteService.addFavorite(email, ingredientId);
         return ResponseEntity.ok(ApiResponse.ok(null));
@@ -56,7 +56,7 @@ public class UserFavoriteIngredientController {
     @DeleteMapping("/{ingredientId}")
     public ResponseEntity<ApiResponse<Void>> removeFavorite(
             @RequestHeader("Authorization") String authHeader,
-            @PathVariable Long ingredientId) {
+            @PathVariable("ingredientId") Long ingredientId) {
         String email = extractEmail(authHeader);
         favoriteService.removeFavorite(email, ingredientId);
         return ResponseEntity.ok(ApiResponse.ok(null));


### PR DESCRIPTION
## 문제

시세 탭에서 즐겨찾기 버튼 클릭 시 500 에러 발생

## 원인

UserFavoriteIngredientController의 addFavorite, removeFavorite 메서드에서
@PathVariable에 이름이 명시되지 않아 컴파일러가 리플렉션으로
파라미터명을 추론하지 못함

## 수정

- @PathVariable Long ingredientId
+ @PathVariable("ingredientId") Long ingredientId

## 파일

ai-meal-assistant-backend/.../controller/UserFavoriteIngredientController.java