### PR TITLE
feat: AI 추천 결과 저장 및 추천 이력 조회 기능 (#154)

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
@@ -62,6 +62,39 @@ public class RecommendationLogController {
         return ResponseEntity.ok(Map.of("success", true, "data", picks));
     }
 
+    @PostMapping("/save")
+    public ResponseEntity<?> saveAiResult(
+            @RequestHeader(value = "Authorization", required = false) String authHeader,
+            @RequestBody SaveRequest request) {
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return ResponseEntity.status(401).body(Map.of("success", false, "error", "인증이 필요합니다."));
+        }
+
+        String email = jwtUtil.getEmailFromToken(authHeader.substring(7));
+        Long logId = recommendationLogService.saveAiResult(email, request.getMenuId(), request.getAiResultJson());
+        return ResponseEntity.ok(Map.of("success", true, "id", logId));
+    }
+
+    @PatchMapping("/{id}/feedback")
+    public ResponseEntity<?> updateFeedback(
+            @RequestHeader(value = "Authorization", required = false) String authHeader,
+            @PathVariable("id") Long id,
+            @RequestBody FeedbackRequest request) {
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return ResponseEntity.status(401).body(Map.of("success", false, "error", "인증이 필요합니다."));
+        }
+
+        String email = jwtUtil.getEmailFromToken(authHeader.substring(7));
+        try {
+            recommendationLogService.updateFeedback(email, id, request.getStarRating(), request.getFeedbackReason());
+            return ResponseEntity.ok(Map.of("success", true));
+        } catch (SecurityException e) {
+            return ResponseEntity.status(403).body(Map.of("success", false, "error", e.getMessage()));
+        }
+    }
+
     @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteFeedback(
             @RequestHeader(value = "Authorization", required = false) String authHeader,
@@ -88,5 +121,13 @@ public class RecommendationLogController {
         private Integer feedbackScore;  // 후보 좋아요/싫어요: 1 or -1
         private Integer starRating;     // AI 픽 별점: 1~5
         private String feedbackReason;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    static class SaveRequest {
+        private Long menuId;
+        private String aiResultJson;
     }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,9 +32,14 @@ public class RecommendationLogController {
         }
 
         String email = jwtUtil.getEmailFromToken(authHeader.substring(7));
-        recommendationLogService.saveFeedback(email, request.getMenuId(),
-                request.getFeedbackScore(), request.getStarRating(), request.getFeedbackReason());
-        return ResponseEntity.ok(Map.of("success", true));
+        try {
+            recommendationLogService.saveFeedback(email, request.getMenuId(),
+                    request.getFeedbackScore(), request.getStarRating(), request.getFeedbackReason());
+            return ResponseEntity.ok(Map.of("success", true));
+        } catch (DataIntegrityViolationException e) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("success", false, "error", "이미 저장된 메뉴입니다."));
+        }
     }
 
     @GetMapping("/my")
@@ -72,8 +78,13 @@ public class RecommendationLogController {
         }
 
         String email = jwtUtil.getEmailFromToken(authHeader.substring(7));
