### PR TITLE
feat: 시세탭 UI 개편 — TabBar 전환, 정렬 팝업, 주요변동 마퀴 스크롤 (#139)

### DIFF
--- a/flutter_app/lib/screens/market_price_screen.dart
+++ b/flutter_app/lib/screens/market_price_screen.dart
@@ -1,9 +1,15 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_app/models/market_price_models.dart';
 import 'package:flutter_app/screens/market_price_detail_screen.dart';
 import 'package:flutter_app/services/favorite_ingredient_service.dart';
 import 'package:flutter_app/services/market_price_service.dart';
 import 'package:flutter_app/theme.dart';
+
+enum _KamisSort { none, risingFirst, fallingFirst }
+
+enum _NaverSort { none, cheapest, expensive }
 
 class MarketPriceScreen extends StatefulWidget {
   const MarketPriceScreen({super.key});
@@ -12,7 +18,8 @@ class MarketPriceScreen extends StatefulWidget {
   State<MarketPriceScreen> createState() => _MarketPriceScreenState();
 }
 
-class _MarketPriceScreenState extends State<MarketPriceScreen> {
+class _MarketPriceScreenState extends State<MarketPriceScreen>
+    with SingleTickerProviderStateMixin {
   List<IngredientPriceModel> _kamisPrices = [];
   List<IngredientPriceModel> _kamisFiltered = [];
   List<IngredientPriceModel> _naverPrices = [];
@@ -20,21 +27,30 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
   Set<int> _favoriteIds = {};
   bool _isLoading = true;
   String? _error;
-  bool _showNaverTab = false;
+  late TabController _tabController;
   bool _showFavoritesOnly = false;
+  _KamisSort _kamisSort = _KamisSort.none;
+  _NaverSort _naverSort = _NaverSort.none;
   final TextEditingController _searchController = TextEditingController();
 
-  List<IngredientPriceModel> get _currentFiltered =>
-      _showNaverTab ? _naverFiltered : _kamisFiltered;
+  bool get _isNaverTab => _tabController.index == 1;
+
+  List<IngredientPriceModel> get _currentFiltered {
+    final base = _isNaverTab ? _naverFiltered : _kamisFiltered;
+    return _applySort(base);
+  }
 
   @override
   void initState() {
     super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+    _tabController.addListener(() => setState(() {}));
     _loadAll();
   }
 
   @override
   void dispose() {
+    _tabController.dispose();
     _searchController.dispose();
     super.dispose();
   }
@@ -57,8 +73,8 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
         _kamisPrices = kamisPrices;
         _naverPrices = naverPrices;
         _favoriteIds = favIds;
-        _kamisFiltered = _applyFilter(kamisPrices);
-        _naverFiltered = _applyFilter(naverPrices);
+        _kamisFiltered = _applyFilter(_kamisPrices);
+        _naverFiltered = _applyFilter(_naverPrices, applyFav: true);
         _isLoading = false;
       });
     } catch (e) {
@@ -69,38 +85,59 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
     }
   }
 
