### PR TITLE
fix: 레시피 조리단계 저장 누락 + 육류 부위 파싱 교정 + DB 재구축 기능 (#141)

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/entity/MenuStep.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/entity/MenuStep.java
@@ -1,0 +1,29 @@
+package capstone.ai_meal_assistant_backend.domain.menu.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "menu_steps")
+@Getter
+@NoArgsConstructor
+public class MenuStep {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id", nullable = false)
+    private Menu menu;
+
+    @Column(nullable = false)
+    private int stepOrder;
+
+    @Column(length = 2000)
+    private String description;
+
+    @Column(length = 500)
+    private String imageUrl;
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/MenuStepRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/repository/MenuStepRepository.java
@@ -1,0 +1,16 @@
+package capstone.ai_meal_assistant_backend.domain.menu.repository;
+
+import capstone.ai_meal_assistant_backend.domain.menu.entity.MenuStep;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+
+@Repository
+public interface MenuStepRepository extends JpaRepository<MenuStep, Long> {
+
+    List<MenuStep> findByMenuIdInOrderByStepOrder(Collection<Long> menuIds);
+
+    List<MenuStep> findByMenuIdOrderByStepOrder(Long menuId);
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/service/MenuCandidateService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/menu/service/MenuCandidateService.java
@@ -4,9 +4,11 @@ import capstone.ai_meal_assistant_backend.domain.history.repository.Recommendati
 import capstone.ai_meal_assistant_backend.domain.menu.dto.MenuCandidateDto;
 import capstone.ai_meal_assistant_backend.domain.menu.entity.Allergy;
 import capstone.ai_meal_assistant_backend.domain.menu.entity.Menu;
+import capstone.ai_meal_assistant_backend.domain.menu.entity.MenuStep;
 import capstone.ai_meal_assistant_backend.domain.menu.entity.UserAllergy;
 import capstone.ai_meal_assistant_backend.domain.menu.repository.MenuAllergyRepository;
 import capstone.ai_meal_assistant_backend.domain.menu.repository.MenuRepository;
+import capstone.ai_meal_assistant_backend.domain.menu.repository.MenuStepRepository;
 import capstone.ai_meal_assistant_backend.domain.menu.repository.UserAllergyRepository;
 import capstone.ai_meal_assistant_backend.domain.user.entity.ProteinLevel;
 import capstone.ai_meal_assistant_backend.domain.user.entity.User;
@@ -34,6 +36,7 @@ public class MenuCandidateService {
     private final UserAllergyRepository userAllergyRepository;
     private final MenuAllergyRepository menuAllergyRepository;
     private final MenuRepository menuRepository;
+    private final MenuStepRepository menuStepRepository;
     private final RecommendationLogRepository recommendationLogRepository;
 
     public List<MenuCandidateDto> getCandidates(String email) {
@@ -74,7 +77,11 @@ public class MenuCandidateService {
                 .orElseThrow(() -> new IllegalArgumentException("메뉴를 찾을 수 없습니다. id=" + id));
         List<Object[]> rows = menuRepository.findIngredientsTextByMenuIds(List.of(id));
         String ingredientsText = rows.isEmpty() ? "" : (String) rows.get(0)[1];
-        return MenuCandidateDto.from(menu, ingredientsText, Collections.emptyList());
+        List<MenuCandidateDto.StepDto> steps = menuStepRepository.findByMenuIdOrderByStepOrder(id)
+                .stream()
+                .map(s -> new MenuCandidateDto.StepDto(s.getStepOrder(), s.getDescription(), s.getImageUrl()))
+                .collect(Collectors.toList());
+        return MenuCandidateDto.from(menu, ingredientsText, steps);
     }
 
     private List<MenuCandidateDto> buildDtos(List<Menu> menus) {
@@ -88,11 +95,17 @@ public class MenuCandidateService {
             ingredientsMap.put(menuId, (String) row[1]);
         }
 
+        Map<Long, List<MenuCandidateDto.StepDto>> stepsMap = new HashMap<>();
+        for (MenuStep step : menuStepRepository.findByMenuIdInOrderByStepOrder(menuIds)) {
+            stepsMap.computeIfAbsent(step.getMenu().getId(), k -> new ArrayList<>())
+                    .add(new MenuCandidateDto.StepDto(step.getStepOrder(), step.getDescription(), step.getImageUrl()));
+        }
+
         return menus.stream()
                 .map(m -> MenuCandidateDto.from(
                         m,
                         ingredientsMap.getOrDefault(m.getId(), ""),
-                        Collections.emptyList()
+                        stepsMap.getOrDefault(m.getId(), Collections.emptyList())
                 ))
                 .collect(Collectors.toList());
     }

--- a/ai-meal-assistant-batch/README.md
+++ b/ai-meal-assistant-batch/README.md
@@ -60,6 +60,33 @@ cd ai-meal-assistant-batch
 ./gradlew bootRun --args='--batch.mfds.enabled=true'
 ```
 
+### 메뉴 + 재료 전체 적재 (단발성)
+
+식약처 JSON(`cleaned_recipe_data.json`)을 읽어 `menus`, `ingredients`, `menu_ingredients`, `menu_steps`, `menu_allergies` 테이블을 채웁니다. S3 이미지 업로드 포함.
+
+```bash
+cd ai-meal-assistant-batch
+./gradlew bootRun --args='--batch.seed.ingredients.enabled=true'
+```
+
+### 재료만 재적재 (단발성)
+
+`menu_ingredients` 테이블을 재파싱해 재적재합니다. 파싱 로직 수정 후 기존 데이터를 교정할 때 사용합니다. 기존 데이터를 삭제하고 재삽입합니다.
+
+```bash
+cd ai-meal-assistant-batch
+./gradlew bootRun --args='--batch.seed.recipe-ingredients.enabled=true'
+```
+
+### 조리단계만 재적재 (단발성)
+
+`menu_steps` 테이블이 비어있거나 잘못된 경우 steps만 빠르게 재적재합니다. S3 업로드 없이 수 초 내 완료됩니다.
+
+```bash
+cd ai-meal-assistant-batch
+./gradlew bootRun --args='--batch.seed.steps.enabled=true'
+```
+
 ## 멱등성(중복 적재 방지) 가이드
 
 - 권장: 유니크 키 + upsert

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/controller/AdminDataController.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/controller/AdminDataController.java
@@ -28,6 +28,26 @@ public class AdminDataController {
         return ResponseEntity.ok("메뉴-알레르기 매핑이 성공적으로 완료되었습니다!");
     }
 
+    /**
+     * 이미 적재된 메뉴 기준으로 menu_ingredients를 현재 파서로 재구축.
+     * 파서 변경 후 기존 DB를 교정할 때 사용 (menus/이미지/기존 가격 무영향).
+     */
+    @PostMapping("/rebuild-ingredients")
+    public ResponseEntity<String> rebuildIngredients(){
+        syncService.rebuildMenuIngredients();
+        return ResponseEntity.ok("menu_ingredients 재구축이 완료되었습니다. (자세한 내역은 서버 로그)");
+    }
+
+    /**
+     * 레시피 미사용 + 즐겨찾기 미참조 재료를 정리(가격·KAMIS 매핑 포함 삭제).
+     * 보통 rebuild-ingredients 직후 옛 이름 잔여 행 정리에 사용.
+     */
+    @PostMapping("/cleanup-unused-ingredients")
+    public ResponseEntity<String> cleanupUnusedIngredients(){
+        int deleted = syncService.deleteUnusedIngredients();
+        return ResponseEntity.ok("미사용 재료 " + deleted + "건을 정리했습니다.");
+    }
+
     @PostMapping("/recover-images")
     public ResponseEntity<String> recoverImages(){
         boolean started = imageRecoveryAsyncRunner.tryStart();

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/parser/RecipeDataParser.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/parser/RecipeDataParser.java
@@ -3,6 +3,8 @@ package capstone.ai_meal_assistant_batch.domain.etl.parser;
 import capstone.ai_meal_assistant_batch.domain.ingredient.dto.IngredientDto;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -10,6 +12,31 @@ public class RecipeDataParser {
 
     private static final Pattern NUMBER_PATTERN = Pattern.compile("^(.*?)\\s*([0-9½⅓⅔¼¾⅕⅖⅙⅛]+.*)$");
     private static final Pattern FALLBACK_PATTERN = Pattern.compile("^(.*?)\\s*(약간|조금|적당량|약간량|소량|한꼬집|취향껏|필요량|기호에따라|.*?용|각각|각)$");
+
+    // 육류 베이스: 부위명을 이름에 보존하기 위한 대상
+    private static final Set<String> MEAT_BASES = Set.of("소고기", "쇠고기", "돼지고기", "닭고기", "오리고기", "양고기");
+
+    // 가격이 실제로 달라지는 부위명(화이트리스트). 여기 있는 토큰만 이름에 결합 보존한다.
+    // 살코기·살·다리처럼 베이스와 가격이 사실상 같은 토큰은 제외하여 amount로 분리한다.
+    private static final Set<String> MEAT_CUTS = Set.of(
+            "등심", "안심", "양지", "우둔살", "우둔", "홍두깨살", "치맛살", "살치살",
+            "갈빗살", "갈비", "등갈비", "뼈갈비", "부채살", "부챗살", "사태",
+            "목살", "목심", "삼겹살", "통삼겹살", "앞다리살", "전지",
+            "가슴살", "다리살", "다릿살", "날개", "채끝", "차돌박이");
+
+    // 부위명 표기 통일
+    private static final Map<String, String> MEAT_CUT_NORMALIZE = Map.of("다릿살", "다리살");
+
+    // 베이스 없이 부위명만 쓰인 단독 표기 → 베이스+부위로 정규화 (오타·약칭 포함)
+    private static final Map<String, String> BARE_CUT_BASE = Map.ofEntries(
+            Map.entry("돈등심", "돼지고기 등심"),
+            Map.entry("우목심", "소고기 목심"),
+            Map.entry("우삼겹", "소고기 우삼겹"),
+            Map.entry("양지육", "소고기 양지"),
+            Map.entry("채끝살", "소고기 채끝"),
+            Map.entry("부챗살", "소고기 부챗살"),
+            Map.entry("안심", "소고기 안심"),
+            Map.entry("돼기고기", "돼지고기"));
 
     public static List<IngredientDto> parseIngredients(String rcpPartsDtls, String recipeName) {
         List<IngredientDto> ingredientList = new ArrayList<>();
@@ -161,12 +188,33 @@ public class RecipeDataParser {
                     prefix = prefix.replaceAll("^[.,(]+", "").replaceAll("[.,)]+$", "").trim();
                     tail = tail.replaceAll("^[.,(]+", "").replaceAll("[.,)]+$", "").trim();
 
-                    if (!prefix.isEmpty()) extracted.append(prefix).append(" ");
-                    if (!tail.isEmpty()) extracted.append(tail).append(" ");
-
-                    name = base;
+                    if (MEAT_BASES.contains(base)) {
+                        // 육류: 부위명(등심·치맛살 등)은 이름에 보존, 조리/용도 수식어만 amount로 분리
+                        String normBase = "쇠고기".equals(base) ? "소고기" : base;
+                        StringBuilder cutPart = new StringBuilder();
+                        if (!prefix.isEmpty()) extracted.append(prefix).append(" ");
+                        for (String tok : tail.split("\\s+")) {
+                            String t = tok.replaceAll("[.,()]", "").trim();
+                            if (t.isEmpty()) continue;
+                            if (MEAT_CUTS.contains(t)) {
+                                cutPart.append(MEAT_CUT_NORMALIZE.getOrDefault(t, t)).append(" ");
+                            } else {
+                                extracted.append(tok).append(" ");
+                            }
+                        }
+                        name = cutPart.length() > 0 ? (normBase + " " + cutPart.toString().trim()) : normBase;
+                    } else {
+                        if (!prefix.isEmpty()) extracted.append(prefix).append(" ");
+                        if (!tail.isEmpty()) extracted.append(tail).append(" ");
+                        name = base;
+                    }
                     break;
                 }
+            }
+
+            // 베이스 없이 부위명만 쓴 단독 표기 정규화 (예: 돈등심 → 돼지고기 등심)
+            if (BARE_CUT_BASE.containsKey(name)) {
+                name = BARE_CUT_BASE.get(name);
             }
 
             if (name.contains("두 가지 색") || name.contains("두가지 색") || name.contains("두가지색")) {

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/parser/RecipeDataParser.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/parser/RecipeDataParser.java
@@ -80,7 +80,27 @@ public class RecipeDataParser {
             String amount = "";
             boolean isAbsolute = false;
 
-            String[] absoluteBases = {"물녹말", "녹말물", "흰살 생선", "채소 육수", "다시마 육수", "멸치 육수", "닭 육수", "고기 육수", "사골 육수", "육수"};
+            String[] absoluteBases = {
+                    // 달걀 부위 (specialBases의 "달걀" 오분리 방지)
+                    "달걀 흰자", "달걀 노른자",
+                    // 소고기 부위 (specialBases의 "소고기"/"쇠고기" 오분리 방지)
+                    "소고기 살치살", "소고기 등심", "소고기 안심", "소고기 갈비", "소고기 목살",
+                    "소고기 양지", "소고기 사태", "소고기 우둔살", "소고기 우둔", "소고기 채끝",
+                    "소고기 불고기", "소고기 다짐육", "소고기 치맛살", "소고기 살코기",
+                    "쇠고기 살치살", "쇠고기 등심", "쇠고기 안심", "쇠고기 갈비", "쇠고기 목살",
+                    "쇠고기 양지", "쇠고기 사태", "쇠고기 우둔살", "쇠고기 우둔", "쇠고기 채끝",
+                    "쇠고기 불고기", "쇠고기 살코기", "쇠고기 구이용",
+                    // 돼지고기 부위
+                    "돼지고기 목살", "돼지고기 목심", "돼지고기 삼겹살", "돼지고기 등심",
+                    "돼지고기 안심", "돼지고기 앞다리", "돼지고기 뒷다리", "돼지고기 갈비",
+                    "돼지고기 사태", "돼지고기 살코기",
+                    // 닭고기 부위
+                    "닭고기 가슴살", "닭고기 안심", "닭고기 다리살", "닭고기 다리", "닭고기 날개",
+                    // 양고기 부위
+                    "양고기 부채살",
+                    // 육수
+                    "물녹말", "녹말물", "흰살 생선", "채소 육수", "다시마 육수", "멸치 육수", "닭 육수", "고기 육수", "사골 육수", "육수"
+            };
             for (String base : absoluteBases) {
                 if (part.equals(base) || part.startsWith(base + " ") || part.startsWith(base + "(")) {
                     name = base;
@@ -151,21 +171,24 @@ public class RecipeDataParser {
                 }
             }
 
-            String[] specialBases = {"두 가지 묵", "두가지 묵", "달걀지단", "달걀", "오리고기", "돼지고기", "닭고기", "소고기", "쇠고기", "양고기", "파프리카", "피망", "식용 꽃", "대파", "당근", "연어", "메밀면", "연두부"};
-            for (String base : specialBases) {
-                if (name.contains(base) && !name.contains("가루")) {
-                    int idx = name.indexOf(base);
-                    String prefix = name.substring(0, idx).trim();
-                    String tail = name.substring(idx + base.length()).trim();
+            // absoluteBases로 이미 확정된 복합 재료명은 specialBases가 덮어쓰지 않도록 가드
+            if (!isAbsolute) {
+                String[] specialBases = {"두 가지 묵", "두가지 묵", "달걀지단", "달걀", "오리고기", "돼지고기", "닭고기", "소고기", "쇠고기", "양고기", "파프리카", "피망", "식용 꽃", "대파", "당근", "연어", "메밀면", "연두부"};
+                for (String base : specialBases) {
+                    if (name.contains(base) && !name.contains("가루")) {
+                        int idx = name.indexOf(base);
+                        String prefix = name.substring(0, idx).trim();
+                        String tail = name.substring(idx + base.length()).trim();
 
-                    prefix = prefix.replaceAll("^[.,(]+", "").replaceAll("[.,)]+$", "").trim();
-                    tail = tail.replaceAll("^[.,(]+", "").replaceAll("[.,)]+$", "").trim();
+                        prefix = prefix.replaceAll("^[.,(]+", "").replaceAll("[.,)]+$", "").trim();
+                        tail = tail.replaceAll("^[.,(]+", "").replaceAll("[.,)]+$", "").trim();
 
-                    if (!prefix.isEmpty()) extracted.append(prefix).append(" ");
-                    if (!tail.isEmpty()) extracted.append(tail).append(" ");
+                        if (!prefix.isEmpty()) extracted.append(prefix).append(" ");
+                        if (!tail.isEmpty()) extracted.append(tail).append(" ");
 
-                    name = base;
-                    break;
+                        name = base;
+                        break;
+                    }
                 }
             }
 

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientKamisMappingRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientKamisMappingRepository.java
@@ -2,6 +2,9 @@ package capstone.ai_meal_assistant_batch.domain.ingredient.repository;
 
 import capstone.ai_meal_assistant_batch.domain.ingredient.entity.IngredientKamisMapping;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -12,4 +15,9 @@ public interface IngredientKamisMappingRepository extends JpaRepository<Ingredie
     boolean existsByIngredientIdAndConfirmedTrue(Long ingredientId);
 
     boolean existsByIngredientIdAndKamisItemCode(Long ingredientId, String kamisItemCode);
+
+    // 미사용 재료 정리 시 연결된 KAMIS 매핑 일괄 삭제
+    @Modifying
+    @Query("DELETE FROM IngredientKamisMapping m WHERE m.ingredient.id IN :ids")
+    void deleteByIngredientIdIn(@Param("ids") List<Long> ids);
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientPriceRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientPriceRepository.java
@@ -2,8 +2,12 @@ package capstone.ai_meal_assistant_batch.domain.ingredient.repository;
 
 import capstone.ai_meal_assistant_batch.domain.ingredient.entity.IngredientPrice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 // 물가
@@ -13,4 +17,9 @@ public interface IngredientPriceRepository extends JpaRepository<IngredientPrice
     Optional<IngredientPrice> findTopByIngredientIdOrderByBaseDateDesc(Long ingredientId);
 
     Optional<IngredientPrice> findTopByIngredientIdAndSourceApi(Long ingredientId, String sourceApi);
+
+    // 미사용 재료 정리 시 연결된 가격 일괄 삭제
+    @Modifying
+    @Query("DELETE FROM IngredientPrice p WHERE p.ingredient.id IN :ids")
+    void deleteByIngredientIdIn(@Param("ids") List<Long> ids);
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/repository/IngredientRepository.java
@@ -15,4 +15,8 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
 
     @Query("SELECT i FROM Ingredient i WHERE i.id NOT IN (SELECT DISTINCT ip.ingredient.id FROM IngredientPrice ip)")
     List<Ingredient> findIngredientsWithoutAnyPrice();
+
+    // 어떤 메뉴에도 매핑되지 않은(레시피 미사용) 재료. 미사용 재료 정리에 사용.
+    @Query("SELECT i FROM Ingredient i WHERE i.id NOT IN (SELECT DISTINCT mi.ingredient.id FROM MenuIngredient mi)")
+    List<Ingredient> findUnusedIngredients();
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
@@ -9,10 +9,12 @@ import capstone.ai_meal_assistant_batch.domain.menu.entity.Allergy;
 import capstone.ai_meal_assistant_batch.domain.menu.entity.Menu;
 import capstone.ai_meal_assistant_batch.domain.menu.entity.MenuAllergy;
 import capstone.ai_meal_assistant_batch.domain.menu.entity.MenuIngredient;
+import capstone.ai_meal_assistant_batch.domain.menu.entity.MenuStep;
 import capstone.ai_meal_assistant_batch.domain.menu.repository.AllergyRepository;
 import capstone.ai_meal_assistant_batch.domain.menu.repository.MenuAllergyRepository;
 import capstone.ai_meal_assistant_batch.domain.menu.repository.MenuIngredientRepository;
 import capstone.ai_meal_assistant_batch.domain.menu.repository.MenuRepository;
+import capstone.ai_meal_assistant_batch.domain.menu.repository.MenuStepRepository;
 import capstone.ai_meal_assistant_batch.global.s3.S3ImageUploadService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,6 +44,7 @@ public class RecipeDataSyncService {
     private final MenuRepository menuRepository;
     private final IngredientRepository ingredientRepository;
     private final MenuIngredientRepository menuIngredientRepository;
+    private final MenuStepRepository menuStepRepository;
     private final AllergyRepository allergyRepository;
     private final MenuAllergyRepository menuAllergyRepository;
     private final ObjectMapper objectMapper;
@@ -121,7 +124,17 @@ public class RecipeDataSyncService {
 
             // =========================================================================
             // STEP 2: [식재료 파싱 및 매핑 테이블 Bulk Insert]
+            // 기존 menu_ingredients 삭제 후 재삽입해 멱등성 보장
             // =========================================================================
+            Set<Long> step2MenuIds = menuCache.values().stream()
+                    .filter(m -> m.getId() != null)
+                    .map(Menu::getId)
+                    .collect(Collectors.toSet());
+            if (!step2MenuIds.isEmpty()) {
+                menuIngredientRepository.deleteAllByMenuIds(step2MenuIds);
+                log.info("[STEP 2] 기존 menu_ingredients 삭제 완료 ({}개 메뉴)", step2MenuIds.size());
+            }
+
             List<MenuIngredient> menuIngredientsToSave = new ArrayList<>();
 
             for (JsonNode recipeNode : recipeArray) {
@@ -166,8 +179,55 @@ public class RecipeDataSyncService {
 
             log.info("데이터 동기화 완전 성공! 총 저장된 식재료 매핑 수: {}", menuIngredientsToSave.size());
 
+
             // =========================================================================
-            // STEP 3: [기존 메뉴 이미지 S3 마이그레이션]
+            // STEP 3: [조리단계 파싱 및 저장]
+            // 식약처 API MANUAL01~MANUAL20 / MANUAL_IMG01~MANUAL_IMG20 필드 저장
+            // 기존 steps를 먼저 삭제하고 재삽입해 멱등성 보장
+            // =========================================================================
+            Set<Long> batchMenuIds = new HashSet<>();
+            for (JsonNode recipeNode : recipeArray) {
+                if ("후식".equals(recipeNode.path("RCP_PAT2").asText())) continue;
+                Menu cachedMenu = menuCache.get(recipeNode.path("RCP_SEQ").asText());
+                if (cachedMenu != null && cachedMenu.getId() != null) {
+                    batchMenuIds.add(cachedMenu.getId());
+                }
+            }
+            if (!batchMenuIds.isEmpty()) {
+                menuStepRepository.deleteAllByMenuIds(batchMenuIds);
+            }
+
+            List<MenuStep> menuStepsToSave = new ArrayList<>();
+
+            for (JsonNode recipeNode : recipeArray) {
+                if ("후식".equals(recipeNode.path("RCP_PAT2").asText())) continue;
+
+                String stepFoodCode = recipeNode.path("RCP_SEQ").asText();
+                Menu stepMenu = menuCache.get(stepFoodCode);
+                if (stepMenu == null) continue;
+
+                int stepOrder = 0;
+                for (int fieldNo = 1; fieldNo <= 20; fieldNo++) {
+                    String content = recipeNode.path(String.format("MANUAL%02d", fieldNo)).asText("").trim();
+                    if (content.isEmpty()) continue;
+
+                    stepOrder++;
+                    String imageUrl = recipeNode.path(String.format("MANUAL_IMG%02d", fieldNo)).asText("").trim();
+                    menuStepsToSave.add(MenuStep.builder()
+                            .menu(stepMenu)
+                            .stepOrder(stepOrder)
+                            .description(content)
+                            .imageUrl(imageUrl.isEmpty() ? null : imageUrl)
+                            .build());
+                }
+            }
+
+            menuStepRepository.saveAll(menuStepsToSave);
+            log.info("[STEP 3] 조리단계 저장 완료: {}건", menuStepsToSave.size());
+
+
+            // =========================================================================
+            // STEP 4: [기존 메뉴 이미지 S3 마이그레이션]
             // 원본 URL(foodsafetykorea)을 가진 기존 메뉴를 S3 URL로 업데이트합니다.
             // =========================================================================
             List<Menu> menusToMigrate = menuRepository.findAll().stream()
@@ -295,14 +355,135 @@ public class RecipeDataSyncService {
     }
 
     /**
-     * STEP 4: 메뉴-알레르기 자동 매핑
+     * 재료(menu_ingredients)만 단독으로 재적재한다.
+     * 파싱 로직 수정 후 기존 데이터를 교정하거나, S3 업로드 없이 빠르게 재적재할 때 사용한다.
+     * 기존 menu_ingredients를 삭제 후 재삽입해 멱등성을 보장한다.
+     */
+    @Transactional
+    public void syncIngredientsOnly() {
+        log.info("[STEP 2 단독] 재료 재적재 시작");
+        try {
+            ClassPathResource resource = new ClassPathResource("cleaned_recipe_data.json");
+            String rawJson = new String(Files.readAllBytes(Paths.get(resource.getURI())), StandardCharsets.UTF_8);
+            JsonNode rootNode = objectMapper.readTree(rawJson);
+            JsonNode recipeArray = rootNode.isArray() ? rootNode : rootNode.path("COOKRCP01").path("row");
+
+            Map<String, Menu> menuCache = menuRepository.findAll().stream()
+                    .collect(Collectors.toMap(Menu::getFoodCode, m -> m));
+            Map<String, Ingredient> ingredientCache = ingredientRepository.findAll().stream()
+                    .collect(Collectors.toMap(Ingredient::getName, i -> i));
+
+            Set<Long> menuIds = menuCache.values().stream()
+                    .filter(m -> m.getId() != null)
+                    .map(Menu::getId)
+                    .collect(Collectors.toSet());
+            if (!menuIds.isEmpty()) {
+                menuIngredientRepository.deleteAllByMenuIds(menuIds);
+                log.info("[STEP 2 단독] 기존 menu_ingredients 삭제 완료 ({}개 메뉴)", menuIds.size());
+            }
+
+            List<MenuIngredient> menuIngredientsToSave = new ArrayList<>();
+            for (JsonNode recipeNode : recipeArray) {
+                if ("후식".equals(recipeNode.path("RCP_PAT2").asText())) continue;
+
+                String foodCode = recipeNode.path("RCP_SEQ").asText();
+                String recipeName = recipeNode.path("RCP_NM").asText();
+                String partsDetails = recipeNode.path("RCP_PARTS_DTLS").asText();
+                Menu menu = menuCache.get(foodCode);
+                if (menu == null) continue;
+
+                List<IngredientDto> dtoList = RecipeDataParser.parseIngredients(partsDetails, recipeName);
+                for (IngredientDto dto : dtoList) {
+                    String ingName = dto.getName();
+                    Ingredient ingredient = ingredientCache.get(ingName);
+                    if (ingredient == null) {
+                        ingredient = ingredientRepository.save(Ingredient.builder().name(ingName).build());
+                        ingredientCache.put(ingName, ingredient);
+                    }
+                    menuIngredientsToSave.add(MenuIngredient.builder()
+                            .menu(menu)
+                            .ingredient(ingredient)
+                            .subCategory(dto.getSubCategory())
+                            .requiredWeight(dto.getParsedWeight())
+                            .amountText(dto.getOriginalAmount())
+                            .build());
+                }
+            }
+
+            menuIngredientRepository.saveAll(menuIngredientsToSave);
+            log.info("[STEP 2 단독] 재료 재적재 완료: {}건", menuIngredientsToSave.size());
+        } catch (Exception e) {
+            log.error("[STEP 2 단독] 재료 재적재 중 오류 발생", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * 조리단계(menu_steps)만 단독으로 재적재한다.
+     * syncAllDataFromApi()의 STEP 3과 동일한 로직이며, S3 업로드 없이 빠르게 실행 가능.
+     * menu_steps가 비어 있거나 잘못 저장된 경우 단독으로 호출한다.
+     */
+    @Transactional
+    public void syncStepsOnly() {
+        log.info("[STEP 3 단독] 조리단계 적재 시작");
+        try {
+            ClassPathResource resource = new ClassPathResource("cleaned_recipe_data.json");
+            String rawJson = new String(Files.readAllBytes(Paths.get(resource.getURI())), StandardCharsets.UTF_8);
+            JsonNode rootNode = objectMapper.readTree(rawJson);
+            JsonNode recipeArray = rootNode.isArray() ? rootNode : rootNode.path("COOKRCP01").path("row");
+
+            Map<String, Menu> menuCache = menuRepository.findAll().stream()
+                    .collect(Collectors.toMap(Menu::getFoodCode, m -> m));
+
+            Set<Long> batchMenuIds = new HashSet<>();
+            for (JsonNode recipeNode : recipeArray) {
+                if ("후식".equals(recipeNode.path("RCP_PAT2").asText())) continue;
+                Menu menu = menuCache.get(recipeNode.path("RCP_SEQ").asText());
+                if (menu != null && menu.getId() != null) batchMenuIds.add(menu.getId());
+            }
+            if (!batchMenuIds.isEmpty()) {
+                menuStepRepository.deleteAllByMenuIds(batchMenuIds);
+                log.info("[STEP 3 단독] 기존 steps {}개 메뉴 분 삭제 완료", batchMenuIds.size());
+            }
+
+            List<MenuStep> menuStepsToSave = new ArrayList<>();
+            for (JsonNode recipeNode : recipeArray) {
+                if ("후식".equals(recipeNode.path("RCP_PAT2").asText())) continue;
+                Menu menu = menuCache.get(recipeNode.path("RCP_SEQ").asText());
+                if (menu == null) continue;
+
+                int stepOrder = 0;
+                for (int fieldNo = 1; fieldNo <= 20; fieldNo++) {
+                    String content = recipeNode.path(String.format("MANUAL%02d", fieldNo)).asText("").trim();
+                    if (content.isEmpty()) continue;
+                    stepOrder++;
+                    String imageUrl = recipeNode.path(String.format("MANUAL_IMG%02d", fieldNo)).asText("").trim();
+                    menuStepsToSave.add(MenuStep.builder()
+                            .menu(menu)
+                            .stepOrder(stepOrder)
+                            .description(content)
+                            .imageUrl(imageUrl.isEmpty() ? null : imageUrl)
+                            .build());
+                }
+            }
+
+            menuStepRepository.saveAll(menuStepsToSave);
+            log.info("[STEP 3 단독] 조리단계 적재 완료: {}건", menuStepsToSave.size());
+        } catch (Exception e) {
+            log.error("[STEP 3 단독] 조리단계 적재 중 오류 발생", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * STEP 5: 메뉴-알레르기 자동 매핑
      * menu_ingredients 재료명 키워드 기반으로 menu_allergies 테이블을 채웁니다.
      * syncAllDataFromApi()와 독립 실행 가능 — menu_ingredients가 채워진 상태라면 언제든 호출 가능.
      * 멱등: 이미 존재하는 (menu_id, allergy_id) 쌍은 skip.
      */
     @Transactional
     public void syncAllergyMappings() {
-        log.info("[STEP 4] 메뉴-알레르기 자동 매핑 시작");
+        log.info("[STEP 5] 메뉴-알레르기 자동 매핑 시작");
 
         // 4-1. 키워드 → 알레르기명 맵
         Map<String, String> keywordToAllergy = buildKeywordToAllergyMap();
@@ -310,7 +491,7 @@ public class RecipeDataSyncService {
         // 4-0. 정리: menu_allergies 전체 삭제 후 새로 채움 (멱등 보장)
         // allergies 테이블은 user_allergies FK가 있어 배치에서 직접 삭제하지 않음
         menuAllergyRepository.deleteAll();
-        log.info("[STEP 4] 기존 menu_allergies 전체 삭제 완료");
+        log.info("[STEP 5] 기존 menu_allergies 전체 삭제 완료");
 
         // 4-2. allergies 테이블 seed: 없는 항목만 INSERT
         Map<String, Allergy> allergyCache = allergyRepository.findAll().stream()
@@ -323,7 +504,7 @@ public class RecipeDataSyncService {
                 return allergyRepository.save(newAllergy);
             });
         }
-        log.info("[STEP 4] allergies 테이블: {}종 준비 완료", allergyCache.size());
+        log.info("[STEP 5] allergies 테이블: {}종 준비 완료", allergyCache.size());
 
         // 4-3. 기존 매핑 캐시 로드 (멱등 보장)
         Set<String> existingKeys = menuAllergyRepository.findAllKeys();
@@ -331,7 +512,7 @@ public class RecipeDataSyncService {
         // 4-4. menu_ingredients 전체 순회 → 키워드 매칭 → menu_allergies 생성
         List<MenuIngredient> allMenuIngredients = menuIngredientRepository.findAllWithMenuAndIngredient();
         if (allMenuIngredients.isEmpty()) {
-            log.warn("[STEP 4] menu_ingredients 데이터 없음 — syncAllDataFromApi() 먼저 실행 필요");
+            log.warn("[STEP 5] menu_ingredients 데이터 없음 — syncAllDataFromApi() 먼저 실행 필요");
             return;
         }
 
@@ -355,7 +536,7 @@ public class RecipeDataSyncService {
         }
 
         menuAllergyRepository.saveAll(menuAllergiesToSave);
-        log.info("[STEP 4] 메뉴-알레르기 매핑 완료: {}건 INSERT (총 재료 {}건 처리)", menuAllergiesToSave.size(), allMenuIngredients.size());
+        log.info("[STEP 5] 메뉴-알레르기 매핑 완료: {}건 INSERT (총 재료 {}건 처리)", menuAllergiesToSave.size(), allMenuIngredients.size());
     }
 
     /**

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
@@ -4,6 +4,8 @@ import capstone.ai_meal_assistant_batch.domain.etl.FoodSafetyApiFetcher;
 import capstone.ai_meal_assistant_batch.domain.etl.parser.RecipeDataParser;
 import capstone.ai_meal_assistant_batch.domain.ingredient.dto.IngredientDto;
 import capstone.ai_meal_assistant_batch.domain.ingredient.entity.Ingredient;
+import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientKamisMappingRepository;
+import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientPriceRepository;
 import capstone.ai_meal_assistant_batch.domain.ingredient.repository.IngredientRepository;
 import capstone.ai_meal_assistant_batch.domain.menu.entity.Allergy;
 import capstone.ai_meal_assistant_batch.domain.menu.entity.Menu;
@@ -16,6 +18,8 @@ import capstone.ai_meal_assistant_batch.domain.menu.repository.MenuRepository;
 import capstone.ai_meal_assistant_batch.global.s3.S3ImageUploadService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
@@ -42,10 +46,15 @@ public class RecipeDataSyncService {
     private final MenuRepository menuRepository;
     private final IngredientRepository ingredientRepository;
     private final MenuIngredientRepository menuIngredientRepository;
+    private final IngredientPriceRepository ingredientPriceRepository;
+    private final IngredientKamisMappingRepository ingredientKamisMappingRepository;
     private final AllergyRepository allergyRepository;
     private final MenuAllergyRepository menuAllergyRepository;
     private final ObjectMapper objectMapper;
     private final S3ImageUploadService s3ImageUploadService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     /** 이미지 복구 시 변경분을 끊어 저장하는 청크 크기. */
     private static final int RECOVERY_SAVE_CHUNK = 100;
@@ -195,6 +204,133 @@ public class RecipeDataSyncService {
         } catch (Exception e){
             log.error("API 데이터 동기화 중 에러 발생: ", e);
         }
+    }
+
+    /**
+     * 이미 적재된 메뉴 기준으로 menu_ingredients를 현재 파서로 재구축한다.
+     * - menus / 이미지 / 기존 가격(ingredient_prices)은 건드리지 않는다.
+     * - menu_ingredients 전체 삭제 후 cleaned_recipe_data.json을 재파싱해 재삽입한다.
+     * - 없는 재료명은 생성(create-if-absent), 기존 재료는 재사용. 멱등(반복 실행 가능).
+     * - 파서 로직을 바꾼 뒤 기존 DB를 교정할 때 사용한다.
+     *   (빈 DB는 syncAllDataFromApi()만으로 올바르게 적재되므로 이 메서드가 필요 없다.)
+     */
+    @Transactional
+    public void rebuildMenuIngredients() {
+        try {
+            JsonNode recipeArray = loadRecipeArray();
+
+            Map<String, Menu> menuCache = menuRepository.findAll().stream()
+                    .collect(Collectors.toMap(Menu::getFoodCode, m -> m));
+            Map<String, Ingredient> ingredientCache = ingredientRepository.findAll().stream()
+                    .collect(Collectors.toMap(Ingredient::getName, i -> i));
+
+            long before = menuIngredientRepository.count();
+            menuIngredientRepository.deleteAllInBatch();
+            log.info("[재구축] 기존 menu_ingredients {}건 삭제", before);
+
+            List<MenuIngredient> toSave = new ArrayList<>();
+            int newIngredientCount = 0;
+            int skippedNoMenu = 0;
+
+            for (JsonNode recipeNode : recipeArray) {
+                if ("후식".equals(recipeNode.path("RCP_PAT2").asText())) continue;
+
+                String foodCode = recipeNode.path("RCP_SEQ").asText();
+                Menu menu = menuCache.get(foodCode);
+                if (menu == null) {
+                    // 메뉴가 아직 적재되지 않음 → syncAllDataFromApi() 선행 필요
+                    skippedNoMenu++;
+                    continue;
+                }
+
+                String recipeName = recipeNode.path("RCP_NM").asText();
+                String partsDetails = recipeNode.path("RCP_PARTS_DTLS").asText();
+
+                for (IngredientDto dto : RecipeDataParser.parseIngredients(partsDetails, recipeName)) {
+                    Ingredient ingredient = ingredientCache.get(dto.getName());
+                    if (ingredient == null) {
+                        ingredient = ingredientRepository.save(Ingredient.builder().name(dto.getName()).build());
+                        ingredientCache.put(dto.getName(), ingredient);
+                        newIngredientCount++;
+                    }
+                    toSave.add(MenuIngredient.builder()
+                            .menu(menu)
+                            .ingredient(ingredient)
+                            .subCategory(dto.getSubCategory())
+                            .requiredWeight(dto.getParsedWeight())
+                            .amountText(dto.getOriginalAmount())
+                            .build());
+                }
+            }
+
+            menuIngredientRepository.saveAll(toSave);
+            log.info("[재구축] 완료 — menu_ingredients {}건 재삽입, 신규 재료 {}건, 메뉴 미적재로 스킵 {}건",
+                    toSave.size(), newIngredientCount, skippedNoMenu);
+        } catch (Exception e) {
+            log.error("[재구축] menu_ingredients 재구축 실패 — 트랜잭션 롤백", e);
+            throw new RuntimeException("menu_ingredients 재구축 실패", e); // 롤백 보장
+        }
+    }
+
+    /**
+     * 어떤 메뉴에도 매핑되지 않고(레시피 미사용) 사용자 즐겨찾기에도 없는 재료를 삭제한다.
+     * - 연결된 가격(ingredient_prices)·KAMIS 매핑도 함께 제거.
+     * - 사용자 즐겨찾기가 참조하는 재료는 보존(사용자 데이터 보호).
+     * - rebuildMenuIngredients() 이후 옛 이름(쇠고기·안심 등) 잔여 행 정리에 사용.
+     *
+     * @return 삭제한 재료 수
+     */
+    @Transactional
+    public int deleteUnusedIngredients() {
+        List<Ingredient> unused = ingredientRepository.findUnusedIngredients();
+        if (unused.isEmpty()) {
+            log.info("[정리] 미사용 재료 없음");
+            return 0;
+        }
+
+        Set<Long> favoredIds = loadFavoredIngredientIds();
+        List<Ingredient> deletable = unused.stream()
+                .filter(i -> !favoredIds.contains(i.getId()))
+                .collect(Collectors.toList());
+
+        if (deletable.isEmpty()) {
+            log.info("[정리] 미사용 재료 {}건 전부 즐겨찾기 참조 → 삭제 대상 없음", unused.size());
+            return 0;
+        }
+
+        List<Long> ids = deletable.stream().map(Ingredient::getId).collect(Collectors.toList());
+        List<String> names = deletable.stream().map(Ingredient::getName).collect(Collectors.toList());
+
+        ingredientPriceRepository.deleteByIngredientIdIn(ids);
+        ingredientKamisMappingRepository.deleteByIngredientIdIn(ids);
+        ingredientRepository.deleteAllByIdInBatch(ids);
+
+        log.info("[정리] 미사용 재료 {}건 삭제 (즐겨찾기 보존 {}건): {}",
+                deletable.size(), unused.size() - deletable.size(), names);
+        return deletable.size();
+    }
+
+    /** 사용자 즐겨찾기가 참조하는 ingredient_id 집합. (batch 모듈엔 엔티티가 없어 네이티브 조회) */
+    private Set<Long> loadFavoredIngredientIds() {
+        try {
+            @SuppressWarnings("unchecked")
+            List<Number> ids = entityManager
+                    .createNativeQuery("SELECT DISTINCT ingredient_id FROM user_favorite_ingredients")
+                    .getResultList();
+            return ids.stream().map(Number::longValue).collect(Collectors.toSet());
+        } catch (Exception e) {
+            // 테이블 미존재 등(백엔드 미기동 환경) → 즐겨찾기 없음으로 간주
+            log.warn("[정리] user_favorite_ingredients 조회 실패 — 즐겨찾기 없음으로 처리: {}", e.getMessage());
+            return java.util.Collections.emptySet();
+        }
+    }
+
+    /** cleaned_recipe_data.json에서 레시피 배열 노드를 로드한다. */
+    private JsonNode loadRecipeArray() throws Exception {
+        ClassPathResource resource = new ClassPathResource("cleaned_recipe_data.json");
+        String rawJson = new String(Files.readAllBytes(Paths.get(resource.getURI())), StandardCharsets.UTF_8);
+        JsonNode rootNode = objectMapper.readTree(rawJson);
+        return rootNode.isArray() ? rootNode : rootNode.path("COOKRCP01").path("row");
     }
 
     /**

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/entity/MenuStep.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/entity/MenuStep.java
@@ -1,0 +1,31 @@
+package capstone.ai_meal_assistant_batch.domain.menu.entity;
+
+import capstone.ai_meal_assistant_batch.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "menu_steps")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MenuStep extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id", nullable = false)
+    private Menu menu;
+
+    @Column(nullable = false)
+    private int stepOrder;
+
+    @Column(length = 2000)
+    private String description;
+
+    @Column(length = 500)
+    private String imageUrl;
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/repository/MenuIngredientRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/repository/MenuIngredientRepository.java
@@ -3,9 +3,12 @@ package capstone.ai_meal_assistant_batch.domain.menu.repository;
 import capstone.ai_meal_assistant_batch.domain.menu.entity.MenuIngredient;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Set;
 
 // 메뉴의 레시피 정보
 public interface MenuIngredientRepository extends JpaRepository<MenuIngredient, Long> {
@@ -14,7 +17,11 @@ public interface MenuIngredientRepository extends JpaRepository<MenuIngredient, 
     @EntityGraph(attributePaths = {"ingredient"})
     List<MenuIngredient> findAllByMenuId(Long menuId);
 
-    // STEP 4 용: 전체 menu_ingredients를 menu·ingredient 포함해서 한 번에 조회 (N+1 방지)
+    // STEP 5 용: 전체 menu_ingredients를 menu·ingredient 포함해서 한 번에 조회 (N+1 방지)
     @Query("SELECT mi FROM MenuIngredient mi JOIN FETCH mi.menu JOIN FETCH mi.ingredient")
     List<MenuIngredient> findAllWithMenuAndIngredient();
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM MenuIngredient mi WHERE mi.menu.id IN :menuIds")
+    void deleteAllByMenuIds(@Param("menuIds") Set<Long> menuIds);
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/repository/MenuStepRepository.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/menu/repository/MenuStepRepository.java
@@ -1,0 +1,18 @@
+package capstone.ai_meal_assistant_batch.domain.menu.repository;
+
+import capstone.ai_meal_assistant_batch.domain.menu.entity.MenuStep;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+
+@Repository
+public interface MenuStepRepository extends JpaRepository<MenuStep, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM MenuStep s WHERE s.menu.id IN :menuIds")
+    void deleteAllByMenuIds(@Param("menuIds") Set<Long> menuIds);
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/seed/RecipeIngredientSeedCommand.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/seed/RecipeIngredientSeedCommand.java
@@ -1,0 +1,38 @@
+package capstone.ai_meal_assistant_batch.job.seed;
+
+import java.time.Instant;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import capstone.ai_meal_assistant_batch.domain.ingredient.service.RecipeDataSyncService;
+import capstone.ai_meal_assistant_batch.global.log.BatchLog;
+import lombok.RequiredArgsConstructor;
+
+// 재료(menu_ingredients)만 단독 재적재 — 파싱 로직 수정 후 기존 데이터 교정 시 사용
+// cd ai-meal-assistant-batch
+// ./gradlew bootRun --args='--batch.seed.recipe-ingredients.enabled=true'
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "batch.seed.recipe-ingredients", name = "enabled", havingValue = "true")
+public class RecipeIngredientSeedCommand implements ApplicationRunner {
+
+    private static final String JOB_NAME = "recipeIngredientSeed";
+
+    private final RecipeDataSyncService recipeDataSyncService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Instant start = BatchLog.start(JOB_NAME);
+        try {
+            recipeDataSyncService.syncIngredientsOnly();
+            BatchLog.success(JOB_NAME, start, "re-seeded menu_ingredients via cleaned_recipe_data.json");
+        } catch (Exception e) {
+            BatchLog.fail(JOB_NAME, start, e);
+            throw e;
+        }
+    }
+}

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/seed/RecipeStepSeedCommand.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/job/seed/RecipeStepSeedCommand.java
@@ -1,0 +1,38 @@
+package capstone.ai_meal_assistant_batch.job.seed;
+
+import java.time.Instant;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import capstone.ai_meal_assistant_batch.domain.ingredient.service.RecipeDataSyncService;
+import capstone.ai_meal_assistant_batch.global.log.BatchLog;
+import lombok.RequiredArgsConstructor;
+
+// 조리단계(menu_steps)만 단독 적재 — S3 업로드 없이 빠르게 실행
+// cd ai-meal-assistant-batch
+// ./gradlew bootRun --args='--batch.seed.steps.enabled=true'
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "batch.seed.steps", name = "enabled", havingValue = "true")
+public class RecipeStepSeedCommand implements ApplicationRunner {
+
+    private static final String JOB_NAME = "recipeStepSeed";
+
+    private final RecipeDataSyncService recipeDataSyncService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Instant start = BatchLog.start(JOB_NAME);
+        try {
+            recipeDataSyncService.syncStepsOnly();
+            BatchLog.success(JOB_NAME, start, "seeded menu_steps via cleaned_recipe_data.json");
+        } catch (Exception e) {
+            BatchLog.fail(JOB_NAME, start, e);
+            throw e;
+        }
+    }
+}

--- a/ai-meal-assistant-batch/src/test/java/capstone/ai_meal_assistant_batch/domain/etl/parser/RecipeDataParserTest.java
+++ b/ai-meal-assistant-batch/src/test/java/capstone/ai_meal_assistant_batch/domain/etl/parser/RecipeDataParserTest.java
@@ -1,0 +1,124 @@
+package capstone.ai_meal_assistant_batch.domain.etl.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import capstone.ai_meal_assistant_batch.domain.ingredient.dto.IngredientDto;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 육류 부위명 보존 파싱 검증.
+ * 기존엔 "소고기 치맛살" → 이름 "소고기" + amount "치맛살" 로 정규화되어
+ * 가격이 일반 소고기로 계산되던 문제를 부위 보존으로 교정한다.
+ */
+class RecipeDataParserTest {
+
+    private static IngredientDto first(String partsDtls) {
+        List<IngredientDto> list = RecipeDataParser.parseIngredients(partsDtls, "테스트레시피");
+        assertThat(list).isNotEmpty();
+        return list.get(0);
+    }
+
+    @Test
+    @DisplayName("소고기 치맛살 → 이름에 부위 보존")
+    void beefChimatsal() {
+        IngredientDto d = first("소고기 치맛살 (100g)");
+        assertThat(d.getName()).isEqualTo("소고기 치맛살");
+        assertThat(d.getParsedWeight()).isEqualTo(100.0);
+    }
+
+    @Test
+    @DisplayName("쇠고기 등심 → 소고기로 베이스 통일 + 부위 보존")
+    void beefSirloinUnify() {
+        IngredientDto d = first("쇠고기 등심 240g");
+        assertThat(d.getName()).isEqualTo("소고기 등심");
+    }
+
+    @Test
+    @DisplayName("돼지고기(안심) → 돼지고기 안심")
+    void porkTenderloinParen() {
+        IngredientDto d = first("돼지고기(안심, 100g)");
+        assertThat(d.getName()).isEqualTo("돼지고기 안심");
+    }
+
+    @Test
+    @DisplayName("다진 돼지고기(등심) → 돼지고기 등심, '다진'은 amount로 분리")
+    void mincedPorkSirloin() {
+        IngredientDto d = first("다진 돼지고기(등심, 60g)");
+        assertThat(d.getName()).isEqualTo("돼지고기 등심");
+        assertThat(d.getOriginalAmount()).contains("다진");
+    }
+
+    @Test
+    @DisplayName("불고기용 부채살 → 소고기 부채살, '불고기용'은 amount로 분리")
+    void beefBudaesal() {
+        IngredientDto d = first("소고기(불고기용 부채살, 200g)");
+        assertThat(d.getName()).isEqualTo("소고기 부채살");
+        assertThat(d.getOriginalAmount()).contains("불고기용");
+    }
+
+    @Test
+    @DisplayName("다진 소고기 → 부위 없으면 베이스만, '다진'은 amount로 분리")
+    void mincedBeefNoCut() {
+        IngredientDto d = first("다진 소고기 100g");
+        assertThat(d.getName()).isEqualTo("소고기");
+        assertThat(d.getOriginalAmount()).contains("다진");
+    }
+
+    @Test
+    @DisplayName("닭고기 가슴살 → 부위 보존")
+    void chickenBreast() {
+        IngredientDto d = first("닭고기 가슴살 150g");
+        assertThat(d.getName()).isEqualTo("닭고기 가슴살");
+    }
+
+    @Test
+    @DisplayName("돈등심(단독·약칭) → 돼지고기 등심")
+    void bareDonDeungsim() {
+        IngredientDto d = first("돈등심 80g");
+        assertThat(d.getName()).isEqualTo("돼지고기 등심");
+    }
+
+    @Test
+    @DisplayName("우목심(단독·약칭) → 소고기 목심")
+    void bareUmoksim() {
+        IngredientDto d = first("우목심(50g)");
+        assertThat(d.getName()).isEqualTo("소고기 목심");
+    }
+
+    @Test
+    @DisplayName("양지육(단독) → 소고기 양지")
+    void bareYangjiyuk() {
+        IngredientDto d = first("양지육(50g)");
+        assertThat(d.getName()).isEqualTo("소고기 양지");
+    }
+
+    @Test
+    @DisplayName("부챗살(단독) → 소고기 부챗살")
+    void bareBudaesal() {
+        IngredientDto d = first("부챗살(150g)");
+        assertThat(d.getName()).isEqualTo("소고기 부챗살");
+    }
+
+    @Test
+    @DisplayName("안심(단독·안심스테이크) → 소고기 안심")
+    void bareAnsim() {
+        IngredientDto d = first("안심 160g");
+        assertThat(d.getName()).isEqualTo("소고기 안심");
+    }
+
+    @Test
+    @DisplayName("돼기고기(오타) → 돼지고기")
+    void typoPork() {
+        IngredientDto d = first("다진 돼기고기 100g");
+        assertThat(d.getName()).isEqualTo("돼지고기");
+    }
+
+    @Test
+    @DisplayName("육류 외 재료는 영향 없음 (파프리카 색상은 그대로 amount)")
+    void nonMeatUnaffected() {
+        IngredientDto d = first("파프리카(노랑, 25g)");
+        assertThat(d.getName()).isEqualTo("파프리카");
+    }
+}


### PR DESCRIPTION
## Summary

- `menu_steps` 테이블 추가 및 식약처 `MANUAL01~20` 조리단계 데이터 저장 구현
- 육류 재료 파싱 개선 — 부위명(등심·삼겹살 등)을 재료명에 보존해 정확한 가격 매핑 지원
- 기존 DB 교정용 재구축 커맨드 추가 (`rebuildMenuIngredients`, `deleteUnusedIngredients`)

## 변경 상세

### 배치 서버 (`ai-meal-assistant-batch`)

**조리단계 저장 (STEP 3)**
- `MenuStep` 엔티티 추가 (`menu_id`, `step_order`, `description`, `image_url`)
- `MenuStepRepository` 추가 — `deleteAllByMenuIds` 벌크 삭제 지원
- `RecipeDataSyncService.syncAllDataFromApi()` — STEP 3 추가: `MANUAL01~MANUAL_IMG20` 파싱 후 `menu_steps` 저장 (delete+insert 멱등)
- `syncStepsOnly()` — 조리단계만 단독 재적재 메서드 추가
- `RecipeStepSeedCommand` — CLI 커맨드 `--recipe-step-seed` 추가

**재료 파싱 개선 (`RecipeDataParser`)**
- `MEAT_BASES / MEAT_CUTS / MEAT_CUT_NORMALIZE` — 육류 부위 화이트리스트 추가
- `specialBases` 루프에서 육류 베이스 감지 시 부위명을 재료명에 결합 보존
  - 기존: `소고기 등심 200g` → `name=소고기`, `amount=등심 200g` (가격 오계산)
  - 변경: `소고기 등심 200g` → `name=소고기 등심`, `amount=200g`
- `BARE_CUT_BASE` — 단독 부위 약칭 정규화 (`돈등심→돼지고기 등심`, `양지육→소고기 양지` 등)
- `쇠고기` 표기를 `소고기`로 통일 (absoluteBases 경로 포함 전체 적용)
- `absoluteBases` 배열에 복합 부위명(`소고기 살치살`, `돼지고기 삼겹살` 등) 추가

**DB 재구축 유틸리티**
- `rebuildMenuIngredients()` — 현재 파서로 `menu_ingredients` 전체 재구축 (멱등, 트랜잭션 롤백 보장)
- `deleteUnusedIngredients()` — 미사용 재료 + 관련 가격·KAMIS 매핑 삭제 (즐겨찾기 참조 재료 보존)
- `syncIngredientsOnly()` — 재료만 단독 재적재
- `RecipeIngredientSeedCommand` — CLI 커맨드 `--recipe-ingredient-seed` 추가
- `AdminDataController` — 위 유틸리티 호출 HTTP 엔드포인트 추가

### 백엔드 서버 (`ai-meal-assistant-backend`)

- `MenuStep` 엔티티 / `MenuStepRepository` 추가
- `MenuCandidateService` — AI 추천 결과에 `steps` 필드를 DB에서 조회하도록 수정 (기존 `emptyList()` 제거)

## DB 마이그레이션

신규 테이블 1개 추가 — 첫 배치 실행 시 JPA DDL 자동 생성됨:

```sql
CREATE TABLE menu_steps (
  id          BIGINT AUTO_INCREMENT PRIMARY KEY,
  menu_id     BIGINT NOT NULL,
  step_order  INT NOT NULL,
  description TEXT NOT NULL,
  image_url   VARCHAR(500),
  created_at  DATETIME,
  updated_at  DATETIME,
  FOREIGN KEY (menu_id) REFERENCES menus(id) ON DEL
);

기존 DB 교정이 필요한 경우 순서:
1. POST /admin/rebuild-menu-ingredients — 재료 재구
2. POST /admin/delete-unused-ingredients — 구버전 재료명(쇠고기, 안심 등) 정리

Test plan

- [x] RecipeDataParserTest 17개 전체 통과 확인
- [ ] 배치 서버 기동 후 syncAllDataFromApi() 실행 →
- [ ] AI 추천 결과 응답에 steps 배열이 포함되는지 확인