-        Long logId = recommendationLogService.saveAiResult(email, request.getMenuId(), request.getAiResultJson());
-        return ResponseEntity.ok(Map.of("success", true, "id", logId));
+        try {
+            Long logId = recommendationLogService.saveAiResult(email, request.getMenuId(), request.getAiResultJson());
+            return ResponseEntity.ok(Map.of("success", true, "id", logId));
+        } catch (DataIntegrityViolationException e) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("success", false, "error", "이미 저장된 메뉴입니다."));
+        }
     }
 
     @PatchMapping("/{id}/feedback")

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/dto/RecommendationLogResponse.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/dto/RecommendationLogResponse.java
@@ -18,6 +18,6 @@ public class RecommendationLogResponse {
     private String feedbackReason;
     private String aiResultJson;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDateTime createdAt;
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/dto/RecommendationLogResponse.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/dto/RecommendationLogResponse.java
@@ -16,7 +16,8 @@ public class RecommendationLogResponse {
     private Integer feedbackScore;
     private Integer starRating;
     private String feedbackReason;
+    private String aiResultJson;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/entity/RecommendationLog.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/entity/RecommendationLog.java
@@ -15,7 +15,8 @@ import java.util.List;
 @Entity
 @Table(
     name = "recommendation_logs",
-    indexes = @Index(name = "idx_rec_log_user_score", columnList = "user_id, feedback_score")
+    indexes = @Index(name = "idx_rec_log_user_score", columnList = "user_id, feedback_score"),
+    uniqueConstraints = @UniqueConstraint(name = "uq_rec_log_user_menu", columnNames = {"user_id", "selected_menu_id"})
 )
 @Getter
 @Setter
@@ -46,4 +47,8 @@ public class RecommendationLog extends BaseEntity {
 
     @Column(columnDefinition = "TEXT")
     private String feedbackReason;
+
+    // AI 추천 결과 전체 JSON (저장 버튼 누를 때 저장, 이력 화면 재현용)
+    @Column(columnDefinition = "TEXT")
+    private String aiResultJson;
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/repository/RecommendationLogRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/repository/RecommendationLogRepository.java
@@ -1,6 +1,7 @@
 package capstone.ai_meal_assistant_backend.domain.history.repository;
 
 import capstone.ai_meal_assistant_backend.domain.history.entity.RecommendationLog;
+import capstone.ai_meal_assistant_backend.domain.menu.entity.Menu;
 import capstone.ai_meal_assistant_backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -8,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Repository
@@ -19,6 +21,8 @@ public interface RecommendationLogRepository extends JpaRepository<Recommendatio
     @Query("SELECT r FROM RecommendationLog r WHERE r.user = :user AND r.feedbackScore IS NOT NULL ORDER BY r.createdAt DESC")
     List<RecommendationLog> findFeedbacksByUser(@Param("user") User user);
 
-    @Query("SELECT r FROM RecommendationLog r WHERE r.user = :user AND r.starRating IS NOT NULL ORDER BY r.createdAt DESC")
+    @Query("SELECT r FROM RecommendationLog r WHERE r.user = :user AND r.aiResultJson IS NOT NULL ORDER BY r.createdAt DESC")
     List<RecommendationLog> findAiPicksByUser(@Param("user") User user);
+
+    Optional<RecommendationLog> findByUserAndSelectedMenu(User user, Menu menu);
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
@@ -30,10 +30,48 @@ public class RecommendationLogService {
         Menu menu = menuRepository.findById(menuId)
                 .orElseThrow(() -> new IllegalArgumentException("메뉴를 찾을 수 없습니다."));
 
-        RecommendationLog log = new RecommendationLog();
-        log.setUser(user);
-        log.setSelectedMenu(menu);
+        RecommendationLog log = recommendationLogRepository
+                .findByUserAndSelectedMenu(user, menu)
+                .orElseGet(() -> {
+                    RecommendationLog newLog = new RecommendationLog();
+                    newLog.setUser(user);
+                    newLog.setSelectedMenu(menu);
+                    return newLog;
+                });
         log.setFeedbackScore(feedbackScore);
+        log.setStarRating(starRating);
+        log.setFeedbackReason(feedbackReason);
+        recommendationLogRepository.save(log);
+    }
+
+    @Transactional
+    public Long saveAiResult(String email, Long menuId, String aiResultJson) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        Menu menu = menuRepository.findById(menuId)
+                .orElseThrow(() -> new IllegalArgumentException("메뉴를 찾을 수 없습니다."));
+
+        RecommendationLog log = recommendationLogRepository
+                .findByUserAndSelectedMenu(user, menu)
+                .orElseGet(() -> {
+                    RecommendationLog newLog = new RecommendationLog();
+                    newLog.setUser(user);
+                    newLog.setSelectedMenu(menu);
+                    return newLog;
+                });
+        log.setAiResultJson(aiResultJson);
+        return recommendationLogRepository.save(log).getId();
+    }
+
+    @Transactional
+    public void updateFeedback(String email, Long logId, Integer starRating, String feedbackReason) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        RecommendationLog log = recommendationLogRepository.findById(logId)
+                .orElseThrow(() -> new IllegalArgumentException("이력을 찾을 수 없습니다."));
+        if (!log.getUser().getId().equals(user.getId())) {
+            throw new SecurityException("권한이 없습니다.");
+        }
         log.setStarRating(starRating);
         log.setFeedbackReason(feedbackReason);
         recommendationLogRepository.save(log);
@@ -72,6 +110,7 @@ public class RecommendationLogService {
                         .menuImageUrl(log.getSelectedMenu().getMainImageUrl())
                         .starRating(log.getStarRating())
                         .feedbackReason(log.getFeedbackReason())
+                        .aiResultJson(log.getAiResultJson())
                         .createdAt(log.getCreatedAt())
                         .build())
                 .collect(Collectors.toList());

--- a/flutter_app/lib/models/recommendation_models.dart
+++ b/flutter_app/lib/models/recommendation_models.dart
@@ -184,6 +184,14 @@ class NutritionInfo {
     carbs: json['carbs'] ?? '-',
     sodium: json['sodium'] ?? '-',
   );
+
+  Map<String, dynamic> toJson() => {
+    'energy': energy,
+    'protein': protein,
+    'fat': fat,
+    'carbs': carbs,
+    'sodium': sodium,
+  };
 }
 
 class RecipeStep {
@@ -202,6 +210,12 @@ class RecipeStep {
     content: json['content'] ?? '',
     image: json['image'] ?? '',
   );
+
+  Map<String, dynamic> toJson() => {
+    'step_no': stepNo,
+    'content': content,
+    'image': image,
+  };
 }
 
 class MarketPriceItem {
@@ -230,6 +244,15 @@ class MarketPriceItem {
         calculationReasoning: json['calculation_reasoning'] ?? '',
         calculatedCost: json['calculated_cost'] ?? 0,
       );
+
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    'recipe_amount': recipeAmount,
+    'market_unit': marketUnit,
+    'market_price': marketPrice,
+    'calculation_reasoning': calculationReasoning,
+    'calculated_cost': calculatedCost,
+  };
 }
 
 class RecommendationResult {
@@ -274,6 +297,19 @@ class RecommendationResult {
             .map((e) => MarketPriceItem.fromJson(e))
             .toList(),
       );
+
+  Map<String, dynamic> toJson() => {
+    'menu_id': menuId,
+    'menu_name': menuName,
+    'main_img': mainImg,
+    'nutrition_info': nutritionInfo.toJson(),
+    'recipe_steps': recipeSteps.map((s) => s.toJson()).toList(),
+    'na_tip': naTip,
+    'selection_reason': selectionReason,
+    'personalized_recipe_tip': personalizedRecipeTip,
+    'total_estimated_cost': totalEstimatedCost,
+    'market_prices': marketPrices.map((p) => p.toJson()).toList(),
+  };
 }
 
 class FeedbackHistoryItem {
@@ -311,6 +347,7 @@ class AiPickItem {
   final String? menuImageUrl;
   final int? starRating;
   final String? feedbackReason;
+  final String? aiResultJson;
   final String? createdAt;
 
   const AiPickItem({
@@ -320,6 +357,7 @@ class AiPickItem {
     this.menuImageUrl,
     this.starRating,
     this.feedbackReason,
+    this.aiResultJson,
     this.createdAt,
   });
 
@@ -330,6 +368,7 @@ class AiPickItem {
         menuImageUrl: json['menuImageUrl'],
         starRating: (json['starRating'] as num?)?.toInt(),
         feedbackReason: json['feedbackReason'],
+        aiResultJson: json['aiResultJson'],
         createdAt: json['createdAt'],
       );
 }

--- a/flutter_app/lib/screens/menu_detail_screen.dart
+++ b/flutter_app/lib/screens/menu_detail_screen.dart
@@ -32,6 +32,10 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
   bool _aiLoading = false;
   String? _aiError;
 
+  // ── 저장 상태 ──
+  bool _saving = false;
+  bool _saved = false;
+
   bool get _isAiPick => widget.aiResult != null;
 
   @override
@@ -51,6 +55,20 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
     } else {
       setState(() { _loading = false; _error = '상세 정보를 불러오지 못했습니다.'; });
     }
+  }
+
+  Future<void> _saveAiResult(RecommendationResult result) async {
+    if (_saving || widget.jwt == null) return;
+    setState(() => _saving = true);
+    final id = await RecommendationService.saveAiResult(result, widget.jwt);
+    if (!mounted) return;
+    setState(() { _saving = false; _saved = id != null; });
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(id != null ? '추천 이력에 저장됐습니다' : '저장에 실패했습니다'),
+        duration: const Duration(seconds: 2),
+      ),
+    );
   }
 
   Future<void> _requestAiAnalysis() async {
@@ -84,6 +102,27 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         actions: shownAi != null
             ? [
+                if (widget.jwt != null)
+                  IconButton(
+                    icon: _saving
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(
+                                strokeWidth: 2, color: AppTheme.primaryColor),
+                          )
+                        : Icon(
+                            _saved
+                                ? Icons.bookmark_rounded
+                                : Icons.bookmark_border_rounded,
+                            color: _saved
+                                ? AppTheme.primaryColor
+                                : Colors.grey[600],
+                          ),
+                    onPressed: _saving
+                        ? null
+                        : () => _saveAiResult(shownAi),
+                  ),
                 Container(
                   margin: const EdgeInsets.only(right: 16),
                   padding:
@@ -109,7 +148,7 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
             : null,
       ),
       body: shownAi != null
-          ? _AiPickBody(result: shownAi)
+          ? AiPickBody(result: shownAi)
           : _CandidateBody(
               candidate: widget.candidate!,
               detail: _detail,
@@ -126,9 +165,9 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
 }
 
 // ── AI 픽 상세 본문 ──────────────────────────────────────────
-class _AiPickBody extends StatelessWidget {
+class AiPickBody extends StatelessWidget {
   final RecommendationResult result;
-  const _AiPickBody({required this.result});
+  const AiPickBody({required this.result});
 
   @override
   Widget build(BuildContext context) {

--- a/flutter_app/lib/screens/menu_detail_screen.dart
+++ b/flutter_app/lib/screens/menu_detail_screen.dart
@@ -268,7 +268,7 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
                   onPressed: () =>
                       _showFeedbackBottomSheet(shownAi.menuId),
                   child: Text(
-                    '피드백 남기기',
+                    '피드백',
                     style: TextStyle(
                         fontSize: 13, color: Colors.grey[600]),
                   ),

--- a/flutter_app/lib/screens/menu_detail_screen.dart
+++ b/flutter_app/lib/screens/menu_detail_screen.dart
@@ -76,97 +76,106 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
       builder: (ctx) => StatefulBuilder(
-        builder: (ctx, setModal) => Padding(
+        builder: (ctx, setModal) => Container(
           padding: EdgeInsets.only(
-            left: 24, right: 24, top: 32,
-            bottom: MediaQuery.of(ctx).viewInsets.bottom + 24,
+            left: 24,
+            right: 24,
+            top: 28,
+            bottom: MediaQuery.of(ctx).viewInsets.bottom + 28,
           ),
-          child: Container(
-            decoration: const BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
-            ),
-            padding: const EdgeInsets.all(24),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                const Text('이번 추천은 어떠셨나요?',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                        fontSize: 20, fontWeight: FontWeight.bold)),
-                const SizedBox(height: 20),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: List.generate(
-                    5,
-                    (i) => IconButton(
-                      icon: Icon(
-                        i < _feedbackRating
-                            ? Icons.star_rounded
-                            : Icons.star_outline_rounded,
-                        size: 48,
-                        color: i < _feedbackRating
-                            ? Colors.amber
-                            : Colors.grey[300],
-                      ),
-                      onPressed: () =>
-                          setModal(() => _feedbackRating = i + 1),
-                    ),
+          decoration: const BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Center(
+                child: Container(
+                  width: 36,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: Colors.grey[300],
+                    borderRadius: BorderRadius.circular(2),
                   ),
                 ),
-                const SizedBox(height: 16),
-                TextField(
-                  controller: _feedbackController,
-                  maxLines: 3,
-                  onChanged: (_) => setModal(() {}),
-                  decoration: InputDecoration(
-                    hintText: '아쉬운 점이 있다면 알려주세요...',
-                    filled: true,
-                    fillColor: Colors.grey.shade100,
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(16),
-                      borderSide: BorderSide.none,
+              ),
+              const SizedBox(height: 20),
+              const Text('이번 추천은 어떠셨나요?',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                      fontSize: 18, fontWeight: FontWeight.bold)),
+              const SizedBox(height: 16),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: List.generate(
+                  5,
+                  (i) => IconButton(
+                    icon: Icon(
+                      i < _feedbackRating
+                          ? Icons.star_rounded
+                          : Icons.star_outline_rounded,
+                      size: 44,
+                      color: i < _feedbackRating
+                          ? Colors.amber
+                          : Colors.grey[300],
                     ),
+                    onPressed: () =>
+                        setModal(() => _feedbackRating = i + 1),
                   ),
                 ),
-                const SizedBox(height: 24),
-                Builder(builder: (_) {
-                  final canSubmit = _feedbackRating > 0 &&
-                      _feedbackController.text.trim().isNotEmpty;
-                  return Container(
-                    height: 56,
-                    decoration: BoxDecoration(
-                      gradient: canSubmit ? AppTheme.aiGradient : null,
-                      color: canSubmit ? null : Colors.grey[300],
-                      borderRadius: BorderRadius.circular(30),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _feedbackController,
+                maxLines: 3,
+                onChanged: (_) => setModal(() {}),
+                decoration: InputDecoration(
+                  hintText: '아쉬운 점이 있다면 알려주세요...',
+                  hintStyle:
+                      TextStyle(color: Colors.grey[400], fontSize: 14),
+                  filled: true,
+                  fillColor: Colors.grey.shade100,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide.none,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 20),
+              Builder(builder: (_) {
+                final canSubmit = _feedbackRating > 0 &&
+                    _feedbackController.text.trim().isNotEmpty;
+                return SizedBox(
+                  height: 52,
+                  child: ElevatedButton(
+                    onPressed: canSubmit
+                        ? () async {
+                            final rating = _feedbackRating;
+                            final reason = _feedbackController.text;
+                            Navigator.pop(ctx);
+                            await RecommendationService.saveDetailedFeedback(
+                                menuId, rating, reason, widget.jwt);
+                            messenger.showSnackBar(const SnackBar(
+                                content: Text('소중한 피드백 감사합니다!')));
+                          }
+                        : null,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppTheme.primaryColor,
+                      disabledBackgroundColor: Colors.grey[300],
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12)),
                     ),
-                    child: ElevatedButton(
-                      onPressed: canSubmit
-                          ? () async {
-                              final rating = _feedbackRating;
-                              final reason = _feedbackController.text;
-                              Navigator.pop(ctx);
-                              await RecommendationService.saveDetailedFeedback(
-                                  menuId, rating, reason, widget.jwt);
-                              messenger.showSnackBar(const SnackBar(
-                                  content: Text('소중한 피드백 감사합니다!')));
-                            }
-                          : null,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.transparent,
-                        shadowColor: Colors.transparent,
-                      ),
-                      child: const Text('제출',
-                          style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 16,
-                              fontWeight: FontWeight.bold)),
-                    ),
-                  );
-                }),
-              ],
-            ),
+                    child: const Text('제출',
+                        style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 15,
+                            fontWeight: FontWeight.w600)),
+                  ),
+                );
+              }),
+            ],
           ),
         ),
       ),
