### PR TITLE
fix: 일부 음식 이미지가 표시되지 않는 에러 수정 완료

### DIFF
--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/controller/AdminDataController.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/etl/controller/AdminDataController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -48,14 +49,27 @@ public class AdminDataController {
         return ResponseEntity.ok("미사용 재료 " + deleted + "건을 정리했습니다.");
     }
 
+    /**
+     * 메뉴 이미지 key 점검/재키잉을 백그라운드로 시작한다.
+     * 안전을 위해 기본은 dry-run(실변경 없음). 실제 적용하려면 dryRun=false 명시.
+     *
+     * @param dryRun     true(기본)면 변경 없이 로그만 남긴다.
+     * @param limit      처리 건수 상한(0=무제한, 기본 0).
+     * @param onlyBroken true(기본)면 쿼리스트링('?')이 박혀 깨진 URL만 대상.
+     */
     @PostMapping("/recover-images")
-    public ResponseEntity<String> recoverImages(){
-        boolean started = imageRecoveryAsyncRunner.tryStart();
+    public ResponseEntity<String> recoverImages(
+            @RequestParam(defaultValue = "true") boolean dryRun,
+            @RequestParam(defaultValue = "0") int limit,
+            @RequestParam(defaultValue = "true") boolean onlyBroken){
+        boolean started = imageRecoveryAsyncRunner.tryStart(dryRun, limit, onlyBroken);
         if (!started) {
             return ResponseEntity.status(409)
                     .body("손상 이미지 복구 작업이 이미 진행 중입니다. 서버 로그를 확인하세요.");
         }
         return ResponseEntity.accepted()
-                .body("손상 이미지 복구 작업을 백그라운드에서 시작했습니다. 진행 상황은 서버 로그를 확인하세요.");
+                .body(String.format(
+                        "이미지 재키잉 작업을 백그라운드에서 시작했습니다 (dryRun=%s, limit=%d, onlyBroken=%s). 진행 상황은 서버 로그를 확인하세요.",
+                        dryRun, limit, onlyBroken));
     }
 }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/ImageRecoveryAsyncRunner.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/ImageRecoveryAsyncRunner.java
