### PR TITLE
fix: _MarqueeStrip multiple ticker 에러 수정 (#144)

### DIFF
--- a/flutter_app/lib/screens/market_price_screen.dart
+++ b/flutter_app/lib/screens/market_price_screen.dart
@@ -783,7 +783,7 @@ class _MarqueeStrip extends StatefulWidget {
 }
 
 class _MarqueeStripState extends State<_MarqueeStrip>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin {
   final ScrollController _controller = ScrollController();
   Ticker? _ticker;
   Duration _lastElapsed = Duration.zero;


### PR DESCRIPTION
## Summary

- `_MarqueeStripState` 믹스인을 `SingleTickerProviderStateMixin` → `TickerProviderStateMixin`으로 교체

## 원인

`_startScroll()`이 아래 두 경로에서 호출되어 `createTicker()`가 두 번 실행됨:
1. `initState` → `addPostFrameCallback` → `_startScroll()`
2. `didUpdateWidget`(items 변경 시) → `_startScroll()`

`SingleTickerProviderStateMixin`은 `createTicker()` 1회만 허용하므로 두 번째 호출 시 예외 발생.

## 변경 사항

`flutter_app/lib/screens/market_price_screen.dart`

```dart
// before
class _MarqueeStripState extends State<_MarqueeStrip>
    with SingleTickerProviderStateMixin {

// after
class _MarqueeStripState extends State<_MarqueeStrip>
    with TickerProviderStateMixin {

Test plan

- [ ] 시세 탭 진입 시 마퀴 스크롤 정상 동작 확인
- [ ] 검색어 입력 등으로 items 변경 시 에러 없이 재시작 확인