@@ -210,65 +219,83 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(title,
-            style: const TextStyle(fontWeight: FontWeight.bold),
-            overflow: TextOverflow.ellipsis),
-        centerTitle: true,
+        titleSpacing: 0,
+        title: Padding(
+          padding: const EdgeInsets.only(right: 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (shownAi != null)
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ShaderMask(
+                      blendMode: BlendMode.srcIn,
+                      shaderCallback: (b) =>
+                          AppTheme.aiGradient.createShader(b),
+                      child: const Icon(Icons.auto_awesome, size: 11),
+                    ),
+                    const SizedBox(width: 3),
+                    ShaderMask(
+                      blendMode: BlendMode.srcIn,
+                      shaderCallback: (b) =>
+                          AppTheme.aiGradient.createShader(b),
+                      child: const Text('AI 픽',
+                          style: TextStyle(
+                              fontSize: 11,
+                              fontWeight: FontWeight.bold)),
+                    ),
+                  ],
+                ),
+              Text(
+                title,
+                style: const TextStyle(
+                    fontSize: 16, fontWeight: FontWeight.bold),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+        centerTitle: false,
+        toolbarHeight: 64,
         elevation: 0,
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        actions: shownAi != null
+        actions: shownAi != null && widget.jwt != null
             ? [
-                if (widget.jwt != null) ...[
-                  IconButton(
-                    icon: Icon(Icons.star_outline_rounded,
-                        color: Colors.grey[600]),
-                    tooltip: '피드백',
-                    onPressed: () =>
-                        _showFeedbackBottomSheet(shownAi.menuId),
+                TextButton(
+                  onPressed: () =>
+                      _showFeedbackBottomSheet(shownAi.menuId),
+                  child: Text(
+                    '피드백 남기기',
+                    style: TextStyle(
+                        fontSize: 13, color: Colors.grey[600]),
                   ),
-                  IconButton(
-                    icon: _saving
-                        ? const SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                                color: AppTheme.primaryColor),
-                          )
-                        : Icon(
-                            _saved
-                                ? Icons.bookmark_rounded
-                                : Icons.bookmark_border_rounded,
+                ),
+                TextButton(
+                  onPressed:
+                      _saving ? null : () => _saveAiResult(shownAi),
+                  child: _saving
+                      ? const SizedBox(
+                          width: 14,
+                          height: 14,
+                          child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: AppTheme.primaryColor),
+                        )
+                      : Text(
+                          _saved ? '저장됨' : '저장',
+                          style: TextStyle(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
                             color: _saved
                                 ? AppTheme.primaryColor
                                 : Colors.grey[600],
                           ),
-                    tooltip: '저장',
-                    onPressed:
-                        _saving ? null : () => _saveAiResult(shownAi),
-                  ),
-                ],
-                Container(
-                  margin: const EdgeInsets.only(right: 16),
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-                  decoration: BoxDecoration(
-                    gradient: AppTheme.aiGradient,
-                    borderRadius: BorderRadius.circular(20),
-                  ),
-                  child: const Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(Icons.auto_awesome, color: Colors.white, size: 12),
-                      SizedBox(width: 4),
-                      Text('AI 픽',
-                          style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 12,
-                              fontWeight: FontWeight.bold)),
-                    ],
-                  ),
+                        ),
                 ),