-  List<IngredientPriceModel> _applyFilter(List<IngredientPriceModel> source) {
+  List<IngredientPriceModel> _applyFilter(
+    List<IngredientPriceModel> source, {
+    bool applyFav = false,
+  }) {
     final q = _searchController.text.trim();
-    var list = _showFavoritesOnly
+    var list = (applyFav && _showFavoritesOnly)
         ? source
             .where((p) =>
                 p.ingredientId != null && _favoriteIds.contains(p.ingredientId))
             .toList()
-        : source;
+        : List<IngredientPriceModel>.from(source);
     if (q.isNotEmpty) {
       list = list.where((p) => p.ingredientName.contains(q)).toList();
     }
     return list;
   }
 
+  List<IngredientPriceModel> _applySort(List<IngredientPriceModel> list) {
+    final sorted = List<IngredientPriceModel>.from(list);
+    if (_isNaverTab) {
+      switch (_naverSort) {
+        case _NaverSort.cheapest:
+          sorted.sort((a, b) => a.pricePerGram.compareTo(b.pricePerGram));
+        case _NaverSort.expensive:
+          sorted.sort((a, b) => b.pricePerGram.compareTo(a.pricePerGram));
+        case _NaverSort.none:
+          break;
+      }
+    } else {
+      switch (_kamisSort) {
+        case _KamisSort.risingFirst:
+          sorted.sort((a, b) {
+            final ar = a.dayChangeRate ?? double.negativeInfinity;
+            final br = b.dayChangeRate ?? double.negativeInfinity;
+            return br.compareTo(ar);
+          });
+        case _KamisSort.fallingFirst:
+          sorted.sort((a, b) {
+            final ar = a.dayChangeRate ?? double.infinity;
+            final br = b.dayChangeRate ?? double.infinity;
+            return ar.compareTo(br);
+          });
+        case _KamisSort.none:
+          break;
+      }
+    }
+    return sorted;
+  }
+
   void _onSearch(String query) {
     setState(() {
       _kamisFiltered = _applyFilter(_kamisPrices);
-      _naverFiltered = _applyFilter(_naverPrices);
-    });
-  }
-
-  void _onFavoritesTabChanged(bool favoritesOnly) {
-    setState(() {
-      _showFavoritesOnly = favoritesOnly;
-      _kamisFiltered = _applyFilter(_kamisPrices);
-      _naverFiltered = _applyFilter(_naverPrices);
-    });
-  }
-
-  void _onSourceTabChanged(bool showNaver) {
-    setState(() {
-      _showNaverTab = showNaver;
+      _naverFiltered = _applyFilter(_naverPrices, applyFav: true);
     });
   }
 
@@ -114,8 +151,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
       } else {
         _favoriteIds = Set.from(_favoriteIds)..add(id);
       }
-      _kamisFiltered = _applyFilter(_kamisPrices);
-      _naverFiltered = _applyFilter(_naverPrices);
+      _naverFiltered = _applyFilter(_naverPrices, applyFav: true);
     });
     try {
       if (isFav) {
@@ -130,8 +166,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
         } else {
           _favoriteIds = Set.from(_favoriteIds)..remove(id);
         }
-        _kamisFiltered = _applyFilter(_kamisPrices);
-        _naverFiltered = _applyFilter(_naverPrices);
+        _naverFiltered = _applyFilter(_naverPrices, applyFav: true);
       });
     }
   }
@@ -145,8 +180,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _buildHeader(),
-            _buildSourceTabRow(),
-            if (!_showNaverTab) const SizedBox(height: 4) else _buildFavoritesTabRow(),
+            _buildTabBar(),
             _buildSearchBar(),
             Expanded(child: _buildBody()),
           ],
@@ -156,12 +190,12 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
   }
 
   Widget _buildHeader() {
-    final subtitle = _showNaverTab
-        ? '네이버쇼핑 기준 실시간 재료 단가'
+    final subtitle = _isNaverTab
+        ? '네이버쇼핑 기준 레시피 재료 온라인 단가'
         : 'KAMIS 농수산물 전일 대비 등락 정보';
-    final notice = _showNaverTab
-        ? '온라인 쇼핑 기준 가격으로, 실제 마트·시장 판매가와 다를 수 있습니다.'
-        : '도·소매 기준 가격으로, 실제 마트·시장 판매가와 다를 수 있습니다.';
+    final notice = _isNaverTab
+        ? '레시피 재료 온라인 기준 · 실제 판매가와 다를 수 있음'
+        : '도소매 기준 · 실제 마트·시장 가격과 다를 수 있음';
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(24, 24, 24, 8),
@@ -213,101 +247,173 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
     );
   }
 