@@ -25,14 +25,14 @@ public class ImageRecoveryAsyncRunner {
     /**
      * @return 새 작업이 시작되었으면 true, 이미 진행 중이라 거부됐으면 false.
      */
-    public boolean tryStart() {
+    public boolean tryStart(boolean dryRun, int limit, boolean onlyBroken) {
         if (!running.compareAndSet(false, true)) {
             log.info("[복구] 이미 진행 중 — 새 요청 거부");
             return false;
         }
         try {
             // 다른 빈의 public @Async 메서드 → 프록시 경유 → 백그라운드 스레드에서 실행.
-            imageRecoveryTask.run(running);
+            imageRecoveryTask.run(running, dryRun, limit, onlyBroken);
         } catch (Throwable t) {
             // 디스패치 실패(스레드 풀 거부, OOM 등 Error 포함) 시 플래그가 영구히 잠기지 않도록 해제.
             running.set(false);

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/ImageRecoveryTask.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/ImageRecoveryTask.java
@@ -28,10 +28,10 @@ public class ImageRecoveryTask {
      * @param running 호출자가 소유한 진행 상태 플래그. 작업 종료 시 false 로 되돌린다.
      */
     @Async
-    public void run(AtomicBoolean running) {
+    public void run(AtomicBoolean running, boolean dryRun, int limit, boolean onlyBroken) {
         try {
-            log.info("[복구] 비동기 작업 시작");
-            recipeDataSyncService.recoverCorruptedImages();
+            log.info("[복구] 비동기 작업 시작 (dryRun={}, limit={}, onlyBroken={})", dryRun, limit, onlyBroken);
+            recipeDataSyncService.recoverCorruptedImages(dryRun, limit, onlyBroken);
         } catch (Exception e) {
             log.error("[복구] 비동기 실행 중 오류", e);
         } finally {

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
@@ -100,7 +100,7 @@ public class RecipeDataSyncService {
                 // 캐시에 없는 새로운 레시피만 골라냅니다.
                 if (!menuCache.containsKey(foodCode)) {
                     String originalImageUrl = recipeNode.path("ATT_FILE_NO_MAIN").asText();
-                    String mainImageUrl = s3ImageUploadService.uploadFromUrl(originalImageUrl);
+                    String mainImageUrl = s3ImageUploadService.uploadFromUrl(originalImageUrl, foodCode);
 
                     Menu newMenu = Menu.builder()
                             .foodCode(foodCode)                                                // 일련번호
@@ -249,7 +249,7 @@ public class RecipeDataSyncService {
                 log.info("S3 마이그레이션 대상 메뉴: {}개", menusToMigrate.size());
                 int successCount = 0;
                 for (Menu menu : menusToMigrate) {
-                    String newUrl = s3ImageUploadService.uploadFromUrl(menu.getMainImageUrl());
+                    String newUrl = s3ImageUploadService.uploadFromUrl(menu.getMainImageUrl(), menu.getFoodCode());
                     if (s3ImageUploadService.isOurStorageUrl(newUrl)) {
                         menu.updateMainImageUrl(newUrl);
                         successCount++;
@@ -406,7 +406,25 @@ public class RecipeDataSyncService {
      * {@link #RECOVERY_SAVE_CHUNK}개 단위로 끊어 각자의 짧은 트랜잭션으로 저장한다.
      */
     public void recoverCorruptedImages() {
-        log.info("[복구] 이미지 URL 점검/복구 시작");
+        // 안전 기본값: 실제 변경 없이 점검만 한다. 실제 적용은 파라미터 버전을 명시 호출.
+        recoverCorruptedImages(true, 0, false);
+    }
+
+    /**
+     * 메뉴 이미지의 S3 key를 foodCode 기반 규칙으로 점검/재정렬(re-key)한다.
+     *
+     * <p>현재 URL이 목표 key({@code images/food/{foodCode}})와 다르면 재키잉한다.
+     * 이미 S3에 사본이 있으면 <b>원본 재다운로드 없이 CopyObject</b>로 옮기고(원본 소스가
+     * 죽어도 안전), 사본이 없을 때만 원본 URL에서 재업로드한다.
+     * old key 객체는 삭제하지 않는다(검증 후 별도 정리 → 롤백 가능).
+     *
+     * @param dryRun     true면 S3/DB를 변경하지 않고 예정 작업만 로그로 남긴다.
+     * @param limit      처리 건수 상한(0이면 무제한).
+     * @param onlyBroken true면 쿼리스트링('?')이 박혀 깨진 URL만 대상으로 한다.
+     */
+    public void recoverCorruptedImages(boolean dryRun, int limit, boolean onlyBroken) {
+        log.info("[복구] 이미지 key 점검/재키잉 시작 (dryRun={}, limit={}, onlyBroken={})",
+                dryRun, limit, onlyBroken);
 
         Map<String, String> codeToOriginalUrl;
         try {
@@ -418,51 +436,74 @@ public class RecipeDataSyncService {
         log.info("[복구] 원본 URL 맵 로드 완료: {}건", codeToOriginalUrl.size());
 
         // 우리 스토리지(S3 직링크 + CloudFront 도메인)에 올라간 메뉴를 모두 검사 대상으로.
-        // amazonaws.com 만 보면 CloudFront 전환 이후 후보가 0개가 되어 재검증이 불가능하다.
         List<Menu> candidates = menuRepository.findAll().stream()
                 .filter(m -> s3ImageUploadService.isOurStorageUrl(m.getMainImageUrl()))
                 .collect(Collectors.toList());
         log.info("[복구] 검사 대상(S3/CloudFront URL) 메뉴: {}개", candidates.size());
 
-        int normalized = 0, corrupt = 0, recovered = 0, missingOrigin = 0, failed = 0;
+        int skipped = 0, rekeyedCopy = 0, rekeyedOrigin = 0, missingOrigin = 0, failed = 0, processed = 0;
         List<Menu> buffer = new ArrayList<>();
         for (Menu menu : candidates) {
-            if (s3ImageUploadService.isS3UrlValid(menu.getMainImageUrl())) {
-                String cfUrl = s3ImageUploadService.toCloudFrontUrl(menu.getMainImageUrl());
-                if (!cfUrl.equals(menu.getMainImageUrl())) {
-                    menu.updateMainImageUrl(cfUrl);
-                    buffer.add(menu);
-                    normalized++;
+            if (limit > 0 && processed >= limit) break;
+
+            String currentUrl = menu.getMainImageUrl();
+            String foodCode = menu.getFoodCode();
+            String originalUrl = codeToOriginalUrl.get(foodCode);
+
+            // 목표 key/URL (foodCode 기반, foodCode 없으면 원본 URL 해시 폴백)
+            String desiredKey = s3ImageUploadService.objectKeyFor(foodCode, originalUrl);
+            String desiredUrl = s3ImageUploadService.urlForKey(desiredKey);
+
+            if (currentUrl.equals(desiredUrl)) {           // 이미 통일됨
+                skipped++;
+                continue;
+            }
+            if (onlyBroken && !currentUrl.contains("?")) { // 깨진 것만 대상으로 한정
+                skipped++;
+                continue;
+            }
+            processed++;
+
+            // 1순위: S3 내부 CopyObject (oldKey 객체가 있으면 원본 재다운로드 불필요)
+            String oldKey = s3ImageUploadService.s3KeyOf(currentUrl);
+            String newUrl = null;
+            String via = null;
+            if (oldKey != null && s3ImageUploadService.existsInS3(oldKey)) {
+                newUrl = dryRun ? desiredUrl : s3ImageUploadService.reKeyWithinS3(oldKey, desiredKey);
+                via = "copy";
+            }
+            // 2순위: 원본에서 재업로드 (S3에 사본이 없을 때만)
+            if (newUrl == null) {
+                if (originalUrl == null || originalUrl.isBlank()) {
+                    log.warn("[복구] 원본 URL 없음 + S3 사본 없음, 스킵: foodCode={}, url={}", foodCode, currentUrl);
+                    missingOrigin++;
+                    continue;
                 }
-                flushIfFull(buffer);
-                continue;
-            }
-            corrupt++;
-
-            String originalUrl = codeToOriginalUrl.get(menu.getFoodCode());
-            if (originalUrl == null || originalUrl.isBlank()) {
-                log.warn("[복구] 원본 URL 없음, 스킵: foodCode={}, name={}", menu.getFoodCode(), menu.getName());
-                missingOrigin++;
-                continue;
+                newUrl = dryRun ? desiredUrl : s3ImageUploadService.uploadFromUrl(originalUrl, foodCode);
+                via = "origin";
             }
 
-            String newUrl = s3ImageUploadService.uploadFromUrl(originalUrl);
-            if (s3ImageUploadService.isOurStorageUrl(newUrl)) {
-                menu.updateMainImageUrl(newUrl);
-                buffer.add(menu);
-                recovered++;
+            if (newUrl != null && newUrl.equals(desiredUrl)) {
+                if (dryRun) {
+                    log.info("[복구][dry-run] 재키잉 예정({}): foodCode={}, {} -> {}",
+                            via, foodCode, currentUrl, desiredUrl);
+                } else {
+                    menu.updateMainImageUrl(newUrl);
+                    buffer.add(menu);
+                }
+                if ("copy".equals(via)) rekeyedCopy++; else rekeyedOrigin++;
             } else {
-                log.warn("[복구] 재업로드 실패: foodCode={}, originalUrl={}", menu.getFoodCode(), originalUrl);
+                log.warn("[복구] 재키잉 실패({}): foodCode={}, url={}", via, foodCode, currentUrl);
                 failed++;
             }
-            flushIfFull(buffer);
+            if (!dryRun) flushIfFull(buffer);
         }
 
-        if (!buffer.isEmpty()) {
+        if (!dryRun && !buffer.isEmpty()) {
             menuRepository.saveAll(buffer);
         }
-        log.info("[복구] 완료 — URL변경={}, 손상={}, 복구성공={}, 원본URL없음={}, 재업로드실패={}",
-                normalized, corrupt, recovered, missingOrigin, failed);
+        log.info("[복구] 완료(dryRun={}) — 처리={}, 스킵={}, 재키잉(copy)={}, 재키잉(origin)={}, 원본없음={}, 실패={}",
+                dryRun, processed, skipped, rekeyedCopy, rekeyedOrigin, missingOrigin, failed);
     }
 
     /** 변경 버퍼가 청크 크기에 도달하면 즉시 저장(각자 짧은 트랜잭션)해 커넥션·메모리 부담을 줄인다. */

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/domain/ingredient/service/RecipeDataSyncService.java
@@ -394,29 +394,16 @@ public class RecipeDataSyncService {
     }
 
     /**
-     * 메뉴 이미지 URL을 점검·정리한다.
-     * - amazonaws.com URL인 메뉴를 대상으로:
-     *   - S3 객체가 정상이면 URL을 CloudFront(또는 설정된 도메인)로 단순 치환.
-     *   - S3 객체가 손상이면 cleaned_recipe_data.json의 원본 URL로 재업로드.
-     * - 멱등하고 반복 호출 가능.
-     *
-     * <p>메뉴 수만큼 네트워크 I/O(S3 HEAD/PUT, 원본 이미지 다운로드)를 수행하므로
-     * 메서드 전체를 하나의 트랜잭션으로 묶지 않는다 — 그러면 DB 커넥션을 수십 분간
-     * 점유해 HikariCP 고갈/트랜잭션 타임아웃을 유발한다. 변경분은
-     * {@link #RECOVERY_SAVE_CHUNK}개 단위로 끊어 각자의 짧은 트랜잭션으로 저장한다.
-     */
-    public void recoverCorruptedImages() {
-        // 안전 기본값: 실제 변경 없이 점검만 한다. 실제 적용은 파라미터 버전을 명시 호출.
-        recoverCorruptedImages(true, 0, false);
-    }
-
-    /**
      * 메뉴 이미지의 S3 key를 foodCode 기반 규칙으로 점검/재정렬(re-key)한다.
      *
      * <p>현재 URL이 목표 key({@code images/food/{foodCode}})와 다르면 재키잉한다.
      * 이미 S3에 사본이 있으면 <b>원본 재다운로드 없이 CopyObject</b>로 옮기고(원본 소스가
      * 죽어도 안전), 사본이 없을 때만 원본 URL에서 재업로드한다.
      * old key 객체는 삭제하지 않는다(검증 후 별도 정리 → 롤백 가능).
+     *
+     * <p>메뉴 수만큼 네트워크 I/O(S3 HEAD/COPY/PUT)를 수행하므로 메서드 전체를 하나의
+     * 트랜잭션으로 묶지 않는다 — DB 커넥션을 수십 분간 점유해 HikariCP 고갈/트랜잭션
+     * 타임아웃을 유발한다. 변경분은 {@link #RECOVERY_SAVE_CHUNK}개 단위로 끊어 저장한다.
      *
      * @param dryRun     true면 S3/DB를 변경하지 않고 예정 작업만 로그로 남긴다.
      * @param limit      처리 건수 상한(0이면 무제한).
@@ -454,7 +441,10 @@ public class RecipeDataSyncService {
             String desiredKey = s3ImageUploadService.objectKeyFor(foodCode, originalUrl);
             String desiredUrl = s3ImageUploadService.urlForKey(desiredKey);
 
-            if (currentUrl.equals(desiredUrl)) {           // 이미 통일됨
+            // 이미 목표 key면 통일 완료 → 스킵. URL 문자열이 아니라 key로 비교해
+            // CloudFront/S3 직링크 등 도메인 표기 차이에 영향받지 않게 한다.
+            String currentKey = s3ImageUploadService.s3KeyOf(currentUrl);
+            if (desiredKey.equals(currentKey)) {           // 이미 통일됨
                 skipped++;
                 continue;
             }

--- a/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/global/s3/S3ImageUploadService.java
+++ b/ai-meal-assistant-batch/src/main/java/capstone/ai_meal_assistant_batch/global/s3/S3ImageUploadService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
@@ -15,6 +16,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 @Slf4j
 @Service
@@ -45,6 +48,14 @@ public class S3ImageUploadService {
      * 다운로드/업로드 실패 시 원본 URL을 반환한다.
      */
     public String uploadFromUrl(String originalUrl) {
+        return uploadFromUrl(originalUrl, null);
+    }
+
+    /**
+     * {@link #uploadFromUrl(String)}와 동일하되, S3 key를 foodCode 기반으로 생성한다.
+     * foodCode가 비어 있으면 원본 URL 해시로 폴백한다. ({@link #buildObjectKey})
+     */
+    public String uploadFromUrl(String originalUrl, String foodCode) {
         if (originalUrl == null || originalUrl.isBlank()) {
             return originalUrl;
         }
@@ -52,8 +63,7 @@ public class S3ImageUploadService {
             return originalUrl;
         }
 
-        String fileName = originalUrl.substring(originalUrl.lastIndexOf('/') + 1);
-        String key = "images/food/" + fileName;
+        String key = buildObjectKey(foodCode, originalUrl);
 
         if (existsValidInS3(key)) {
             log.debug("S3 이미 존재(정상), 스킵: {}", key);
@@ -244,6 +254,83 @@ public class S3ImageUploadService {
             return "https://" + cloudfrontDomain + "/" + key;
         }
         return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + key;
+    }
+
+    /**
+     * S3 객체 key를 생성한다.
+     * <p>업무 식별자인 foodCode 기반(예: {@code images/food/10_00028})을 우선 사용한다.
+     * URL-safe(특수문자 없음)하고 메뉴당 유일하므로 쿼리스트링이 key에 섞여 들어가
+     * URL이 깨지는 문제를 원천 차단한다. foodCode가 없으면 원본 URL 해시로 폴백한다.
+     * <p>확장자는 붙이지 않는다 — 렌더링은 업로드 시 저장한 Content-Type 메타데이터로 결정된다.
+     */
+    private String buildObjectKey(String foodCode, String originalUrl) {
+        if (foodCode != null && !foodCode.isBlank()) {
+            return "images/food/" + foodCode;
+        }
+        return "images/food/" + sha256Hex(originalUrl);
+    }
+
+    private String sha256Hex(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(input.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256은 모든 JVM에 존재하므로 사실상 도달 불가.
+            throw new IllegalStateException("SHA-256 알고리즘 사용 불가", e);
+        }
+    }
+
+    /**
+     * 원본 재다운로드 없이 S3 내부에서 oldKey → newKey 로 객체를 복사(재키잉)한다.
+     * 이미 S3에 정상 사본이 있는 경우(예: 쿼리스트링이 박힌 깨진 key) 안전하게 재정렬할 때 사용한다.
+     *
+     * @return 성공 시 newKey의 접근 URL, 실패/불필요 시 처리 결과 URL. 복사 실패 시 null.
+     */
+    public String reKeyWithinS3(String oldKey, String newKey) {
+        if (oldKey == null || oldKey.isBlank() || newKey == null || newKey.isBlank()) {
+            return null;
+        }
+        if (oldKey.equals(newKey)) {
+            return buildS3Url(newKey);
+        }
+        try {
+            s3Client.copyObject(CopyObjectRequest.builder()
+                    .sourceBucket(bucket)
+                    .sourceKey(oldKey)
+                    .destinationBucket(bucket)
+                    .destinationKey(newKey)
+                    .build());
+            log.info("S3 재키잉 성공: {} -> {}", oldKey, newKey);
+            return buildS3Url(newKey);
+        } catch (Exception e) {
+            log.warn("S3 재키잉 실패: {} -> {} | 원인: {}", oldKey, newKey, e.getMessage());
+            return null;
+        }
+    }
+
+    /** foodCode/원본 URL로 생성될 S3 key를 외부에서 조회한다. ({@link #buildObjectKey} 노출) */
+    public String objectKeyFor(String foodCode, String originalUrl) {
+        return buildObjectKey(foodCode, originalUrl);
+    }
+
+    /** S3 key로부터 접근 URL을 만든다. ({@link #buildS3Url} 노출) */
+    public String urlForKey(String key) {
+        return buildS3Url(key);
+    }
+
+    /** URL에서 S3 key를 추출한다. 매칭 안 되면 null. ({@link #extractS3Key} 노출) */
+    public String s3KeyOf(String url) {
+        return extractS3Key(url);
+    }
+
+    /** 주어진 key의 S3 객체가 유효한 이미지로 존재하는지 확인한다. ({@link #existsValidInS3} 노출) */
+    public boolean existsInS3(String key) {
+        return existsValidInS3(key);
     }
 
     /**

--- a/flutter_app/ios/Runner/Info.plist
+++ b/flutter_app/ios/Runner/Info.plist
@@ -49,6 +49,11 @@
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>https</string>
+		<string>http</string>
+	</array>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>현재 위치의 날씨 정보를 제공하기 위해 위치 권한이 필요합니다.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>

--- a/flutter_app/linux/flutter/generated_plugin_registrant.cc
+++ b/flutter_app/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/flutter_app/linux/flutter/generated_plugins.cmake
+++ b/flutter_app/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/flutter_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/flutter_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,8 +7,10 @@ import Foundation
 
 import geolocator_apple
 import shared_preferences_foundation
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -477,6 +477,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.30"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: transitive
     description:
@@ -519,4 +583,4 @@ packages:
     version: "1.1.0"
 sdks:
   dart: ">=3.11.3 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: ">=3.38.0"

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   geolocator: ^13.0.0
   permission_handler: ^11.0.0
   geocoding: ^3.0.0
+  url_launcher: ^6.3.0
 
 dev_dependencies:
   flutter_test:

--- a/flutter_app/windows/flutter/generated_plugin_registrant.cc
+++ b/flutter_app/windows/flutter/generated_plugin_registrant.cc
@@ -8,10 +8,13 @@
 
 #include <geolocator_windows/geolocator_windows.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   GeolocatorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/flutter_app/windows/flutter/generated_plugins.cmake
+++ b/flutter_app/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   geolocator_windows
   permission_handler_windows
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
목적
시세탭 등에서 일부 음식 이미지가 표시되지 않음. 다른 이미지는 정상.

응답: 403 AccessDenied (S3)
원인
S3ImageUploadService.uploadFromUrl()의 파일명 추출 로직이 원본 URL의 쿼리스트링을 그대로 파일명에 포함시킴.

작업 내용
신규 업로드 버그 수정: key 생성을 원본 URL 해시 기반(sha256(originalUrl) + 확장자)으로 변경. URL-safe 보장 + 충돌 방지. (단순 ? 치환은 충돌/타 특수문자 미흡)
기존 데이터 재정비(통일성): 시드 소스의 원본 URL 기준으로 old key → 해시 key 산출 후 S3 내부 CopyObject로 재키잉 → menus.main_image_url 갱신 → 기존 key 정리.
원본 재다운로드 금지: 원본 소스가 죽은 경우 현재 정상 이미지까지 깨질 수 있음. S3 내부 복사로만 진행.
DB 다건 수정 + S3 대량 복사/삭제이므로 건수 카운트 → dry-run/limit → 적용 순서.