+                const SizedBox(width: 4),
               ]
             : null,
       ),

--- a/flutter_app/lib/screens/menu_detail_screen.dart
+++ b/flutter_app/lib/screens/menu_detail_screen.dart
@@ -36,6 +36,10 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
   bool _saving = false;
   bool _saved = false;
 
+  // ── 피드백 상태 ──
+  int _feedbackRating = 0;
+  final TextEditingController _feedbackController = TextEditingController();
+
   bool get _isAiPick => widget.aiResult != null;
 
   @override
@@ -55,6 +59,118 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
     } else {
       setState(() { _loading = false; _error = '상세 정보를 불러오지 못했습니다.'; });
     }
+  }
+
+  @override
+  void dispose() {
+    _feedbackController.dispose();
+    super.dispose();
+  }
+
+  void _showFeedbackBottomSheet(int menuId) {
+    _feedbackRating = 0;
+    _feedbackController.clear();
+    final messenger = ScaffoldMessenger.of(context);
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setModal) => Padding(
+          padding: EdgeInsets.only(
+            left: 24, right: 24, top: 32,
+            bottom: MediaQuery.of(ctx).viewInsets.bottom + 24,
+          ),
+          child: Container(
+            decoration: const BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+            ),
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const Text('이번 추천은 어떠셨나요?',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                        fontSize: 20, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 20),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: List.generate(
+                    5,
+                    (i) => IconButton(
+                      icon: Icon(
+                        i < _feedbackRating
+                            ? Icons.star_rounded
+                            : Icons.star_outline_rounded,
+                        size: 48,
+                        color: i < _feedbackRating
+                            ? Colors.amber
+                            : Colors.grey[300],
+                      ),
+                      onPressed: () =>
+                          setModal(() => _feedbackRating = i + 1),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: _feedbackController,
+                  maxLines: 3,
+                  onChanged: (_) => setModal(() {}),
+                  decoration: InputDecoration(
+                    hintText: '아쉬운 점이 있다면 알려주세요...',
+                    filled: true,
+                    fillColor: Colors.grey.shade100,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(16),
+                      borderSide: BorderSide.none,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 24),
+                Builder(builder: (_) {
+                  final canSubmit = _feedbackRating > 0 &&
+                      _feedbackController.text.trim().isNotEmpty;
+                  return Container(
+                    height: 56,
+                    decoration: BoxDecoration(
+                      gradient: canSubmit ? AppTheme.aiGradient : null,
+                      color: canSubmit ? null : Colors.grey[300],
+                      borderRadius: BorderRadius.circular(30),
+                    ),
+                    child: ElevatedButton(
+                      onPressed: canSubmit
+                          ? () async {
+                              final rating = _feedbackRating;
+                              final reason = _feedbackController.text;
+                              Navigator.pop(ctx);
+                              await RecommendationService.saveDetailedFeedback(
+                                  menuId, rating, reason, widget.jwt);
+                              messenger.showSnackBar(const SnackBar(
+                                  content: Text('소중한 피드백 감사합니다!')));
+                            }
+                          : null,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.transparent,
+                        shadowColor: Colors.transparent,
+                      ),
+                      child: const Text('제출',
+                          style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold)),
+                    ),
+                  );
+                }),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
   }
 
   Future<void> _saveAiResult(RecommendationResult result) async {
@@ -102,14 +218,22 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         actions: shownAi != null
             ? [
-                if (widget.jwt != null)
+                if (widget.jwt != null) ...[
+                  IconButton(
+                    icon: Icon(Icons.star_outline_rounded,
+                        color: Colors.grey[600]),
+                    tooltip: '피드백',
+                    onPressed: () =>
+                        _showFeedbackBottomSheet(shownAi.menuId),
+                  ),
                   IconButton(
                     icon: _saving
                         ? const SizedBox(
                             width: 18,
                             height: 18,
                             child: CircularProgressIndicator(
-                                strokeWidth: 2, color: AppTheme.primaryColor),
+                                strokeWidth: 2,
+                                color: AppTheme.primaryColor),
                           )
                         : Icon(
                             _saved
@@ -119,10 +243,11 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
                                 ? AppTheme.primaryColor
                                 : Colors.grey[600],
                           ),
-                    onPressed: _saving
-                        ? null
-                        : () => _saveAiResult(shownAi),
+                    tooltip: '저장',
+                    onPressed:
+                        _saving ? null : () => _saveAiResult(shownAi),
                   ),
+                ],
                 Container(
                   margin: const EdgeInsets.only(right: 16),
                   padding:
@@ -167,7 +292,7 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
 // ── AI 픽 상세 본문 ──────────────────────────────────────────
 class AiPickBody extends StatelessWidget {
   final RecommendationResult result;
-  const AiPickBody({required this.result});
+  const AiPickBody({super.key, required this.result});
 
   @override
   Widget build(BuildContext context) {

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_app/models/recommendation_models.dart';
 import 'package:flutter_app/models/user_profile_models.dart';
 import 'package:flutter_app/services/recommendation_service.dart';
 import 'package:flutter_app/services/user_profile_service.dart';
+import 'package:flutter_app/screens/recommendation_history_screen.dart';
 import 'package:flutter_app/services/token_storage.dart';
 import 'package:flutter_app/theme.dart';
 
@@ -519,7 +520,56 @@ class _MyPageScreenState extends State<MyPageScreen>
                     fontSize: 14, color: Colors.grey[800], height: 1.5),
               ),
             ),
+            const SizedBox(height: 12),
+            _buildHistoryButton(),
             const SizedBox(height: 32),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHistoryButton() {
+    return GestureDetector(
+      onTap: () async {
+        final jwt = await TokenStorage.getAccessToken();
+        if (!mounted || jwt == null || jwt.isEmpty) return;
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => RecommendationHistoryScreen(jwt: jwt),
+          ),
+        );
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.04),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            ShaderMask(
+              blendMode: BlendMode.srcIn,
+              shaderCallback: (bounds) =>
+                  AppTheme.aiGradient.createShader(bounds),
+              child: const Icon(Icons.bookmark_rounded, size: 20),
+            ),
+            const SizedBox(width: 12),
+            const Text(
+              'AI 추천 이력',
+              style: TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+            ),
+            const Spacer(),
+            Icon(Icons.chevron_right_rounded,
+                color: Colors.grey[400], size: 20),
           ],
         ),
       ),