-  Widget _buildSourceTabRow() {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(24, 0, 24, 4),
-      child: Row(
-        children: [
-          _buildTabChip(
-            '가격 동향',
-            !_showNaverTab,
-            () => _onSourceTabChanged(false),
-            icon: Icons.trending_up,
-          ),
-          const SizedBox(width: 8),
-          _buildTabChip(
-            '실시간 가격',
-            _showNaverTab,
-            () => _onSourceTabChanged(true),
-            icon: Icons.shopping_cart_outlined,
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildFavoritesTabRow() {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(24, 0, 24, 4),
-      child: Row(
-        children: [
-          _buildTabChip('전체', !_showFavoritesOnly,
-              () => _onFavoritesTabChanged(false)),
-          const SizedBox(width: 8),
-          _buildTabChip('관심 재료', _showFavoritesOnly,
-              () => _onFavoritesTabChanged(true)),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildTabChip(String label, bool selected, VoidCallback onTap,
-      {IconData? icon}) {
-    return GestureDetector(
-      onTap: onTap,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 180),
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 7),
-        decoration: BoxDecoration(
-          color: selected ? AppTheme.primaryColor : Colors.transparent,
-          borderRadius: BorderRadius.circular(20),
-          border: Border.all(
-            color: selected ? AppTheme.primaryColor : Colors.grey.shade300,
-          ),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (icon != null) ...[
-              Icon(icon,
-                  size: 13,
-                  color: selected ? Colors.white : Colors.grey[600]),
-              const SizedBox(width: 4),
-            ],
-            Text(
-              label,
-              style: TextStyle(
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-                color: selected ? Colors.white : Colors.grey[600],
-              ),
-            ),
-          ],
-        ),
-      ),
+  Widget _buildTabBar() {
+    return TabBar(
+      controller: _tabController,
+      labelStyle: const TextStyle(fontSize: 14, fontWeight: FontWeight.w700),
+      unselectedLabelStyle:
+          const TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+      labelColor: AppTheme.primaryColor,
+      unselectedLabelColor: Colors.grey,
+      indicatorColor: AppTheme.primaryColor,
+      indicatorWeight: 2.5,
+      tabs: const [
+        Tab(text: '가격 동향'),
+        Tab(text: '온라인 단가'),
+      ],
     );
   }
 
   Widget _buildSearchBar() {
     return Padding(
       padding: const EdgeInsets.fromLTRB(24, 8, 24, 16),
-      child: TextField(
-        controller: _searchController,
-        onChanged: _onSearch,
-        decoration: InputDecoration(
-          hintText: '재료명 검색 (예: 감자, 양파)',
-          hintStyle: TextStyle(color: Colors.grey[400], fontSize: 14),
-          prefixIcon: Icon(Icons.search, color: Colors.grey[400]),
-          suffixIcon: _searchController.text.isNotEmpty
-              ? IconButton(
-                  icon: Icon(Icons.clear, color: Colors.grey[400]),
-                  onPressed: () {
-                    _searchController.clear();
-                    _onSearch('');
-                  },
-                )
-              : null,
-        ),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: _searchController,
+              onChanged: _onSearch,
+              decoration: InputDecoration(
+                hintText: '재료명 검색 (예: 감자, 양파)',
+                hintStyle: TextStyle(color: Colors.grey[400], fontSize: 14),
+                prefixIcon: Icon(Icons.search, color: Colors.grey[400]),
+                suffixIcon: _searchController.text.isNotEmpty
+                    ? IconButton(
+                        icon: Icon(Icons.clear, color: Colors.grey[400]),
+                        onPressed: () {
+                          _searchController.clear();
+                          _onSearch('');
+                        },
+                      )
+                    : null,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          _buildSortButton(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSortButton() {
+    final hasActive = _isNaverTab
+        ? (_showFavoritesOnly || _naverSort != _NaverSort.none)
+        : _kamisSort != _KamisSort.none;
+
+    return PopupMenuButton<String>(
+      offset: const Offset(0, 40),
+      icon: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Icon(
+            Icons.tune,
+            color: hasActive ? AppTheme.primaryColor : Colors.grey[600],
+            size: 22,
+          ),
+          if (hasActive)
+            Positioned(
+              right: -3,
+              top: -3,
+              child: Container(
+                width: 7,
+                height: 7,
+                decoration: BoxDecoration(
+                  color: AppTheme.primaryColor,
+                  shape: BoxShape.circle,
+                ),
+              ),
+            ),
+        ],
+      ),
+      onSelected: (value) {
+        setState(() {
+          if (_isNaverTab) {
+            switch (value) {
+              case 'fav':
+                _showFavoritesOnly = !_showFavoritesOnly;
+                _naverFiltered = _applyFilter(_naverPrices, applyFav: true);
+              case 'naver_none':
+                _naverSort = _NaverSort.none;
+              case 'cheapest':
+                _naverSort = _NaverSort.cheapest;
+              case 'expensive':
+                _naverSort = _NaverSort.expensive;
+            }
+          } else {
+            switch (value) {
+              case 'kamis_none':
+                _kamisSort = _KamisSort.none;
+              case 'rising':
+                _kamisSort = _KamisSort.risingFirst;
+              case 'falling':
+                _kamisSort = _KamisSort.fallingFirst;
+            }
+          }
+        });
+      },
+      itemBuilder: (context) {
+        if (_isNaverTab) {
+          return [
+            PopupMenuItem<String>(
+              value: 'fav',
+              child: Row(
+                children: [
+                  Icon(
+                    _showFavoritesOnly
+                        ? Icons.check_box
+                        : Icons.check_box_outline_blank,
+                    size: 20,
+                    color: _showFavoritesOnly
+                        ? AppTheme.primaryColor
+                        : Colors.grey[500],
+                  ),
+                  const SizedBox(width: 8),
+                  const Text('관심 재료만 보기'),
+                ],
+              ),
+            ),
+            const PopupMenuDivider(),
+            _sortMenuItem('naver_none', '기본 순', _naverSort == _NaverSort.none),
+            _sortMenuItem(
+                'cheapest', '저렴한 순', _naverSort == _NaverSort.cheapest),
+            _sortMenuItem(
+                'expensive', '비싼 순', _naverSort == _NaverSort.expensive),
+          ];
+        } else {
+          return [
+            _sortMenuItem(
+                'kamis_none', '기본 순', _kamisSort == _KamisSort.none),
+            _sortMenuItem('rising', '상승률 높은 순',
+                _kamisSort == _KamisSort.risingFirst),
+            _sortMenuItem('falling', '하락률 높은 순',
+                _kamisSort == _KamisSort.fallingFirst),
+          ];
+        }
+      },
+    );
+  }
+
+  PopupMenuItem<String> _sortMenuItem(
+      String value, String label, bool selected) {
+    return PopupMenuItem<String>(
+      value: value,
+      child: Row(
+        children: [
+          Icon(
+            Icons.check,
+            size: 18,
+            color: selected ? AppTheme.primaryColor : Colors.transparent,
+          ),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: TextStyle(
+              fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
+              color: selected ? AppTheme.primaryColor : Colors.black87,
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -343,13 +449,15 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
           mainAxisSize: MainAxisSize.min,
           children: [
             Icon(
-              _showFavoritesOnly ? Icons.favorite_border : Icons.search_off,
+              _isNaverTab && _showFavoritesOnly
+                  ? Icons.favorite_border
+                  : Icons.search_off,
               size: 48,
               color: Colors.grey[400],
             ),
             const SizedBox(height: 12),
             Text(
-              _showFavoritesOnly
+              _isNaverTab && _showFavoritesOnly
                   ? '관심 재료를 추가해보세요\n시세 카드의 하트를 눌러 저장할 수 있어요'
                   : (_searchController.text.isNotEmpty
                       ? "'${_searchController.text}'에 대한 시세 정보가 없습니다"
@@ -363,9 +471,10 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
       );
     }
 
-    final bool showSummary = !_showNaverTab &&
+    final bool showSummary = !_isNaverTab &&
         !_showFavoritesOnly &&
         _searchController.text.isEmpty &&
+        _kamisSort == _KamisSort.none &&
         _kamisPrices.any((p) => p.dayChangeRate != null);
 
     return RefreshIndicator(
@@ -422,20 +531,15 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
   Widget _buildSummarySection() {
     final withRates =
         _kamisPrices.where((p) => p.dayChangeRate != null).toList();
-    final topUp = (withRates.where((p) => p.dayChangeRate! > 0).toList()
-          ..sort((a, b) => b.dayChangeRate!.compareTo(a.dayChangeRate!)))
-        .take(3)
-        .toList();
-    final topDown = (withRates.where((p) => p.dayChangeRate! < 0).toList()
-          ..sort((a, b) => a.dayChangeRate!.compareTo(b.dayChangeRate!)))
-        .take(3)
-        .toList();
+    final upItems = withRates.where((p) => p.dayChangeRate! >= 3.0).toList()
+      ..sort((a, b) => b.dayChangeRate!.compareTo(a.dayChangeRate!));
+    final downItems = withRates.where((p) => p.dayChangeRate! <= -3.0).toList()
+      ..sort((a, b) => a.dayChangeRate!.compareTo(b.dayChangeRate!));
 
-    if (topUp.isEmpty && topDown.isEmpty) return const SizedBox.shrink();
+    if (upItems.isEmpty && downItems.isEmpty) return const SizedBox.shrink();
 
     return Container(
       margin: const EdgeInsets.only(bottom: 16),
-      padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(16),
@@ -450,29 +554,67 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
-            '오늘의 주요 변동',
-            style: TextStyle(
-              fontSize: 13,
-              fontWeight: FontWeight.w700,
-              color: Colors.black54,
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 12, 16, 8),
+            child: Text(
+              '오늘의 주요 변동',
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: Colors.black54,
+              ),
             ),
           ),
-          const SizedBox(height: 10),
-          if (topUp.isNotEmpty)
-            Wrap(
-              spacing: 6,
-              runSpacing: 6,
-              children: topUp.map((p) => _buildSummaryChip(p, true)).toList(),
+          _buildMarqueeRow(upItems, true),
+          const SizedBox(height: 6),
+          _buildMarqueeRow(downItems, false),
+          const SizedBox(height: 12),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMarqueeRow(List<IngredientPriceModel> items, bool isUp) {
+    final color =
+        isUp ? const Color(0xFFE53935) : const Color(0xFF1E88E5);
+    final icon = isUp ? Icons.arrow_upward : Icons.arrow_downward;
+    final label = isUp ? '상승' : '하락';
+
+    return SizedBox(
+      height: 34,
+      child: Row(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(icon, size: 11, color: color),
+                const SizedBox(width: 2),
+                Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    color: color,
+                  ),
+                ),
+              ],
             ),
-          if (topUp.isNotEmpty && topDown.isNotEmpty) const SizedBox(height: 6),
-          if (topDown.isNotEmpty)
-            Wrap(
-              spacing: 6,
-              runSpacing: 6,
-              children:
-                  topDown.map((p) => _buildSummaryChip(p, false)).toList(),
-            ),
+          ),
+          Container(width: 1, height: 16, color: Colors.grey.shade200),
+          const SizedBox(width: 8),
+          Expanded(
+            child: items.isEmpty
+                ? Text(
+                    '오늘 해당 없음',
+                    style: TextStyle(fontSize: 12, color: Colors.grey[400]),
+                  )
+                : _MarqueeStrip(
+                    items: items,
+                    chipBuilder: (p) => _buildSummaryChip(p, isUp),
+                  ),
+          ),
         ],
       ),
     );
@@ -523,7 +665,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
   Widget _buildPriceCard(IngredientPriceModel price) {
     final isFav =
         price.ingredientId != null && _favoriteIds.contains(price.ingredientId);
-    final sourceLabel = _showNaverTab ? '네이버쇼핑' : 'KAMIS';
+    final sourceLabel = _isNaverTab ? '네이버쇼핑' : 'KAMIS';
 
     return GestureDetector(
       onTap: () => _pushDetail(price),
@@ -583,7 +725,9 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
             ),
             if (price.dayChangeRate != null)
               _buildChangeRateColumn(price.dayChangeRate!),
-            if (!_showNaverTab) const SizedBox(width: 4) else ...[
+            if (!_isNaverTab)
+              const SizedBox(width: 4)
+            else ...[
               const SizedBox(width: 8),
               GestureDetector(
                 behavior: HitTestBehavior.opaque,
@@ -616,6 +760,86 @@ class _MarketPriceScreenState extends State<MarketPriceScreen> {
               ? () => _toggleFavorite(price)
               : null,
         ),
+      ),
+    );
+  }
+}
+
+class _MarqueeStrip extends StatefulWidget {
+  final List<IngredientPriceModel> items;
+  final Widget Function(IngredientPriceModel) chipBuilder;
+
+  const _MarqueeStrip({
+    required this.items,
+    required this.chipBuilder,
+  });
+
+  @override
+  State<_MarqueeStrip> createState() => _MarqueeStripState();
+}
+
+class _MarqueeStripState extends State<_MarqueeStrip> {
+  final ScrollController _controller = ScrollController();
+  Timer? _timer;
+
+  static const int _repeatCount = 4;
+  static const double _pixelsPerMs = 0.04; // 40px/s
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _startScroll());
+  }
+
+  @override
+  void didUpdateWidget(_MarqueeStrip oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.items != widget.items) {
+      _timer?.cancel();
+      if (_controller.hasClients) _controller.jumpTo(0);
+      WidgetsBinding.instance.addPostFrameCallback((_) => _startScroll());
+    }
+  }
+
+  void _startScroll() {
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(milliseconds: 16), (_) {
+      if (!_controller.hasClients) return;
+      final pos = _controller.position;
+      final max = pos.maxScrollExtent;
+      if (max <= 0) return;
+
+      // 전체 콘텐츠 너비의 1/_repeatCount 지점에서 처음으로 점프 (seamless loop)
+      final singleWidth = (max + pos.viewportDimension) / _repeatCount;
+      final next = pos.pixels + (_pixelsPerMs * 16);
+      _controller.jumpTo(next >= singleWidth ? next - singleWidth : next);
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final allItems = List.generate(_repeatCount, (_) => widget.items)
+        .expand((x) => x)
+        .toList();
+
+    return SingleChildScrollView(
+      controller: _controller,
+      scrollDirection: Axis.horizontal,
+      physics: const NeverScrollableScrollPhysics(),
+      child: Row(
+        children: [
+          for (final item in allItems) ...[
+            widget.chipBuilder(item),
+            const SizedBox(width: 6),
+          ],
+        ],
       ),
     );
   }

--- a/flutter_app/lib/screens/market_price_screen.dart
+++ b/flutter_app/lib/screens/market_price_screen.dart
@@ -1,6 +1,5 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_app/models/market_price_models.dart';
 import 'package:flutter_app/screens/market_price_detail_screen.dart';
 import 'package:flutter_app/services/favorite_ingredient_service.dart';
@@ -35,10 +34,8 @@ class _MarketPriceScreenState extends State<MarketPriceScreen>
 
   bool get _isNaverTab => _tabController.index == 1;
 
-  List<IngredientPriceModel> get _currentFiltered {
-    final base = _isNaverTab ? _naverFiltered : _kamisFiltered;
-    return _applySort(base);
-  }
+  List<IngredientPriceModel> get _currentFiltered =>
+      _isNaverTab ? _naverFiltered : _kamisFiltered;
 
   @override
   void initState() {
@@ -73,8 +70,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen>
         _kamisPrices = kamisPrices;
         _naverPrices = naverPrices;
         _favoriteIds = favIds;
-        _kamisFiltered = _applyFilter(_kamisPrices);
-        _naverFiltered = _applyFilter(_naverPrices, applyFav: true);
+        _updateDisplayLists();
         _isLoading = false;
       });
     } catch (e) {
@@ -102,9 +98,12 @@ class _MarketPriceScreenState extends State<MarketPriceScreen>
     return list;
   }
 
-  List<IngredientPriceModel> _applySort(List<IngredientPriceModel> list) {
+  List<IngredientPriceModel> _applySort(
+    List<IngredientPriceModel> list, {
+    bool naver = false,
+  }) {
     final sorted = List<IngredientPriceModel>.from(list);
-    if (_isNaverTab) {
+    if (naver) {
       switch (_naverSort) {
         case _NaverSort.cheapest:
           sorted.sort((a, b) => a.pricePerGram.compareTo(b.pricePerGram));
@@ -134,10 +133,15 @@ class _MarketPriceScreenState extends State<MarketPriceScreen>
     return sorted;
   }
 
+  void _updateDisplayLists() {
+    _kamisFiltered = _applySort(_applyFilter(_kamisPrices));
+    _naverFiltered =
+        _applySort(_applyFilter(_naverPrices, applyFav: true), naver: true);
+  }
+
   void _onSearch(String query) {
     setState(() {
-      _kamisFiltered = _applyFilter(_kamisPrices);
-      _naverFiltered = _applyFilter(_naverPrices, applyFav: true);
+      _updateDisplayLists();
     });
   }
 
@@ -151,7 +155,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen>
       } else {
         _favoriteIds = Set.from(_favoriteIds)..add(id);
       }
-      _naverFiltered = _applyFilter(_naverPrices, applyFav: true);
+      _updateDisplayLists();
     });
     try {
       if (isFav) {
@@ -166,7 +170,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen>
         } else {
           _favoriteIds = Set.from(_favoriteIds)..remove(id);
         }
-        _naverFiltered = _applyFilter(_naverPrices, applyFav: true);
+        _updateDisplayLists();
       });
     }
   }
@@ -332,7 +336,6 @@ class _MarketPriceScreenState extends State<MarketPriceScreen>
             switch (value) {
               case 'fav':
                 _showFavoritesOnly = !_showFavoritesOnly;
-                _naverFiltered = _applyFilter(_naverPrices, applyFav: true);
               case 'naver_none':
                 _naverSort = _NaverSort.none;
               case 'cheapest':
@@ -350,6 +353,7 @@ class _MarketPriceScreenState extends State<MarketPriceScreen>
                 _kamisSort = _KamisSort.fallingFirst;
             }
           }
+          _updateDisplayLists();
         });
       },
       itemBuilder: (context) {
@@ -778,9 +782,11 @@ class _MarqueeStrip extends StatefulWidget {
   State<_MarqueeStrip> createState() => _MarqueeStripState();
 }
 
-class _MarqueeStripState extends State<_MarqueeStrip> {
+class _MarqueeStripState extends State<_MarqueeStrip>
+    with SingleTickerProviderStateMixin {
   final ScrollController _controller = ScrollController();
-  Timer? _timer;
+  Ticker? _ticker;
+  Duration _lastElapsed = Duration.zero;
 
   static const int _repeatCount = 4;
   static const double _pixelsPerMs = 0.04; // 40px/s
@@ -795,30 +801,36 @@ class _MarqueeStripState extends State<_MarqueeStrip> {
   void didUpdateWidget(_MarqueeStrip oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.items != widget.items) {
-      _timer?.cancel();
+      _ticker?.stop();
       if (_controller.hasClients) _controller.jumpTo(0);
+      _lastElapsed = Duration.zero;
       WidgetsBinding.instance.addPostFrameCallback((_) => _startScroll());
     }
   }
 
   void _startScroll() {
-    _timer?.cancel();
-    _timer = Timer.periodic(const Duration(milliseconds: 16), (_) {
+    _ticker?.dispose();
+    _lastElapsed = Duration.zero;
+    _ticker = createTicker((elapsed) {
       if (!_controller.hasClients) return;
       final pos = _controller.position;
       final max = pos.maxScrollExtent;
       if (max <= 0) return;
 
+      final deltaMs = (elapsed - _lastElapsed).inMicroseconds / 1000.0;
+      _lastElapsed = elapsed;
+
       // 전체 콘텐츠 너비의 1/_repeatCount 지점에서 처음으로 점프 (seamless loop)
       final singleWidth = (max + pos.viewportDimension) / _repeatCount;
-      final next = pos.pixels + (_pixelsPerMs * 16);
+      final next = pos.pixels + (_pixelsPerMs * deltaMs);
       _controller.jumpTo(next >= singleWidth ? next - singleWidth : next);
     });
+    _ticker!.start();
   }
 
   @override
   void dispose() {
-    _timer?.cancel();
+    _ticker?.dispose();
     _controller.dispose();
     super.dispose();
   }


### PR DESCRIPTION
Summary

- 상단 소스 탭을 칩 토글 → Flutter TabBar로 교체, 글자 잘림 및 레이아웃 시프트 문제 해결
- 검색창 우측 정렬 팝업 버튼 추가 (탭별 옵션 분리)
  - 가격동향: 기본 순 / 상승률 높은 순 / 하락률 높은 순
  - 온라인 단가: 관심 재료 필터 + 기본 순 / 저렴한 순 / 비싼 순
- 주요변동 섹션을 상승/하락 행 분리 + 자동 마퀴 스크롤로 개편
- 변동 기준을 기존 상위 3개 고정 → dayChangeRate ±3% 이상 전체 표시로 변경
- 탭 이름 실시간 가격 → 온라인 단가, 안내 문구 한 줄로 단축

Test plan

- [ ] 가격동향 / 온라인 단가 탭 전환 시 레이아웃 시프트 없음 확인
- [ ] 각 탭에서 정렬 팝업 항목이 탭에 맞게 다르게 노출되는지 확인
- [ ] 정렬 선택 후 목록 순서 변경 확인 (상승률, 하락률, 저렴한 순, 비싼 순)
- [ ] 관심 재료 필터 토글 및 체크 상태 표시 확인
- [ ] 주요변동 마퀴 자동 스크롤 및 루프 확인
- [ ] 3% 미만 변동 항목은 주요변동 섹션에 미표시 확인