### PR TITLE
feat: 육류 부위 보존 파싱 + menu_ingredients 재구축/미사용 정리 기능

### DIFF
--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/controller/AdminDataController.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/controller/AdminDataController.java
@@ -28,6 +28,26 @@ public class AdminDataController {
         return ResponseEntity.ok("메뉴-알레르기 매핑이 성공적으로 완료되었습니다!");
     }
 
+    /**
+     * 이미 적재된 메뉴 기준으로 menu_ingredients를 현재 파서로 재구축.
+     * 파서 변경 후 기존 DB를 교정할 때 사용 (menus/이미지/기존 가격 무영향).
+     */
+    @PostMapping("/rebuild-ingredients")
+    public ResponseEntity<String> rebuildIngredients(){
+        syncService.rebuildMenuIngredients();
+        return ResponseEntity.ok("menu_ingredients 재구축이 완료되었습니다. (자세한 내역은 서버 로그)");
+    }
+
+    /**
+     * 레시피 미사용 + 즐겨찾기 미참조 재료를 정리(가격·KAMIS 매핑 포함 삭제).
+     * 보통 rebuild-ingredients 직후 옛 이름 잔여 행 정리에 사용.
+     */
+    @PostMapping("/cleanup-unused-ingredients")
+    public ResponseEntity<String> cleanupUnusedIngredients(){
+        int deleted = syncService.deleteUnusedIngredients();
+        return ResponseEntity.ok("미사용 재료 " + deleted + "건을 정리했습니다.");
+    }
+
     @PostMapping("/recover-images")
     public ResponseEntity<String> recoverImages(){
         boolean started = imageRecoveryAsyncRunner.tryStart();

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/parser/RecipeDataParser.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/parser/RecipeDataParser.java
@@ -3,6 +3,8 @@ package capstone.ai_meal_assistant_batch.domain.etl.parser;
 import capstone.ai_meal_assistant_batch.domain.ingredient.dto.IngredientDto;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -10,6 +12,31 @@ public class RecipeDataParser {
 
     private static final Pattern NUMBER_PATTERN = Pattern.compile("^(.*?)\\s*([0-9½⅓⅔¼¾⅕⅖⅙⅛]+.*)$");
     private static final Pattern FALLBACK_PATTERN = Pattern.compile("^(.*?)\\s*(약간|조금|적당량|약간량|소량|한꼬집|취향껏|필요량|기호에따라|.*?용|각각|각)$");
+
+    // 육류 베이스: 부위명을 이름에 보존하기 위한 대상
+    private static final Set<String> MEAT_BASES = Set.of("소고기", "쇠고기", "돼지고기", "닭고기", "오리고기", "양고기");
+
+    // 가격이 실제로 달라지는 부위명(화이트리스트). 여기 있는 토큰만 이름에 결합 보존한다.
+    // 살코기·살·다리처럼 베이스와 가격이 사실상 같은 토큰은 제외하여 amount로 분리한다.
+    private static final Set<String> MEAT_CUTS = Set.of(
+            "등심", "안심", "양지", "우둔살", "우둔", "홍두깨살", "치맛살", "살치살",
+            "갈빗살", "갈비", "등갈비", "뼈갈비", "부채살", "부챗살", "사태",
+            "목살", "목심", "삼겹살", "통삼겹살", "앞다리살", "전지",
+            "가슴살", "다리살", "다릿살", "날개", "채끝", "차돌박이");
+
+    // 부위명 표기 통일
+    private static final Map<String, String> MEAT_CUT_NORMALIZE = Map.of("다릿살", "다리살");
+
+    // 베이스 없이 부위명만 쓰인 단독 표기 → 베이스+부위로 정규화 (오타·약칭 포함)
+    private static final Map<String, String> BARE_CUT_BASE = Map.ofEntries(
+            Map.entry("돈등심", "돼지고기 등심"),
+            Map.entry("우목심", "소고기 목심"),
+            Map.entry("우삼겹", "소고기 우삼겹"),
+            Map.entry("양지육", "소고기 양지"),
+            Map.entry("채끝살", "소고기 채끝"),
+            Map.entry("부챗살", "소고기 부챗살"),
+            Map.entry("안심", "소고기 안심"),
+            Map.entry("돼기고기", "돼지고기"));
 
     public static List<IngredientDto> parseIngredients(String rcpPartsDtls, String recipeName) {
         List<IngredientDto> ingredientList = new ArrayList<>();
@@ -161,12 +188,33 @@ public class RecipeDataParser {
                     prefix = prefix.replaceAll("^[.,(]+", "").replaceAll("[.,)]+$", "").trim();
                     tail = tail.replaceAll("^[.,(]+", "").replaceAll("[.,)]+$", "").trim();
 
-                    if (!prefix.isEmpty()) extracted.append(prefix).append(" ");
-                    if (!tail.isEmpty()) extracted.append(tail).append(" ");
-
-                    name = base;
+                    if (MEAT_BASES.contains(base)) {
+                        // 육류: 부위명(등심·치맛살 등)은 이름에 보존, 조리/용도 수식어만 amount로 분리
+                        String normBase = "쇠고기".equals(base) ? "소고기" : base;
+                        StringBuilder cutPart = new StringBuilder();
+                        if (!prefix.isEmpty()) extracted.append(prefix).append(" ");
+                        for (String tok : tail.split("\\s+")) {
+                            String t = tok.replaceAll("[.,()]", "").trim();
+                            if (t.isEmpty()) continue;
+                            if (MEAT_CUTS.contains(t)) {
+                                cutPart.append(MEAT_CUT_NORMALIZE.getOrDefault(t, t)).append(" ");
+                            } else {
+                                extracted.append(tok).append(" ");
+                            }
+                        }
+                        name = cutPart.length() > 0 ? (normBase + " " + cutPart.toString().trim()) : normBase;
+                    } else {
+                        if (!prefix.isEmpty()) extracted.append(prefix).append(" ");
+                        if (!tail.isEmpty()) extracted.append(tail).append(" ");
+                        name = base;
+                    }
                     break;
                 }
+            }
+
+            // 베이스 없이 부위명만 쓴 단독 표기 정규화 (예: 돈등심 → 돼지고기 등심)
+            if (BARE_CUT_BASE.containsKey(name)) {
+                name = BARE_CUT_BASE.get(name);
             }
 
             if (name.contains("두 가지 색") || name.contains("두가지 색") || name.contains("두가지색")) {

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientKamisMappingRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientKamisMappingRepository.java
@@ -2,6 +2,9 @@ package capstone.ai_meal_assistant_batch.domain.ingredient.repository;
 
 import capstone.ai_meal_assistant_batch.domain.ingredient.entity.IngredientKamisMapping;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -12,4 +15,9 @@ public interface IngredientKamisMappingRepository extends JpaRepository<Ingredie
     boolean existsByIngredientIdAndConfirmedTrue(Long ingredientId);
 
     boolean existsByIngredientIdAndKamisItemCode(Long ingredientId, String kamisItemCode);
+
+    // 미사용 재료 정리 시 연결된 KAMIS 매핑 일괄 삭제
+    @Modifying
+    @Query("DELETE FROM IngredientKamisMapping m WHERE m.ingredient.id IN :ids")
+    void deleteByIngredientIdIn(@Param("ids") List<Long> ids);
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientPriceRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientPriceRepository.java
@@ -2,8 +2,12 @@ package capstone.ai_meal_assistant_batch.domain.ingredient.repository;
 
 import capstone.ai_meal_assistant_batch.domain.ingredient.entity.IngredientPrice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 // 물가
@@ -13,4 +17,9 @@ public interface IngredientPriceRepository extends JpaRepository<IngredientPrice
     Optional<IngredientPrice> findTopByIngredientIdOrderByBaseDateDesc(Long ingredientId);
 
     Optional<IngredientPrice> findTopByIngredientIdAndSourceApi(Long ingredientId, String sourceApi);
+
+    // 미사용 재료 정리 시 연결된 가격 일괄 삭제
+    @Modifying
+    @Query("DELETE FROM IngredientPrice p WHERE p.ingredient.id IN :ids")
+    void deleteByIngredientIdIn(@Param("ids") List<Long> ids);
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientRepository.java
@@ -15,4 +15,8 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
 
     @Query("SELECT i FROM Ingredient i WHERE i.id NOT IN (SELECT DISTINCT ip.ingredient.id FROM IngredientPrice ip)")
     List<Ingredient> findIngredientsWithoutAnyPrice();
+
+    // 어떤 메뉴에도 매핑되지 않은(레시피 미사용) 재료. 미사용 재료 정리에 사용.
+    @Query("SELECT i FROM Ingredient i WHERE i.id NOT IN (SELECT DISTINCT mi.ingredient.id FROM MenuIngredient mi)")
+    List<Ingredient> findUnusedIngredients();
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
@@ -4,6 +4,8 @@ import capstone.ai_meal_assistant_batch.domain.etl.FoodSafetyApiFetcher;
 import capstone.ai_meal_assistant_batch.domain.etl.parser.RecipeDataParser;
 import capstone.ai_meal_assistant_batch.domain.ingredient.dto.IngredientDto;
 import capstone.ai_meal_assistant_batch.domain.ingredient.entity.Ingredient;
+import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientKamisMappingRepository;
+import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientPriceRepository;
 import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientRepository;
 import capstone.ai_meal_assistant_batch.domain.menu.entity.Allergy;
 import capstone.ai_meal_assistant_batch.domain.menu.entity.Menu;
@@ -16,6 +18,8 @@ import capstone.ai_meal_assistant_batch.domain.menu.repository.MenuRepository;
 import capstone.ai_meal_assistant_batch.global.s3.S3ImageUploadService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
@@ -42,10 +46,15 @@ public class RecipeDataSyncService {
     private final MenuRepository menuRepository;
     private final IngredientRepository ingredientRepository;
     private final MenuIngredientRepository menuIngredientRepository;
+    private final IngredientPriceRepository ingredientPriceRepository;
+    private final IngredientKamisMappingRepository ingredientKamisMappingRepository;
     private final AllergyRepository allergyRepository;
     private final MenuAllergyRepository menuAllergyRepository;
     private final ObjectMapper objectMapper;
     private final S3ImageUploadService s3ImageUploadService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     /** 이미지 복구 시 변경분을 끊어 저장하는 청크 크기. */
     private static final int RECOVERY_SAVE_CHUNK = 100;
@@ -195,6 +204,133 @@ public class RecipeDataSyncService {
         } catch (Exception e){
             log.error("API 데이터 동기화 중 에러 발생: ", e);
         }
+    }
+
+    /**
+     * 이미 적재된 메뉴 기준으로 menu_ingredients를 현재 파서로 재구축한다.
+     * - menus / 이미지 / 기존 가격(ingredient_prices)은 건드리지 않는다.
+     * - menu_ingredients 전체 삭제 후 cleaned_recipe_data.json을 재파싱해 재삽입한다.
+     * - 없는 재료명은 생성(create-if-absent), 기존 재료는 재사용. 멱등(반복 실행 가능).
+     * - 파서 로직을 바꾼 뒤 기존 DB를 교정할 때 사용한다.
+     *   (빈 DB는 syncAllDataFromApi()만으로 올바르게 적재되므로 이 메서드가 필요 없다.)
+     */
+    @Transactional
+    public void rebuildMenuIngredients() {
+        try {
+            JsonNode recipeArray = loadRecipeArray();
+
+            Map<String, Menu> menuCache = menuRepository.findAll().stream()
+                    .collect(Collectors.toMap(Menu::getFoodCode, m -> m));
+            Map<String, Ingredient> ingredientCache = ingredientRepository.findAll().stream()
+                    .collect(Collectors.toMap(Ingredient::getName, i -> i));
+
+            long before = menuIngredientRepository.count();
+            menuIngredientRepository.deleteAllInBatch();
+            log.info("[재구축] 기존 menu_ingredients {}건 삭제", before);
+
+            List<MenuIngredient> toSave = new ArrayList<>();
+            int newIngredientCount = 0;
+            int skippedNoMenu = 0;
+
+            for (JsonNode recipeNode : recipeArray) {
+                if ("후식".equals(recipeNode.path("RCP_PAT2").asText())) continue;
+
+                String foodCode = recipeNode.path("RCP_SEQ").asText();
+                Menu menu = menuCache.get(foodCode);
+                if (menu == null) {
+                    // 메뉴가 아직 적재되지 않음 → syncAllDataFromApi() 선행 필요
+                    skippedNoMenu++;
+                    continue;
+                }
+
+                String recipeName = recipeNode.path("RCP_NM").asText();
+                String partsDetails = recipeNode.path("RCP_PARTS_DTLS").asText();
+
+                for (IngredientDto dto : RecipeDataParser.parseIngredients(partsDetails, recipeName)) {
+                    Ingredient ingredient = ingredientCache.get(dto.getName());
+                    if (ingredient == null) {
+                        ingredient = ingredientRepository.save(Ingredient.builder().name(dto.getName()).build());
+                        ingredientCache.put(dto.getName(), ingredient);
+                        newIngredientCount++;
+                    }
+                    toSave.add(MenuIngredient.builder()
+                            .menu(menu)
+                            .ingredient(ingredient)
+                            .subCategory(dto.getSubCategory())
+                            .requiredWeight(dto.getParsedWeight())
+                            .amountText(dto.getOriginalAmount())
+                            .build());
+                }
+            }
+
+            menuIngredientRepository.saveAll(toSave);
+            log.info("[재구축] 완료 — menu_ingredients {}건 재삽입, 신규 재료 {}건, 메뉴 미적재로 스킵 {}건",
+                    toSave.size(), newIngredientCount, skippedNoMenu);
+        } catch (Exception e) {
+            log.error("[재구축] menu_ingredients 재구축 실패 — 트랜잭션 롤백", e);
+            throw new RuntimeException("menu_ingredients 재구축 실패", e); // 롤백 보장
+        }
+    }
+
+    /**
+     * 어떤 메뉴에도 매핑되지 않고(레시피 미사용) 사용자 즐겨찾기에도 없는 재료를 삭제한다.
+     * - 연결된 가격(ingredient_prices)·KAMIS 매핑도 함께 제거.
+     * - 사용자 즐겨찾기가 참조하는 재료는 보존(사용자 데이터 보호).
+     * - rebuildMenuIngredients() 이후 옛 이름(쇠고기·안심 등) 잔여 행 정리에 사용.
+     *
+     * @return 삭제한 재료 수
+     */
+    @Transactional
+    public int deleteUnusedIngredients() {
+        List<Ingredient> unused = ingredientRepository.findUnusedIngredients();
+        if (unused.isEmpty()) {
+            log.info("[정리] 미사용 재료 없음");
+            return 0;
+        }
+
+        Set<Long> favoredIds = loadFavoredIngredientIds();
+        List<Ingredient> deletable = unused.stream()
+                .filter(i -> !favoredIds.contains(i.getId()))
+                .collect(Collectors.toList());
+
+        if (deletable.isEmpty()) {
+            log.info("[정리] 미사용 재료 {}건 전부 즐겨찾기 참조 → 삭제 대상 없음", unused.size());
+            return 0;
+        }
+
+        List<Long> ids = deletable.stream().map(Ingredient::getId).collect(Collectors.toList());
+        List<String> names = deletable.stream().map(Ingredient::getName).collect(Collectors.toList());
+
+        ingredientPriceRepository.deleteByIngredientIdIn(ids);
+        ingredientKamisMappingRepository.deleteByIngredientIdIn(ids);
+        ingredientRepository.deleteAllByIdInBatch(ids);
+
+        log.info("[정리] 미사용 재료 {}건 삭제 (즐겨찾기 보존 {}건): {}",
+                deletable.size(), unused.size() - deletable.size(), names);
+        return deletable.size();
+    }
+
+    /** 사용자 즐겨찾기가 참조하는 ingredient_id 집합. (batch 모듈엔 엔티티가 없어 네이티브 조회) */
+    private Set<Long> loadFavoredIngredientIds() {
+        try {
+            @SuppressWarnings("unchecked")
+            List<Number> ids = entityManager
+                    .createNativeQuery("SELECT DISTINCT ingredient_id FROM user_favorite_ingredients")
+                    .getResultList();
+            return ids.stream().map(Number::longValue).collect(Collectors.toSet());
+        } catch (Exception e) {
+            // 테이블 미존재 등(백엔드 미기동 환경) → 즐겨찾기 없음으로 간주
+            log.warn("[정리] user_favorite_ingredients 조회 실패 — 즐겨찾기 없음으로 처리: {}", e.getMessage());
+            return java.util.Collections.emptySet();
+        }
+    }
+
+    /** cleaned_recipe_data.json에서 레시피 배열 노드를 로드한다. */
+    private JsonNode loadRecipeArray() throws Exception {
+        ClassPathResource resource = new ClassPathResource("cleaned_recipe_data.json");
+        String rawJson = new String(Files.readAllBytes(Paths.get(resource.getURI())), StandardCharsets.UTF_8);
+        JsonNode rootNode = objectMapper.readTree(rawJson);
+        return rootNode.isArray() ? rootNode : rootNode.path("COOKRCP01").path("row");
     }
 
     /**

--- a/ai-meal-assistant-batch/src/test/java/capstone/ai_meal_assistant_batch/domain/etl/parser/RecipeDataParserTest.java
+++ b/ai-meal-assistant-batch/src/test/java/capstone/ai_meal_assistant_batch/domain/etl/parser/RecipeDataParserTest.java
@@ -1,0 +1,124 @@
+package capstone.ai_meal_assistant_batch.domain.etl.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import capstone.ai_meal_assistant_batch.domain.ingredient.dto.IngredientDto;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 육류 부위명 보존 파싱 검증.
+ * 기존엔 "소고기 치맛살" → 이름 "소고기" + amount "치맛살" 로 정규화되어
+ * 가격이 일반 소고기로 계산되던 문제를 부위 보존으로 교정한다.
+ */
+class RecipeDataParserTest {
+
+    private static IngredientDto first(String partsDtls) {
+        List<IngredientDto> list = RecipeDataParser.parseIngredients(partsDtls, "테스트레시피");
+        assertThat(list).isNotEmpty();
+        return list.get(0);
+    }
+
+    @Test
+    @DisplayName("소고기 치맛살 → 이름에 부위 보존")
+    void beefChimatsal() {
+        IngredientDto d = first("소고기 치맛살 (100g)");
+        assertThat(d.getName()).isEqualTo("소고기 치맛살");
+        assertThat(d.getParsedWeight()).isEqualTo(100.0);
+    }
+
+    @Test
+    @DisplayName("쇠고기 등심 → 소고기로 베이스 통일 + 부위 보존")
+    void beefSirloinUnify() {
+        IngredientDto d = first("쇠고기 등심 240g");
+        assertThat(d.getName()).isEqualTo("소고기 등심");
+    }
+
+    @Test
+    @DisplayName("돼지고기(안심) → 돼지고기 안심")
+    void porkTenderloinParen() {
+        IngredientDto d = first("돼지고기(안심, 100g)");
+        assertThat(d.getName()).isEqualTo("돼지고기 안심");
+    }
+
+    @Test
+    @DisplayName("다진 돼지고기(등심) → 돼지고기 등심, '다진'은 amount로 분리")
+    void mincedPorkSirloin() {
+        IngredientDto d = first("다진 돼지고기(등심, 60g)");
+        assertThat(d.getName()).isEqualTo("돼지고기 등심");
+        assertThat(d.getOriginalAmount()).contains("다진");
+    }
+
+    @Test
+    @DisplayName("불고기용 부채살 → 소고기 부채살, '불고기용'은 amount로 분리")
+    void beefBudaesal() {
+        IngredientDto d = first("소고기(불고기용 부채살, 200g)");
+        assertThat(d.getName()).isEqualTo("소고기 부채살");
+        assertThat(d.getOriginalAmount()).contains("불고기용");
+    }
+
+    @Test
+    @DisplayName("다진 소고기 → 부위 없으면 베이스만, '다진'은 amount로 분리")
+    void mincedBeefNoCut() {
+        IngredientDto d = first("다진 소고기 100g");
+        assertThat(d.getName()).isEqualTo("소고기");
+        assertThat(d.getOriginalAmount()).contains("다진");
+    }
+
+    @Test
+    @DisplayName("닭고기 가슴살 → 부위 보존")
+    void chickenBreast() {
+        IngredientDto d = first("닭고기 가슴살 150g");
+        assertThat(d.getName()).isEqualTo("닭고기 가슴살");
+    }
+
+    @Test
+    @DisplayName("돈등심(단독·약칭) → 돼지고기 등심")
+    void bareDonDeungsim() {
+        IngredientDto d = first("돈등심 80g");
+        assertThat(d.getName()).isEqualTo("돼지고기 등심");
+    }
+
+    @Test
+    @DisplayName("우목심(단독·약칭) → 소고기 목심")
+    void bareUmoksim() {
+        IngredientDto d = first("우목심(50g)");
+        assertThat(d.getName()).isEqualTo("소고기 목심");
+    }
+
+    @Test
+    @DisplayName("양지육(단독) → 소고기 양지")
+    void bareYangjiyuk() {
+        IngredientDto d = first("양지육(50g)");
+        assertThat(d.getName()).isEqualTo("소고기 양지");
+    }
+
+    @Test
+    @DisplayName("부챗살(단독) → 소고기 부챗살")
+    void bareBudaesal() {
+        IngredientDto d = first("부챗살(150g)");
+        assertThat(d.getName()).isEqualTo("소고기 부챗살");
+    }
+
+    @Test
+    @DisplayName("안심(단독·안심스테이크) → 소고기 안심")
+    void bareAnsim() {
+        IngredientDto d = first("안심 160g");
+        assertThat(d.getName()).isEqualTo("소고기 안심");
+    }
+
+    @Test
+    @DisplayName("돼기고기(오타) → 돼지고기")
+    void typoPork() {
+        IngredientDto d = first("다진 돼기고기 100g");
+        assertThat(d.getName()).isEqualTo("돼지고기");
+    }
+
+    @Test
+    @DisplayName("육류 외 재료는 영향 없음 (파프리카 색상은 그대로 amount)")
+    void nonMeatUnaffected() {
+        IngredientDto d = first("파프리카(노랑, 25g)");
+        assertThat(d.getName()).isEqualTo("파프리카");
+    }
+}


### PR DESCRIPTION
## 배경
메뉴 추천 시 "소고기 치맛살"처럼 부위가 명시된 재료가 `ingredients` 테이블엔 일반 "소고기"로만 저장돼, 부위와 무관한 가격(일반 소고기)으로 계산되는 문제가 있었습니다.
원인은 ETL 파서(`RecipeDataParser`)가 부위명을 이름에서 떼어내 `amount_text`로 밀어넣고 이름은 베이스("소고기")로만 저장했기 때문입니다.

## 변경 사항
- **파서(`RecipeDataParser`)**: 육류 베이스의 부위명을 이름에 보존(`소고기 치맛살`).
  - `쇠고기` → `소고기` 표기 통일
  - 단독/약칭/오타 정규화: `돈등심→돼지고기 등심`, `우목심→소고기 목심`,
    `양지육→소고기 양지`, `안심(단독)→소고기 안심`, `돼기고기→돼지고기` 등
  - 조리/용도 수식어(`다진`·`불고기용`·`샤브샤브용` 등)는 `amount_text`로 분리
- **재구축 API** `POST /api/admin/data/rebuild-ingredients`
  - 이미 적재된 메뉴 기준으로 `menu_ingredients`를 현재 파서로 재구축
  - **menus·이미지·기존 가격은 건드리지 않음**, 멱등(반복 실행 가능)
- **정리 API** `POST /api/admin/data/cleanup-unused-ingredients`
  - 레시피 미사용 + **사용자 즐겨찾기 미참조** 재료만 삭제(가격·KAMIS 매핑 동반)
  - 즐겨찾기가 참조하는 재료는 보존(사용자 데이터 보호)
- 테스트: `RecipeDataParserTest` 14케이스 추가

## ⚠️ 팀원 필수 액션 (각자 로컬 DB에서 실행)
> **코드 머지만으로는 DB 데이터가 바뀌지 않습니다.** DB는 개발자별 로컬(localhost:3307)이라
> 각자 아래를 실행해야 교정된 데이터를 볼 수 있습니다.

**이미 데이터가 적재된 DB:**
1. ./gradlew bootRun
2. curl -X POST localhost:8080/api/admin/data/rebuild-ingredients
3. NAVER 가격 잡 실행 (신규 부위 가격 수집)
4. curl -X POST localhost:8080/api/admin/data/cleanup-unused-ingredients

**빈 DB(처음 세팅):** 기존 `POST /sync-recipes` 만으로 고친 파서가 적용됩니다(1·4단계 불필요).

## 검증
- 파서 단위테스트 14건 통과 (`소고기 치맛살`, `쇠고기 등심→소고기 등심`, `다진 돼지고기(등심)` 등)
- 재구축 후: `소고기 치맛살`이 별도 재료로 매핑, 소고기 부위 12종 분리 확인
- 신규 부위 가격 예: 소고기 치맛살 ≈ 155원/g(한우 치마살) — 기존 일반 소고기(~22원/g) 대비 정상 반영

## 참고 / 주의
- NAVER 가격은 수집 **시점에 따라 값이 달라질 수 있습니다**(로직은 동일).
- `닭고기 가슴살 다리살`(다회 포장 상품)은 중량 인식 한계로 단가가 과대 추정될 수 있음(해당 재료 1회 사용).