--- a/flutter_app/lib/screens/recommendation_history_detail_screen.dart
+++ b/flutter_app/lib/screens/recommendation_history_detail_screen.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/models/recommendation_models.dart';
+import 'package:flutter_app/screens/menu_detail_screen.dart' show AiPickBody;
+import 'package:flutter_app/services/recommendation_service.dart';
+import 'package:flutter_app/theme.dart';
+
+class RecommendationHistoryDetailScreen extends StatefulWidget {
+  final int logId;
+  final RecommendationResult result;
+  final int? initialStarRating;
+  final String? initialFeedbackReason;
+  final String jwt;
+
+  const RecommendationHistoryDetailScreen({
+    super.key,
+    required this.logId,
+    required this.result,
+    this.initialStarRating,
+    this.initialFeedbackReason,
+    required this.jwt,
+  });
+
+  @override
+  State<RecommendationHistoryDetailScreen> createState() =>
+      _RecommendationHistoryDetailScreenState();
+}
+
+class _RecommendationHistoryDetailScreenState
+    extends State<RecommendationHistoryDetailScreen> {
+  late int _starRating;
+  late TextEditingController _reasonController;
+  bool _submitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _starRating = widget.initialStarRating ?? 0;
+    _reasonController =
+        TextEditingController(text: widget.initialFeedbackReason ?? '');
+  }
+
+  @override
+  void dispose() {
+    _reasonController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submitFeedback() async {
+    if (_starRating == 0) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('별점을 선택해주세요')),
+      );
+      return;
+    }
+    setState(() => _submitting = true);
+    final ok = await RecommendationService.updateFeedback(
+      widget.logId,
+      _starRating,
+      _reasonController.text.trim(),
+      widget.jwt,
+    );
+    if (!mounted) return;
+    setState(() => _submitting = false);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(ok ? '피드백이 저장됐습니다' : '저장에 실패했습니다')),
+    );
+    if (ok) Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.backgroundColor,
+      appBar: AppBar(
+        title: Text(widget.result.menuName,
+            style: const TextStyle(fontWeight: FontWeight.bold),
+            overflow: TextOverflow.ellipsis),
+        centerTitle: true,
+        elevation: 0,
+        backgroundColor: AppTheme.backgroundColor,
+        actions: [
+          Container(
+            margin: const EdgeInsets.only(right: 16),
+            padding:
+                const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            decoration: BoxDecoration(
+              gradient: AppTheme.aiGradient,
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: const Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.auto_awesome, color: Colors.white, size: 12),
+                SizedBox(width: 4),
+                Text('AI 픽',
+                    style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold)),
+              ],
+            ),
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            // AI 결과 본문 재현
+            AiPickBody(result: widget.result),
+            // 피드백 폼
+            _buildFeedbackSection(),
+            const SizedBox(height: 32),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFeedbackSection() {
+    return Container(
+      margin: const EdgeInsets.fromLTRB(20, 0, 20, 0),
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.04),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text('이 추천은 어떠셨나요?',
+              style: TextStyle(
+                  fontSize: 15, fontWeight: FontWeight.w700)),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: List.generate(
+              5,
+              (i) => IconButton(
+                icon: Icon(
+                  i < _starRating
+                      ? Icons.star_rounded
+                      : Icons.star_outline_rounded,
+                  size: 40,
+                  color: i < _starRating ? Colors.amber : Colors.grey[300],
+                ),
+                onPressed: () => setState(() => _starRating = i + 1),
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _reasonController,
+            maxLines: 3,
+            decoration: InputDecoration(
+              hintText: '한 줄 코멘트 (선택)',
+              hintStyle:
+                  TextStyle(color: Colors.grey[400], fontSize: 14),
+              filled: true,
+              fillColor: Colors.grey.shade100,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide.none,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            height: 50,
+            child: ElevatedButton(
+              onPressed: _submitting ? null : _submitFeedback,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppTheme.primaryColor,
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12)),
+              ),
+              child: _submitting
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                          strokeWidth: 2, color: Colors.white),
+                    )
+                  : const Text('피드백 저장',
+                      style: TextStyle(
+                          fontSize: 15, fontWeight: FontWeight.w600)),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/screens/recommendation_history_screen.dart
+++ b/flutter_app/lib/screens/recommendation_history_screen.dart
@@ -1,0 +1,193 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_app/models/recommendation_models.dart';
+import 'package:flutter_app/screens/recommendation_history_detail_screen.dart';
+import 'package:flutter_app/services/recommendation_service.dart';
+import 'package:flutter_app/theme.dart';
+
+class RecommendationHistoryScreen extends StatefulWidget {
+  final String jwt;
+  const RecommendationHistoryScreen({super.key, required this.jwt});
+
+  @override
+  State<RecommendationHistoryScreen> createState() =>
+      _RecommendationHistoryScreenState();
+}
+
+class _RecommendationHistoryScreenState
+    extends State<RecommendationHistoryScreen> {
+  List<AiPickItem> _items = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    final items = await RecommendationService.fetchMyAiPicks(widget.jwt);
+    if (mounted) setState(() { _items = items; _loading = false; });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.backgroundColor,
+      appBar: AppBar(
+        title: const Text('추천 이력',
+            style: TextStyle(fontWeight: FontWeight.bold)),
+        centerTitle: true,
+        elevation: 0,
+        backgroundColor: AppTheme.backgroundColor,
+      ),
+      body: _loading
+          ? const Center(
+              child: CircularProgressIndicator(color: AppTheme.primaryColor))
+          : _items.isEmpty
+              ? _buildEmpty()
+              : RefreshIndicator(
+                  color: AppTheme.primaryColor,
+                  onRefresh: _load,
+                  child: ListView.builder(
+                    padding: const EdgeInsets.all(20),
+                    itemCount: _items.length,
+                    itemBuilder: (context, index) =>
+                        _buildCard(_items[index]),
+                  ),
+                ),
+    );
+  }
+
+  Widget _buildEmpty() {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.bookmark_border_rounded,
+              size: 64, color: Colors.grey[300]),
+          const SizedBox(height: 16),
+          Text('저장된 추천 이력이 없어요',
+              style: TextStyle(fontSize: 16, color: Colors.grey[500])),
+          const SizedBox(height: 8),
+          Text('AI 픽 화면의 저장 버튼을 눌러보세요',
+              style: TextStyle(fontSize: 13, color: Colors.grey[400])),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCard(AiPickItem item) {
+    return GestureDetector(
+      onTap: () async {
+        if (item.aiResultJson == null) return;
+        RecommendationResult? result;
+        try {
+          result = RecommendationResult.fromJson(
+              jsonDecode(item.aiResultJson!) as Map<String, dynamic>);
+        } catch (_) {
+          return;
+        }
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => RecommendationHistoryDetailScreen(
+              logId: item.id,
+              result: result!,
+              initialStarRating: item.starRating,
+              initialFeedbackReason: item.feedbackReason,
+              jwt: widget.jwt,
+            ),
+          ),
+        );
+        _load();
+      },
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 12),
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.04),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            if (item.menuImageUrl != null && item.menuImageUrl!.isNotEmpty)
+              ClipRRect(
+                borderRadius: BorderRadius.circular(10),
+                child: Image.network(
+                  item.menuImageUrl!,
+                  width: 56,
+                  height: 56,
+                  fit: BoxFit.cover,
+                  errorBuilder: (_, __, ___) =>
+                      _imagePlaceholder(),
+                ),
+              )
+            else
+              _imagePlaceholder(),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    item.menuName,
+                    style: const TextStyle(
+                        fontSize: 15, fontWeight: FontWeight.w700),
+                  ),
+                  if (item.createdAt != null) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      item.createdAt!,
+                      style: TextStyle(
+                          fontSize: 12, color: Colors.grey[400]),
+                    ),
+                  ],
+                  if (item.starRating != null) ...[
+                    const SizedBox(height: 4),
+                    Row(
+                      children: List.generate(
+                        5,
+                        (i) => Icon(
+                          i < item.starRating!
+                              ? Icons.star_rounded
+                              : Icons.star_outline_rounded,
+                          size: 14,
+                          color: Colors.amber,
+                        ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            Icon(Icons.chevron_right_rounded,
+                color: Colors.grey[400], size: 20),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _imagePlaceholder() {
+    return Container(
+      width: 56,
+      height: 56,
+      decoration: BoxDecoration(
+        color: AppTheme.primaryColor.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: const Icon(Icons.restaurant_menu,
+          color: AppTheme.primaryColor, size: 24),
+    );
+  }
+}

--- a/flutter_app/lib/screens/recommendation_history_screen.dart
+++ b/flutter_app/lib/screens/recommendation_history_screen.dart
@@ -26,8 +26,8 @@ class _RecommendationHistoryScreenState
     _load();
   }
 
-  Future<void> _load() async {
-    setState(() => _loading = true);
+  Future<void> _load({bool silent = false}) async {
+    if (!silent) setState(() => _loading = true);
     final items = await RecommendationService.fetchMyAiPicks(widget.jwt);
     if (mounted) setState(() { _items = items; _loading = false; });
   }
@@ -102,7 +102,7 @@ class _RecommendationHistoryScreenState
             ),
           ),
         );
-        _load();
+        await _load(silent: true);
       },
       child: Container(
         margin: const EdgeInsets.only(bottom: 12),

--- a/flutter_app/lib/screens/recommendation_screen.dart
+++ b/flutter_app/lib/screens/recommendation_screen.dart
@@ -30,8 +30,6 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
   final Set<int> _negativeFeedbackIds = {};
   final Set<int> _positiveFeedbackIds = {};
 
-  int _rating = 0;
-  final TextEditingController _feedbackController = TextEditingController();
 
   @override
   void initState() {
@@ -39,12 +37,6 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
     _candidates = List.from(widget.candidates);
     _currentRequest = widget.request;
     _fetchAiResult();
-  }
-
-  @override
-  void dispose() {
-    _feedbackController.dispose();
-    super.dispose();
   }
 
   Future<void> _fetchAiResult() async {
@@ -114,103 +106,6 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
     }
   }
 
-  void _showFeedbackBottomSheet(int menuId) {
-    _rating = 0;
-    _feedbackController.clear();
-    final messenger = ScaffoldMessenger.of(context);
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      backgroundColor: Colors.transparent,
-      builder: (context) => StatefulBuilder(
-        builder: (ctx, setModal) => Container(
-          padding: EdgeInsets.only(
-            left: 24, right: 24, top: 32,
-            bottom: MediaQuery.of(context).viewInsets.bottom + 24,
-          ),
-          decoration: const BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              const Text('이번 추천은 어떠셨나요?',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-              const SizedBox(height: 20),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: List.generate(5, (i) => IconButton(
-                  icon: Icon(
-                    i < _rating ? Icons.star_rounded : Icons.star_outline_rounded,
-                    size: 48,
-                    color: i < _rating ? Colors.amber : Colors.grey[300],
-                  ),
-                  onPressed: () => setModal(() => _rating = i + 1),
-                )),
-              ),
-              const SizedBox(height: 20),
-              TextField(
-                controller: _feedbackController,
-                maxLines: 3,
-                onChanged: (_) => setModal(() {}),
-                decoration: InputDecoration(
-                  hintText: '아쉬운 점이 있다면 알려주세요...',
-                  filled: true,
-                  fillColor: Colors.grey.shade100,
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(16),
-                    borderSide: BorderSide.none,
-                  ),
-                ),
-              ),
-              const SizedBox(height: 24),
-              Builder(
-                builder: (_) {
-                  final canSubmit =
-                      _rating > 0 && _feedbackController.text.trim().isNotEmpty;
-                  return Container(
-                    height: 56,
-                    decoration: BoxDecoration(
-                      gradient: canSubmit ? AppTheme.aiGradient : null,
-                      color: canSubmit ? null : Colors.grey[300],
-                      borderRadius: BorderRadius.circular(30),
-                    ),
-                    child: ElevatedButton(
-                      onPressed: canSubmit
-                          ? () async {
-                              final rating = _rating;
-                              final reason = _feedbackController.text;
-                              Navigator.pop(context);
-                              await RecommendationService.saveDetailedFeedback(
-                                  menuId, rating, reason, widget.request.jwtToken);
-                              messenger.showSnackBar(
-                                const SnackBar(content: Text('소중한 피드백 감사합니다!')),
-                              );
-                            }
-                          : null,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.transparent,
-                        shadowColor: Colors.transparent,
-                        shape: const StadiumBorder(),
-                      ),
-                      child: Text('피드백 제출하기',
-                          style: TextStyle(
-                              fontSize: 16,
-                              fontWeight: FontWeight.bold,
-                              color: canSubmit ? Colors.white : Colors.grey[600])),
-                    ),
-                  );
-                },
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -249,7 +144,6 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
                           ),
                         ),
                       ),
-                      onFeedbackTap: (result) => _showFeedbackBottomSheet(result.menuId),
                     ),
                   ),
                 ),
@@ -338,7 +232,6 @@ class _AiPickSection extends StatefulWidget {
   final String? error;
   final VoidCallback onRetry;
   final void Function(RecommendationResult) onDetailTap;
-  final void Function(RecommendationResult) onFeedbackTap;
 
   const _AiPickSection({
     required this.loading,
@@ -346,7 +239,6 @@ class _AiPickSection extends StatefulWidget {
     required this.error,
     required this.onRetry,
     required this.onDetailTap,
-    required this.onFeedbackTap,
   });
 
   @override
@@ -430,10 +322,7 @@ class _AiPickSectionState extends State<_AiPickSection> {
                   padding: const EdgeInsets.symmetric(horizontal: 4),
                   child: GestureDetector(
                     onTap: () => widget.onDetailTap(r),
-                    child: _ResultCard(
-                      result: r,
-                      onFeedbackTap: () => widget.onFeedbackTap(r),
-                    ),
+                    child: _ResultCard(result: r),
                   ),
                 );
               },
@@ -492,30 +381,56 @@ class _LoadingCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: Padding(
-        padding: const EdgeInsets.all(20),
-        child: Row(
-          children: [
-            const SizedBox(
-              width: 24, height: 24,
-              child: CircularProgressIndicator(
-                  color: AppTheme.primaryColor, strokeWidth: 2.5),
-            ),
-            const SizedBox(width: 14),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Text('AI가 최적 메뉴를 분석 중입니다...',
-                      style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14)),
-                  const SizedBox(height: 4),
-                  Text('후보 목록을 먼저 확인해보세요.',
-                      style: TextStyle(fontSize: 12, color: Colors.grey[600])),
-                ],
+      clipBehavior: Clip.antiAlias,
+      elevation: 2,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Container(
+            height: 130,
+            color: Colors.grey[100],
+            child: Icon(Icons.restaurant_menu,
+                size: 52, color: Colors.grey[300]),
+          ),
+          Expanded(
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const SizedBox(
+                      width: 44,
+                      height: 44,
+                      child: CircularProgressIndicator(
+                          color: AppTheme.primaryColor, strokeWidth: 3),
+                    ),
+                    const SizedBox(height: 20),
+                    ShaderMask(
+                      blendMode: BlendMode.srcIn,
+                      shaderCallback: (b) =>
+                          AppTheme.aiGradient.createShader(b),
+                      child: const Text(
+                        'AI 분석 중...',
+                        style: TextStyle(
+                            fontSize: 17, fontWeight: FontWeight.w800),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      '최적의 메뉴를 찾고 있어요\n아래 후보 목록을 먼저 확인해 보세요',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                          fontSize: 13,
+                          color: Colors.grey[500],
+                          height: 1.5),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -549,8 +464,7 @@ class _ErrorCard extends StatelessWidget {
 
 class _ResultCard extends StatelessWidget {
   final RecommendationResult result;
-  final VoidCallback? onFeedbackTap;
-  const _ResultCard({required this.result, this.onFeedbackTap});
+  const _ResultCard({required this.result});
 
   @override
   Widget build(BuildContext context) {
@@ -598,22 +512,6 @@ class _ResultCard extends StatelessWidget {
                     ]),
                   ],
                   const Spacer(),
-                  const Divider(height: 20),
-                  SizedBox(
-                    width: double.infinity,
-                    child: OutlinedButton.icon(
-                      onPressed: onFeedbackTap,
-                      icon: const Icon(Icons.star_outline_rounded, size: 15),
-                      label: const Text('이 메뉴 피드백 남기기'),
-                      style: OutlinedButton.styleFrom(
-                        foregroundColor: AppTheme.primaryColor,
-                        side: const BorderSide(color: AppTheme.primaryColor, width: 1),
-                        textStyle: const TextStyle(
-                            fontSize: 13, fontWeight: FontWeight.w600),
-                        shape: const StadiumBorder(),
-                      ),
-                    ),
-                  ),
                 ],
               ),
             ),

--- a/flutter_app/lib/screens/recommendation_screen.dart
+++ b/flutter_app/lib/screens/recommendation_screen.dart
@@ -243,7 +243,10 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
                       onDetailTap: (result) => Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (_) => MenuDetailScreen(aiResult: result),
+                          builder: (_) => MenuDetailScreen(
+                            aiResult: result,
+                            jwt: widget.request.jwtToken,
+                          ),
                         ),
                       ),
                       onFeedbackTap: (result) => _showFeedbackBottomSheet(result.menuId),

--- a/flutter_app/lib/services/recommendation_service.dart
+++ b/flutter_app/lib/services/recommendation_service.dart
@@ -186,6 +186,62 @@ class RecommendationService {
     }
   }
 
+  static Future<int?> saveAiResult(
+      RecommendationResult result, String? jwt) async {
+    if (jwt == null || jwt.isEmpty) return null;
+    final uri =
+        Uri.parse('${ApiConfig.baseUrl}/api/recommendation-logs/save');
+    try {
+      final response = await http
+          .post(
+            uri,
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer $jwt',
+            },
+            body: jsonEncode({
+              'menuId': result.menuId,
+              'aiResultJson': jsonEncode(result.toJson()),
+            }),
+          )
+          .timeout(const Duration(seconds: 10));
+      if (response.statusCode != 200) return null;
+      final json = jsonDecode(utf8.decode(response.bodyBytes));
+      if (json['success'] != true) return null;
+      return (json['id'] as num?)?.toInt();
+    } catch (e) {
+      debugPrint('AI 결과 저장 실패: $e');
+      return null;
+    }
+  }
+
+  static Future<bool> updateFeedback(
+      int logId, int starRating, String feedbackReason, String? jwt) async {
+    if (jwt == null || jwt.isEmpty) return false;
+    final uri = Uri.parse(
+        '${ApiConfig.baseUrl}/api/recommendation-logs/$logId/feedback');
+    try {
+      final response = await http
+          .patch(
+            uri,
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer $jwt',
+            },
+            body: jsonEncode({
+              'starRating': starRating,
+              'feedbackReason': feedbackReason,
+            }),
+          )
+          .timeout(const Duration(seconds: 10));
+      final json = jsonDecode(utf8.decode(response.bodyBytes));
+      return json['success'] == true;
+    } catch (e) {
+      debugPrint('피드백 업데이트 실패: $e');
+      return false;
+    }
+  }
+
   static Future<MenuDetail?> fetchMenuDetail(int id, String? jwt) async {
     final uri = Uri.parse('${ApiConfig.baseUrl}/api/menus/$id');
     final headers = <String, String>{};


### PR DESCRIPTION
## Summary

- AI 픽 화면에서 저장 버튼으로 추천 결과 보관
- 마이페이지 → 추천 이력에서 저장한 결과 다시보기 + 피드백 작성/수정

## 변경 상세

### 백엔드

**`recommendation_logs` 테이블 변경**
- `ai_result_json TEXT` 컬럼 추가
- `(user_id, selected_menu_id)` unique 제약 추가 — 저장·피드백 중복 방지

**신규 API**
- `POST /api/recommendation-logs/save` — AI 결과 저장 (feedback 없이), UPSERT
- `PATCH /api/recommendation-logs/{id}/feedback` — 피드백 추가/수정

**기존 API 변경**
- `GET /api/recommendation-logs/ai-picks` — `aiResultJson` 포함, `aiResultJson IS NOT NULL` 기준으로 필터
- `POST /api/recommendation-logs` — 기존 레코드 있으면 UPDATE, 없으면 INSERT (중복 row 방지)

### Flutter

**추천 결과 저장**
- `RecommendationResult.toJson()` 추가 (+ `NutritionInfo`, `RecipeStep`, `MarketPriceItem`)
- AI 픽 상세 AppBar에 `피드백` / `저장`·`저장됨` 텍스트 버튼 추가
- `recommendation_screen.dart`: `MenuDetailScreen` 진입 시 jwt 전달 (저장 버튼 노출)

**추천 이력 화면**
- `RecommendationHistoryScreen` — 저장된 목록 (메뉴명, 날짜, 별점 미리보기)
- `RecommendationHistoryDetailScreen` — AI 결과 전체 재현 + 피드백 폼 (기존값 pre-fill, 수정 가능)
- 마이페이지 프로필 탭에 `AI 추천 이력` 진입 버튼 추가

**AI 추천 카드 정리**
- 카드 내 피드백 버튼 제거 (상세 화면에서 통합 처리)
- 로딩 카드: 전체 높이 채우는 스피너 + 그라디언트 텍스트로 개선

## 비고

- 같은 메뉴 재추천 시 기존 레코드 덮어씀 (최신 유지)
- RAG(`UserHistoryManager`, ChromaDB)와 완전히 분리된 시스템 — 영향 없음
- 이력 화면 복귀 시 silent refresh (전체 로딩 스피너 미노출)

## Test plan

- [ ] AI 픽 화면 → 저장 → 마이페이지 → 추천 이력에 나타나는지 확인
- [ ] 추천 이력 상세 → 피드백 제출 → 이력 목록에 별점 표시 확인
- [ ] 같은 메뉴 재저장 시 중복 row 미생성 확인
- [ ] 후보 메뉴 단일 AI 분석 → 피드백/저장 버튼 노출 확인