### PR TITLE
feat: 회원가입 서버 검증 강화 및 이메일·닉네임 중복확인 API 추가, 회원가입 화면 개편 - 중복확인, 실시간 검증,…

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/AuthExceptionHandler.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/AuthExceptionHandler.java
@@ -1,0 +1,33 @@
+package capstone.ai_meal_assistant_backend.domain.user.controller;
+
+import capstone.ai_meal_assistant_backend.domain.user.dto.AuthResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * auth 도메인 한정 예외 핸들러.
+ * 다른 컨트롤러들은 각자 응답 포맷(ApiResponse)을 사용 중이므로 전역 적용하지 않는다.
+ */
+@RestControllerAdvice(assignableTypes = AuthController.class)
+public class AuthExceptionHandler {
+
+    // @Valid 검증 실패 시 클라이언트가 파싱 가능한 AuthResponse 포맷으로 변환
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<AuthResponse> handleValidationException(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(FieldError::getDefaultMessage)
+                .orElse("입력값이 올바르지 않습니다");
+        return ResponseEntity.badRequest().body(AuthResponse.failure(errorMessage));
+    }
+
+    // JSON 파싱 실패(잘못된 enum 값 등) 대응
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<AuthResponse> handleMessageNotReadable(HttpMessageNotReadableException e) {
+        return ResponseEntity.badRequest().body(AuthResponse.failure("요청 형식이 올바르지 않습니다"));
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/UserController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/UserController.java
@@ -1,0 +1,65 @@
+package capstone.ai_meal_assistant_backend.domain.user.controller;
+
+import capstone.ai_meal_assistant_backend.domain.user.service.AuthService;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final AuthService authService;
+
+    /**
+     * 회원가입 화면의 이메일/닉네임 중복확인 API (비로그인 호출 허용)
+     * GET /api/v1/users/exists?email=... 또는 ?nickname=...
+     */
+    @GetMapping("/exists")
+    public ResponseEntity<ApiResponse<ExistsResponse>> exists(
+            @RequestParam(required = false) String email,
+            @RequestParam(required = false) String nickname) {
+
+        if ((email == null || email.isBlank()) && (nickname == null || nickname.isBlank())) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.fail("email 또는 nickname 파라미터가 필요합니다"));
+        }
+
+        boolean exists;
+        if (email != null && !email.isBlank()) {
+            exists = authService.isEmailTaken(email);
+        } else {
+            exists = authService.isNicknameTaken(nickname);
+        }
+
+        return ResponseEntity.ok(ApiResponse.ok(new ExistsResponse(exists)));
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class ExistsResponse {
+        private boolean exists;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class ApiResponse<T> {
+        private boolean success;
+        private T data;
+        private String error;
+
+        static <T> ApiResponse<T> ok(T data) {
+            return new ApiResponse<>(true, data, null);
+        }
+
+        static <T> ApiResponse<T> fail(String error) {
+            return new ApiResponse<>(false, null, error);
+        }
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/UserProfileController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/UserProfileController.java
@@ -4,10 +4,13 @@ import capstone.ai_meal_assistant_backend.domain.user.dto.UserProfileRequest;
 import capstone.ai_meal_assistant_backend.domain.user.dto.UserProfileResponse;
 import capstone.ai_meal_assistant_backend.domain.user.service.UserProfileService;
 import capstone.ai_meal_assistant_backend.global.security.JwtUtil;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -43,7 +46,7 @@ public class UserProfileController {
     @PostMapping("/profile")
     public ResponseEntity<ApiResponse<UserProfileResponse>> saveProfile(
             @RequestHeader("Authorization") String authHeader,
-            @RequestBody UserProfileRequest request) {
+            @Valid @RequestBody UserProfileRequest request) {
 
         String email = extractEmailFromToken(authHeader);
         UserProfileResponse response = userProfileService.saveOrUpdateProfile(email, request);
@@ -56,7 +59,7 @@ public class UserProfileController {
     @PutMapping("/profile")
     public ResponseEntity<ApiResponse<UserProfileResponse>> updateProfile(
             @RequestHeader("Authorization") String authHeader,
-            @RequestBody UserProfileRequest request) {
+            @Valid @RequestBody UserProfileRequest request) {
 
         String email = extractEmailFromToken(authHeader);
         UserProfileResponse response = userProfileService.saveOrUpdateProfile(email, request);
@@ -73,6 +76,18 @@ public class UserProfileController {
         String email = extractEmailFromToken(authHeader);
         UserProfileResponse response = userProfileService.getProfile(email);
         return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    /**
+     * @Valid 검증 실패 시 이 컨트롤러의 ApiResponse 포맷으로 400 응답
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(FieldError::getDefaultMessage)
+                .orElse("입력값이 올바르지 않습니다");
+        return ResponseEntity.badRequest().body(ApiResponse.fail(errorMessage));
     }
 
     /**

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/SignupRequest.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/SignupRequest.java
@@ -4,6 +4,7 @@ import capstone.ai_meal_assistant_backend.domain.user.entity.Gender;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +18,11 @@ public class SignupRequest {
     private String email;
     
     @NotBlank(message = "비밀번호는 필수입니다")
-    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다")
+    @Size(min = 8, max = 64, message = "비밀번호는 8자 이상 64자 이하여야 합니다")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[^A-Za-z0-9\\s])\\S+$",
+            message = "비밀번호는 영문, 숫자, 특수문자를 각각 1자 이상 포함해야 합니다"
+    )
     private String password;
     
     @NotBlank(message = "닉네임은 필수입니다")

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/UserProfileRequest.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/dto/UserProfileRequest.java
@@ -4,6 +4,7 @@ import capstone.ai_meal_assistant_backend.domain.user.entity.FitnessGoal;
 import capstone.ai_meal_assistant_backend.domain.user.entity.Gender;
 import capstone.ai_meal_assistant_backend.domain.user.entity.ProteinLevel;
 import capstone.ai_meal_assistant_backend.domain.user.entity.VegetarianType;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,6 +19,8 @@ import java.util.List;
 @AllArgsConstructor
 public class UserProfileRequest {
     // 온보딩에서는 보내지 않고 마이페이지에서 수정할 때만 보내야됩니다
+    // null이면 검증을 통과하고(닉네임 미변경), 값이 있으면 2~20자여야 합니다
+    @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하여야 합니다")
     private String nickname;
     private Gender gender;
 

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/User.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/User.java
@@ -20,7 +20,7 @@ public class User extends BaseEntity {
 
     private String password;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String nickname;
 
     // --- 추가된 성별 필드 ---

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/repository/UserRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/repository/UserRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthService.java
@@ -23,16 +23,24 @@ public class AuthService {
     @Transactional
     public AuthResponse signup(SignupRequest request) {
         try {
-            // 이메일 중복 체크
-            if (userRepository.existsByEmail(request.getEmail())) {
+            String email = request.getEmail().trim();
+            String nickname = request.getNickname().trim();
+
+            // 이메일 중복 체크 (사전 중복확인과 별개로 가입 시점에 최종 확인)
+            if (userRepository.existsByEmail(email)) {
                 return AuthResponse.failure("이미 사용 중인 이메일입니다");
             }
-            
+
+            // 닉네임 중복 체크
+            if (userRepository.existsByNickname(nickname)) {
+                return AuthResponse.failure("이미 사용 중인 닉네임입니다");
+            }
+
             // User 엔티티 생성
             User user = User.builder()
-                    .email(request.getEmail())
+                    .email(email)
                     .password(passwordEncoder.encode(request.getPassword()))
-                    .nickname(request.getNickname())
+                    .nickname(nickname)
                     .gender(request.getGender())
                     .role(Role.USER) // 기본값 USER
                     .provider("local") // 직접 회원가입
@@ -59,6 +67,16 @@ public class AuthService {
         }
     }
     
+    @Transactional(readOnly = true)
+    public boolean isEmailTaken(String email) {
+        return userRepository.existsByEmail(email.trim());
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isNicknameTaken(String nickname) {
+        return userRepository.existsByNickname(nickname.trim());
+    }
+
     @Transactional(readOnly = true)
     public AuthResponse login(LoginRequest request) {
         try {

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/global/security/SecurityConfig.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/global/security/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // JWT 사용하므로 세션 사용 안 함
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/v1/auth/**").permitAll() // 인증 API는 모두 허용
+                .requestMatchers("/api/v1/users/exists").permitAll() // 회원가입 중복확인은 비로그인 허용
                 .anyRequest().permitAll() // 개발 단계에서는 모두 허용 (나중에 authenticated()로 변경)
             );
         

--- a/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/dto/SignupRequestValidationTest.java
+++ b/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/dto/SignupRequestValidationTest.java
@@ -1,0 +1,140 @@
+package capstone.ai_meal_assistant_backend.domain.user.dto;
+
+import capstone.ai_meal_assistant_backend.domain.user.entity.Gender;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SignupRequestValidationTest {
+
+    private static ValidatorFactory validatorFactory;
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        validatorFactory.close();
+    }
+
+    private SignupRequest createRequest(String email, String password, String nickname, Gender gender) {
+        SignupRequest request = new SignupRequest();
+        ReflectionTestUtils.setField(request, "email", email);
+        ReflectionTestUtils.setField(request, "password", password);
+        ReflectionTestUtils.setField(request, "nickname", nickname);
+        ReflectionTestUtils.setField(request, "gender", gender);
+        return request;
+    }
+
+    @Test
+    @DisplayName("영문+숫자+특수문자 포함 8자 이상 비밀번호는 통과한다")
+    void validPassword() {
+        SignupRequest request = createRequest("test@example.com", "abcd1234!", "닉네임", Gender.MALE);
+
+        Set<ConstraintViolation<SignupRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("특수문자가 없는 비밀번호는 거부된다")
+    void passwordWithoutSpecialCharacter() {
+        SignupRequest request = createRequest("test@example.com", "abcd1234", "닉네임", Gender.MALE);
+
+        Set<ConstraintViolation<SignupRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("비밀번호는 영문, 숫자, 특수문자를 각각 1자 이상 포함해야 합니다");
+    }
+
+    @Test
+    @DisplayName("숫자가 없는 비밀번호는 거부된다")
+    void passwordWithoutDigit() {
+        SignupRequest request = createRequest("test@example.com", "abcdefgh!", "닉네임", Gender.MALE);
+
+        Set<ConstraintViolation<SignupRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("영문이 없는 비밀번호는 거부된다")
+    void passwordWithoutLetter() {
+        SignupRequest request = createRequest("test@example.com", "12345678!", "닉네임", Gender.MALE);
+
+        Set<ConstraintViolation<SignupRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("8자 미만 비밀번호는 거부된다")
+    void passwordTooShort() {
+        SignupRequest request = createRequest("test@example.com", "ab12!", "닉네임", Gender.MALE);
+
+        Set<ConstraintViolation<SignupRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("비밀번호는 8자 이상 64자 이하여야 합니다");
+    }
+
+    @Test
+    @DisplayName("공백이 포함된 비밀번호는 거부된다")
+    void passwordWithWhitespace() {
+        SignupRequest request = createRequest("test@example.com", "abcd 1234!", "닉네임", Gender.MALE);
+
+        Set<ConstraintViolation<SignupRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("닉네임이 1자면 거부된다")
+    void nicknameTooShort() {
+        SignupRequest request = createRequest("test@example.com", "abcd1234!", "a", Gender.MALE);
+
+        Set<ConstraintViolation<SignupRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("닉네임은 2자 이상 20자 이하여야 합니다");
+    }
+
+    @Test
+    @DisplayName("닉네임이 20자를 초과하면 거부된다")
+    void nicknameTooLong() {
+        SignupRequest request = createRequest("test@example.com", "abcd1234!", "가".repeat(21), Gender.MALE);
+
+        Set<ConstraintViolation<SignupRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("잘못된 이메일 형식은 거부된다")
+    void invalidEmailFormat() {
+        SignupRequest request = createRequest("not-an-email", "abcd1234!", "닉네임", Gender.MALE);
+
+        Set<ConstraintViolation<SignupRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("올바른 이메일 형식이 아닙니다");
+    }
+}

--- a/flutter_app/lib/screens/signup_screen.dart
+++ b/flutter_app/lib/screens/signup_screen.dart
@@ -5,6 +5,9 @@ import 'package:flutter_app/theme.dart';
 
 // 직접 가입 선택 후 회원가입을 진행하는 페이지입니다.
 
+// 이메일/닉네임 중복확인 상태
+enum _DuplicateCheckStatus { unchecked, checking, available, taken }
+
 class SignupScreen extends StatefulWidget {
   const SignupScreen({super.key});
 
@@ -18,47 +21,162 @@ class _SignupScreenState extends State<SignupScreen> {
   final TextEditingController _passwordController = TextEditingController();
   final TextEditingController _passwordConfirmController = TextEditingController();
   final TextEditingController _nicknameController = TextEditingController();
-  String? _selectedGender = '남성';
+  String? _selectedGender; // 명시적 선택 유도를 위해 기본값 없음
   bool _isLoading = false;
 
-  void _submitSignup() async {
-    if (_formKey.currentState!.validate()) {
-      setState(() {
-        _isLoading = true;
-      });
+  bool _obscurePassword = true;
+  bool _obscurePasswordConfirm = true;
+  String _password = ''; // 비밀번호 조건 체크리스트 실시간 갱신용
 
-      final response = await AuthService.signup(
-        email: _emailController.text,
-        password: _passwordController.text,
-        nickname: _nicknameController.text,
-        gender: _mapGenderToApiValue(_selectedGender),
+  _DuplicateCheckStatus _emailCheckStatus = _DuplicateCheckStatus.unchecked;
+  String? _checkedEmail; // 중복확인을 통과한 시점의 값 (입력이 바뀌면 재확인 필요)
+  _DuplicateCheckStatus _nicknameCheckStatus = _DuplicateCheckStatus.unchecked;
+  String? _checkedNickname;
+
+  bool _agreeServiceTerms = false;
+  bool _agreePrivacyPolicy = false;
+
+  static final RegExp _emailRegex = RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$');
+
+  // 서버(SignupRequest) 비밀번호 정책과 동일하게 유지
+  static final RegExp _letterRegex = RegExp(r'[A-Za-z]');
+  static final RegExp _digitRegex = RegExp(r'\d');
+  static final RegExp _specialCharRegex = RegExp(r'[^A-Za-z0-9\s]');
+  static final RegExp _whitespaceRegex = RegExp(r'\s');
+
+  bool _isPasswordValid(String value) {
+    return value.length >= 8 &&
+        value.length <= 64 &&
+        _letterRegex.hasMatch(value) &&
+        _digitRegex.hasMatch(value) &&
+        _specialCharRegex.hasMatch(value) &&
+        !_whitespaceRegex.hasMatch(value);
+  }
+
+  void _showSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  Future<void> _checkEmailDuplicate() async {
+    final email = _emailController.text.trim();
+    if (!_emailRegex.hasMatch(email)) {
+      _showSnackBar('올바른 이메일을 먼저 입력해 주세요.');
+      return;
+    }
+
+    setState(() => _emailCheckStatus = _DuplicateCheckStatus.checking);
+
+    final exists = await AuthService.checkEmailExists(email);
+    if (!mounted) return;
+
+    if (exists == null) {
+      setState(() => _emailCheckStatus = _DuplicateCheckStatus.unchecked);
+      _showSnackBar('중복확인에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      return;
+    }
+
+    setState(() {
+      _emailCheckStatus =
+          exists ? _DuplicateCheckStatus.taken : _DuplicateCheckStatus.available;
+      _checkedEmail = email;
+    });
+  }
+
+  Future<void> _checkNicknameDuplicate() async {
+    final nickname = _nicknameController.text.trim();
+    if (nickname.length < 2 || nickname.length > 20) {
+      _showSnackBar('닉네임은 2자 이상 20자 이하로 먼저 입력해 주세요.');
+      return;
+    }
+
+    setState(() => _nicknameCheckStatus = _DuplicateCheckStatus.checking);
+
+    final exists = await AuthService.checkNicknameExists(nickname);
+    if (!mounted) return;
+
+    if (exists == null) {
+      setState(() => _nicknameCheckStatus = _DuplicateCheckStatus.unchecked);
+      _showSnackBar('중복확인에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      return;
+    }
+
+    setState(() {
+      _nicknameCheckStatus =
+          exists ? _DuplicateCheckStatus.taken : _DuplicateCheckStatus.available;
+      _checkedNickname = nickname;
+    });
+  }
+
+  bool get _isEmailCheckPassed =>
+      _emailCheckStatus == _DuplicateCheckStatus.available &&
+      _checkedEmail == _emailController.text.trim();
+
+  bool get _isNicknameCheckPassed =>
+      _nicknameCheckStatus == _DuplicateCheckStatus.available &&
+      _checkedNickname == _nicknameController.text.trim();
+
+  void _submitSignup() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    if (!_agreeServiceTerms || !_agreePrivacyPolicy) {
+      _showSnackBar('필수 약관에 동의해 주세요.');
+      return;
+    }
+
+    if (!_isEmailCheckPassed) {
+      _showSnackBar('이메일 중복확인을 해주세요.');
+      return;
+    }
+    if (!_isNicknameCheckPassed) {
+      _showSnackBar('닉네임 중복확인을 해주세요.');
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    final response = await AuthService.signup(
+      email: _emailController.text.trim(),
+      password: _passwordController.text,
+      nickname: _nicknameController.text.trim(),
+      gender: _mapGenderToApiValue(_selectedGender),
+    );
+
+    if (!mounted) return;
+
+    setState(() {
+      _isLoading = false;
+    });
+
+    if (response.success) {
+      await showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('회원가입 완료'),
+          content: const Text('회원가입이 완료되었습니다.\n프로필 설정을 진행해 주세요.'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext),
+              child: const Text('시작하기'),
+            ),
+          ],
+        ),
       );
 
       if (!mounted) return;
 
-      setState(() {
-        _isLoading = false;
-      });
-
-      if (response.success) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('회원가입 성공! 로그인을 진행해 주세요.')), // 문구 수정
-        );
-
-        // 가입 성공 시 로그인 화면으로
-        Navigator.pop(context); 
-        
-        /* 만약 pop()으로 안 되는 라우팅 구조라면 명시적으로 이동
-        Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(builder: (context) => const LoginScreen()),
-        );
-        */
-      } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(response.error ?? '회원가입 실패했습니다.')),
-        );
-      }
+      // 가입 시 발급된 토큰으로 자동 로그인 처리 → 신규 유저는 온보딩으로 이동 (뒤로 가기 방지)
+      Navigator.pushAndRemoveUntil(
+        context,
+        MaterialPageRoute(builder: (context) => const OnboardingScreen()),
+        (route) => false,
+      );
+    } else {
+      _showSnackBar(response.error ?? '회원가입 실패했습니다.');
     }
   }
 
@@ -82,50 +200,81 @@ class _SignupScreenState extends State<SignupScreen> {
       body: SafeArea(
         child: Form(
           key: _formKey,
+          // 입력과 동시에 검증 결과를 보여줌 (비밀번호 확인 실시간 일치 검사 포함)
+          autovalidateMode: AutovalidateMode.onUserInteraction,
           child: SingleChildScrollView(
             padding: const EdgeInsets.all(24.0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 const Text(
-                  'NUTRI Agent 가입을 위해\n정보를 입력해 주세요.', 
+                  'NUTRI Agent 가입을 위해\n정보를 입력해 주세요.',
                   style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold, height: 1.4)
                 ),
                 const SizedBox(height: 40),
 
-                _buildTextField(
-                  controller: _emailController,
-                  label: '이메일 (아이디)',
-                  hint: 'example@email.com',
-                  keyboardType: TextInputType.emailAddress,
-                  validator: (value) {
-                    if (value == null || value.isEmpty) return '이메일을 입력해 주세요.';
-                    // 💡 이메일 형식 정규식 검사
-                    final emailRegex = RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$');
-                    if (!emailRegex.hasMatch(value)) return '올바른 이메일 형식이 아닙니다.';
-                    return null;
-                  },
+                _buildFieldWithCheckButton(
+                  field: _buildTextField(
+                    controller: _emailController,
+                    label: '이메일 (아이디)',
+                    hint: 'example@email.com',
+                    keyboardType: TextInputType.emailAddress,
+                    onChanged: (value) {
+                      // 입력이 바뀌면 중복확인 상태 초기화
+                      if (_checkedEmail != value.trim() &&
+                          _emailCheckStatus != _DuplicateCheckStatus.unchecked) {
+                        setState(() => _emailCheckStatus = _DuplicateCheckStatus.unchecked);
+                      }
+                    },
+                    validator: (value) {
+                      final email = value?.trim() ?? '';
+                      if (email.isEmpty) return '이메일을 입력해 주세요.';
+                      if (!_emailRegex.hasMatch(email)) return '올바른 이메일 형식이 아닙니다.';
+                      return null;
+                    },
+                  ),
+                  status: _emailCheckStatus,
+                  isCheckPassed: _isEmailCheckPassed,
+                  onCheck: _checkEmailDuplicate,
+                ),
+                _DuplicateCheckStatusText(
+                  status: _emailCheckStatus,
+                  availableText: '사용 가능한 이메일입니다.',
+                  takenText: '이미 사용 중인 이메일입니다.',
                 ),
                 const SizedBox(height: 20),
 
                 _buildTextField(
                   controller: _passwordController,
                   label: '비밀번호',
-                  hint: '영문, 숫자 포함 8자 이상',
-                  obscureText: true,
+                  hint: '영문, 숫자, 특수문자 포함 8자 이상',
+                  obscureText: _obscurePassword,
+                  suffixIcon: _buildObscureToggle(
+                    isObscured: _obscurePassword,
+                    onPressed: () => setState(() => _obscurePassword = !_obscurePassword),
+                  ),
+                  onChanged: (value) => setState(() => _password = value),
                   validator: (value) {
                     if (value == null || value.isEmpty) return '비밀번호를 입력해 주세요.';
-                    if (value.length < 8) return '비밀번호는 8자 이상이어야 합니다.';
+                    if (_whitespaceRegex.hasMatch(value)) return '비밀번호에 공백은 사용할 수 없습니다.';
+                    if (!_isPasswordValid(value)) return '아래 비밀번호 조건을 모두 충족해야 합니다.';
                     return null;
                   },
                 ),
+                const SizedBox(height: 8),
+                _PasswordRequirementsChecklist(password: _password),
                 const SizedBox(height: 20),
 
                 _buildTextField(
                   controller: _passwordConfirmController,
                   label: '비밀번호 확인',
                   hint: '위에 입력한 비밀번호와 동일하게 입력해 주세요',
-                  obscureText: true,
+                  obscureText: _obscurePasswordConfirm,
+                  suffixIcon: _buildObscureToggle(
+                    isObscured: _obscurePasswordConfirm,
+                    onPressed: () => setState(
+                        () => _obscurePasswordConfirm = !_obscurePasswordConfirm),
+                  ),
                   validator: (value) {
                     if (value == null || value.isEmpty) return '비밀번호 확인을 입력해 주세요.';
                     if (value != _passwordController.text) return '비밀번호가 일치하지 않습니다.';
@@ -134,14 +283,34 @@ class _SignupScreenState extends State<SignupScreen> {
                 ),
                 const SizedBox(height: 20),
 
-                _buildTextField(
-                  controller: _nicknameController,
-                  label: '닉네임',
-                  hint: '사용할 닉네임을 입력해 주세요',
-                  validator: (value) {
-                    if (value == null || value.isEmpty) return '닉네임을 입력해 주세요.';
-                    return null;
-                  },
+                _buildFieldWithCheckButton(
+                  field: _buildTextField(
+                    controller: _nicknameController,
+                    label: '닉네임',
+                    hint: '2~20자 닉네임을 입력해 주세요',
+                    onChanged: (value) {
+                      if (_checkedNickname != value.trim() &&
+                          _nicknameCheckStatus != _DuplicateCheckStatus.unchecked) {
+                        setState(() => _nicknameCheckStatus = _DuplicateCheckStatus.unchecked);
+                      }
+                    },
+                    validator: (value) {
+                      final nickname = value?.trim() ?? '';
+                      if (nickname.isEmpty) return '닉네임을 입력해 주세요.';
+                      if (nickname.length < 2 || nickname.length > 20) {
+                        return '닉네임은 2자 이상 20자 이하여야 합니다.';
+                      }
+                      return null;
+                    },
+                  ),
+                  status: _nicknameCheckStatus,
+                  isCheckPassed: _isNicknameCheckPassed,
+                  onCheck: _checkNicknameDuplicate,
+                ),
+                _DuplicateCheckStatusText(
+                  status: _nicknameCheckStatus,
+                  availableText: '사용 가능한 닉네임입니다.',
+                  takenText: '이미 사용 중인 닉네임입니다.',
                 ),
                 const SizedBox(height: 20),
 
@@ -165,7 +334,7 @@ class _SignupScreenState extends State<SignupScreen> {
                       ),
                     ),
                   ),
-                  value: _selectedGender,
+                  initialValue: _selectedGender,
                   onChanged: (v) => setState(() => _selectedGender = v),
                   items: const [
                     DropdownMenuItem(value: '남성', child: Text('남성')),
@@ -176,7 +345,19 @@ class _SignupScreenState extends State<SignupScreen> {
                     return null;
                   },
                 ),
-                const SizedBox(height: 40),
+                const SizedBox(height: 24),
+
+                _TermsAgreementSection(
+                  agreeServiceTerms: _agreeServiceTerms,
+                  agreePrivacyPolicy: _agreePrivacyPolicy,
+                  onServiceTermsChanged: (v) => setState(() => _agreeServiceTerms = v),
+                  onPrivacyPolicyChanged: (v) => setState(() => _agreePrivacyPolicy = v),
+                  onAllChanged: (v) => setState(() {
+                    _agreeServiceTerms = v;
+                    _agreePrivacyPolicy = v;
+                  }),
+                ),
+                const SizedBox(height: 32),
 
                 // 💡 가입 완료 버튼: 캡슐형 그라데이션 적용
                 Container(
@@ -189,7 +370,7 @@ class _SignupScreenState extends State<SignupScreen> {
                     boxShadow: [
                       if (!_isLoading)
                         BoxShadow(
-                          color: AppTheme.primaryColor.withOpacity(0.3),
+                          color: AppTheme.primaryColor.withValues(alpha: 0.3),
                           blurRadius: 10,
                           offset: const Offset(0, 4),
                         ),
@@ -213,7 +394,7 @@ class _SignupScreenState extends State<SignupScreen> {
                             ),
                           )
                         : const Text(
-                            '가입 완료하기', 
+                            '가입 완료하기',
                             style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Colors.white)
                           ),
                   ),
@@ -226,6 +407,55 @@ class _SignupScreenState extends State<SignupScreen> {
     );
   }
 
+  // 입력 필드 + 중복확인 버튼을 한 줄로 배치
+  Widget _buildFieldWithCheckButton({
+    required Widget field,
+    required _DuplicateCheckStatus status,
+    required bool isCheckPassed,
+    required VoidCallback onCheck,
+  }) {
+    final isChecking = status == _DuplicateCheckStatus.checking;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(child: field),
+        const SizedBox(width: 8),
+        SizedBox(
+          height: 56,
+          child: OutlinedButton(
+            onPressed: (isChecking || isCheckPassed) ? null : onCheck,
+            style: OutlinedButton.styleFrom(
+              foregroundColor: AppTheme.primaryColor,
+              side: const BorderSide(color: AppTheme.primaryColor),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            ),
+            child: isChecking
+                ? const SizedBox(
+                    height: 18,
+                    width: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : Text(isCheckPassed ? '확인 완료' : '중복확인'),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildObscureToggle({
+    required bool isObscured,
+    required VoidCallback onPressed,
+  }) {
+    return IconButton(
+      icon: Icon(
+        isObscured ? Icons.visibility_off_outlined : Icons.visibility_outlined,
+        color: Colors.grey,
+      ),
+      onPressed: onPressed,
+    );
+  }
+
   // 💡 TextField 공통 위젯도 16px 라운딩 및 AppTheme 색상으로 업데이트
   Widget _buildTextField({
     required TextEditingController controller,
@@ -233,23 +463,27 @@ class _SignupScreenState extends State<SignupScreen> {
     required String hint,
     bool obscureText = false,
     TextInputType keyboardType = TextInputType.text,
+    Widget? suffixIcon,
+    ValueChanged<String>? onChanged,
     required String? Function(String?) validator,
   }) {
     return TextFormField(
       controller: controller,
       obscureText: obscureText,
       keyboardType: keyboardType,
+      onChanged: onChanged,
       decoration: InputDecoration(
         labelText: label,
         hintText: hint,
+        suffixIcon: suffixIcon,
         filled: true,
         fillColor: Colors.grey.shade100,
         border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(16), 
+          borderRadius: BorderRadius.circular(16),
           borderSide: BorderSide.none
         ),
         focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(16), 
+          borderRadius: BorderRadius.circular(16),
           borderSide: const BorderSide(color: AppTheme.primaryColor, width: 2)
         ),
       ),
@@ -262,5 +496,258 @@ class _SignupScreenState extends State<SignupScreen> {
     if (uiGender == '남성') return 'MALE';
     if (uiGender == '여성') return 'FEMALE';
     return null;
+  }
+}
+
+// 약관 동의 섹션 — 전체 동의 + 필수 약관 2건
+class _TermsAgreementSection extends StatelessWidget {
+  final bool agreeServiceTerms;
+  final bool agreePrivacyPolicy;
+  final ValueChanged<bool> onServiceTermsChanged;
+  final ValueChanged<bool> onPrivacyPolicyChanged;
+  final ValueChanged<bool> onAllChanged;
+
+  const _TermsAgreementSection({
+    required this.agreeServiceTerms,
+    required this.agreePrivacyPolicy,
+    required this.onServiceTermsChanged,
+    required this.onPrivacyPolicyChanged,
+    required this.onAllChanged,
+  });
+
+  bool get _isAllAgreed => agreeServiceTerms && agreePrivacyPolicy;
+
+  void _showTermsDialog(BuildContext context, String title, String content) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(title),
+        content: SingleChildScrollView(
+          child: Text(content, style: const TextStyle(fontSize: 14, height: 1.6)),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('닫기'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.grey.shade100,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Column(
+        children: [
+          _AgreementRow(
+            label: '전체 동의',
+            isBold: true,
+            value: _isAllAgreed,
+            onChanged: onAllChanged,
+          ),
+          const Divider(height: 1),
+          _AgreementRow(
+            label: '(필수) 서비스 이용약관 동의',
+            value: agreeServiceTerms,
+            onChanged: onServiceTermsChanged,
+            onViewPressed: () =>
+                _showTermsDialog(context, '서비스 이용약관', _serviceTermsContent),
+          ),
+          _AgreementRow(
+            label: '(필수) 개인정보 수집·이용 동의',
+            value: agreePrivacyPolicy,
+            onChanged: onPrivacyPolicyChanged,
+            onViewPressed: () =>
+                _showTermsDialog(context, '개인정보 수집·이용 동의', _privacyPolicyContent),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AgreementRow extends StatelessWidget {
+  final String label;
+  final bool isBold;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final VoidCallback? onViewPressed;
+
+  const _AgreementRow({
+    required this.label,
+    this.isBold = false,
+    required this.value,
+    required this.onChanged,
+    this.onViewPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: InkWell(
+            onTap: () => onChanged(!value),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 10),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.check_circle,
+                    size: 22,
+                    color: value ? AppTheme.primaryColor : Colors.grey.shade400,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      label,
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: isBold ? FontWeight.bold : FontWeight.normal,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        if (onViewPressed != null)
+          TextButton(
+            onPressed: onViewPressed,
+            child: const Text('보기', style: TextStyle(fontSize: 13, color: Colors.grey)),
+          ),
+      ],
+    );
+  }
+}
+
+// 서비스 이용약관 (NUTRI Agent — AI 식단/레시피 추천 서비스)
+const String _serviceTermsContent = '''
+제1조 (목적)
+본 약관은 NUTRI Agent(이하 "서비스")가 제공하는 AI 기반 식단·레시피 추천 서비스의 이용 조건 및 절차를 규정합니다.
+
+제2조 (회원의 의무)
+1. 회원은 가입 시 본인의 정확한 정보를 제공해야 하며, 타인의 정보를 도용할 수 없습니다.
+2. 계정 및 비밀번호의 관리 책임은 회원 본인에게 있습니다.
+
+제3조 (서비스 내용)
+1. 서비스는 회원의 신체 정보와 식품 선호를 바탕으로 맞춤형 식단·레시피 추천, 식재료 시세 및 날씨 기반 정보를 제공합니다.
+2. AI가 제공하는 추천 결과는 참고용 정보이며, 의학적 진단·처방을 대체하지 않습니다. 질환이 있거나 특수한 식이 관리가 필요한 경우 전문가와 상담하시기 바랍니다.
+
+제4조 (서비스 이용 제한)
+부정한 방법으로 서비스를 이용하거나 서비스 운영을 방해하는 경우 이용이 제한될 수 있습니다.
+''';
+
+// 개인정보 수집·이용 동의 문구
+const String _privacyPolicyContent = '''
+NUTRI Agent는 회원가입 및 서비스 제공을 위해 아래와 같이 개인정보를 수집·이용합니다.
+
+1. 수집 항목
+- 필수: 이메일, 비밀번호, 닉네임, 성별
+- 서비스 이용 과정에서 수집: 신체 정보(키, 몸무게 등), 식품 선호·알레르기 정보, 위치 정보(날씨·주변 시세 연동 시)
+
+2. 수집 목적
+- 회원 식별 및 계정 관리
+- 맞춤형 식단·레시피 추천 제공
+- 식재료 가격, 날씨 등 생활 정보 제공
+
+3. 보유 및 이용 기간
+- 회원 탈퇴 시까지 보유하며, 탈퇴 시 지체 없이 파기합니다. (관계 법령에 따라 보관이 필요한 정보는 해당 기간 동안 보관)
+
+4. 동의 거부 권리
+- 동의를 거부할 권리가 있으나, 필수 항목 동의를 거부할 경우 회원가입이 제한됩니다.
+''';
+
+// 중복확인 결과를 필드 아래에 색상으로 표시
+class _DuplicateCheckStatusText extends StatelessWidget {
+  final _DuplicateCheckStatus status;
+  final String availableText;
+  final String takenText;
+
+  const _DuplicateCheckStatusText({
+    required this.status,
+    required this.availableText,
+    required this.takenText,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (status != _DuplicateCheckStatus.available &&
+        status != _DuplicateCheckStatus.taken) {
+      return const SizedBox.shrink();
+    }
+
+    final isAvailable = status == _DuplicateCheckStatus.available;
+    return Padding(
+      padding: const EdgeInsets.only(top: 6, left: 4),
+      child: Text(
+        isAvailable ? availableText : takenText,
+        style: TextStyle(
+          fontSize: 13,
+          color: isAvailable ? Colors.green : Colors.red,
+        ),
+      ),
+    );
+  }
+}
+
+// 비밀번호 조건 체크리스트 — 입력하면서 충족된 항목의 색이 바뀜
+class _PasswordRequirementsChecklist extends StatelessWidget {
+  final String password;
+
+  const _PasswordRequirementsChecklist({required this.password});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _RequirementRow(
+          label: '8자 이상 (최대 64자)',
+          isMet: password.length >= 8 && password.length <= 64,
+        ),
+        _RequirementRow(
+          label: '영문 포함',
+          isMet: password.contains(RegExp(r'[A-Za-z]')),
+        ),
+        _RequirementRow(
+          label: '숫자 포함',
+          isMet: password.contains(RegExp(r'\d')),
+        ),
+        _RequirementRow(
+          label: '특수문자 포함',
+          isMet: password.contains(RegExp(r'[^A-Za-z0-9\s]')),
+        ),
+      ],
+    );
+  }
+}
+
+class _RequirementRow extends StatelessWidget {
+  final String label;
+  final bool isMet;
+
+  const _RequirementRow({required this.label, required this.isMet});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isMet ? Colors.green : Colors.grey;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
+      child: Row(
+        children: [
+          Icon(Icons.check_circle, size: 16, color: color),
+          const SizedBox(width: 6),
+          Text(label, style: TextStyle(fontSize: 13, color: color)),
+        ],
+      ),
+    );
   }
 }

--- a/flutter_app/lib/services/auth_service.dart
+++ b/flutter_app/lib/services/auth_service.dart
@@ -38,10 +38,6 @@ class AuthService {
       final jsonResponse = jsonDecode(response.body);
       final authResponse = AuthResponse.fromJson(jsonResponse);
 
-  // 디버깅: 서버 응답에 user.id가 포함되는지 확인
-  // ignore: avoid_print
-  print('[AuthService.login] status=${response.statusCode} body=${response.body}');
-
       // 성공 시 토큰 저장
       if (authResponse.success && authResponse.data?.accessToken != null) {
         await TokenStorage.saveTokens(
@@ -64,6 +60,36 @@ class AuthService {
         success: false,
         error: '로그인 중 오류가 발생했습니다: $e',
       );
+    }
+  }
+
+  // 이메일 중복확인 (true: 이미 사용 중, false: 사용 가능, null: 확인 실패)
+  static Future<bool?> checkEmailExists(String email) {
+    return _checkExists('email', email);
+  }
+
+  // 닉네임 중복확인 (true: 이미 사용 중, false: 사용 가능, null: 확인 실패)
+  static Future<bool?> checkNicknameExists(String nickname) {
+    return _checkExists('nickname', nickname);
+  }
+
+  static Future<bool?> _checkExists(String paramName, String value) async {
+    try {
+      final url = Uri.parse('${ApiConfig.baseUrl}${ApiConfig.apiVersion}/users/exists')
+          .replace(queryParameters: {paramName: value});
+
+      final response = await http.get(url).timeout(
+        const Duration(seconds: 10),
+        onTimeout: () => throw Exception('요청 시간 초과'),
+      );
+
+      final jsonResponse = jsonDecode(response.body);
+      if (jsonResponse['success'] == true) {
+        return jsonResponse['data']?['exists'] == true;
+      }
+      return null;
+    } catch (e) {
+      return null;
     }
   }
 
@@ -98,10 +124,6 @@ class AuthService {
 
       final jsonResponse = jsonDecode(response.body);
       final authResponse = AuthResponse.fromJson(jsonResponse);
-
-  // 디버깅: 서버 응답에 user.id가 포함되는지 확인
-  // ignore: avoid_print
-  print('[AuthService.signup] status=${response.statusCode} body=${response.body}');
 
       // 성공 시 토큰 저장
       if (authResponse.success && authResponse.data?.accessToken != null) {

--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -260,10 +260,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -465,10 +465,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -40,7 +40,6 @@ dependencies:
   geolocator: ^13.0.0
   permission_handler: ^11.0.0
   geocoding: ^3.0.0
-  url_launcher: ^6.3.0
 
 dev_dependencies:
   flutter_test:

--- a/flutter_app/test/widget_test.dart
+++ b/flutter_app/test/widget_test.dart
@@ -1,30 +1,143 @@
-// This is a basic Flutter widget test.
+// 회원가입 화면 위젯 테스트
 //
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
+// 기존 Flutter 템플릿의 카운터 테스트는 실제 앱과 무관해 항상 실패했으므로
+// 회원가입 화면 동작 검증 테스트로 교체했습니다.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:flutter_app/main.dart';
+import 'package:flutter_app/screens/signup_screen.dart';
+import 'package:flutter_app/theme.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const NutriAgentApp());
+  Future<void> pumpSignupScreen(WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SignupScreen()));
+  }
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+  // 필드 순서: 이메일(0), 비밀번호(1), 비밀번호 확인(2), 닉네임(3)
+  Finder passwordField() => find.byType(TextFormField).at(1);
+  Finder passwordConfirmField() => find.byType(TextFormField).at(2);
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
+  testWidgets('회원가입 화면이 필수 요소와 함께 렌더링된다', (WidgetTester tester) async {
+    await pumpSignupScreen(tester);
+
+    expect(find.text('가입 완료하기'), findsOneWidget);
+    expect(find.text('중복확인'), findsNWidgets(2)); // 이메일, 닉네임
+    expect(find.text('8자 이상 (최대 64자)'), findsOneWidget);
+    expect(find.text('영문 포함'), findsOneWidget);
+    expect(find.text('숫자 포함'), findsOneWidget);
+    expect(find.text('특수문자 포함'), findsOneWidget);
+  });
+
+  testWidgets('비밀번호 조건 충족 시 체크리스트 항목이 초록색으로 바뀐다', (WidgetTester tester) async {
+    await pumpSignupScreen(tester);
+
+    await tester.enterText(passwordField(), 'abcd1234!');
     await tester.pump();
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    for (final label in ['8자 이상 (최대 64자)', '영문 포함', '숫자 포함', '특수문자 포함']) {
+      final text = tester.widget<Text>(find.text(label));
+      expect(text.style?.color, Colors.green, reason: '$label 항목이 초록색이어야 합니다');
+    }
+  });
+
+  testWidgets('조건 미충족 항목은 회색으로 남는다', (WidgetTester tester) async {
+    await pumpSignupScreen(tester);
+
+    // 특수문자 없는 비밀번호
+    await tester.enterText(passwordField(), 'abcd1234');
+    await tester.pump();
+
+    final specialChar = tester.widget<Text>(find.text('특수문자 포함'));
+    expect(specialChar.style?.color, Colors.grey);
+
+    final letter = tester.widget<Text>(find.text('영문 포함'));
+    expect(letter.style?.color, Colors.green);
+  });
+
+  testWidgets('비밀번호 확인이 다르면 실시간으로 불일치 메시지가 표시된다', (WidgetTester tester) async {
+    await pumpSignupScreen(tester);
+
+    await tester.enterText(passwordField(), 'abcd1234!');
+    await tester.enterText(passwordConfirmField(), 'different1!');
+    await tester.pump();
+
+    expect(find.text('비밀번호가 일치하지 않습니다.'), findsOneWidget);
+
+    // 동일하게 수정하면 메시지가 사라진다
+    await tester.enterText(passwordConfirmField(), 'abcd1234!');
+    await tester.pump();
+
+    expect(find.text('비밀번호가 일치하지 않습니다.'), findsNothing);
+  });
+
+  // 모든 필드를 유효하게 채우고 성별까지 선택 (약관/중복확인은 별도)
+  Future<void> fillValidForm(WidgetTester tester) async {
+    await tester.enterText(find.byType(TextFormField).at(0), 'test@example.com');
+    await tester.enterText(passwordField(), 'abcd1234!');
+    await tester.enterText(passwordConfirmField(), 'abcd1234!');
+    await tester.enterText(find.byType(TextFormField).at(3), '테스트닉네임');
+
+    await tester.ensureVisible(find.byType(DropdownButtonFormField<String>));
+    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('남성').last);
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('약관 미동의 상태로 제출하면 안내 스낵바가 표시된다', (WidgetTester tester) async {
+    await pumpSignupScreen(tester);
+    await fillValidForm(tester);
+
+    await tester.ensureVisible(find.text('가입 완료하기'));
+    await tester.tap(find.text('가입 완료하기'));
+    await tester.pump();
+
+    expect(find.text('필수 약관에 동의해 주세요.'), findsOneWidget);
+  });
+
+  testWidgets('전체 동의를 누르면 필수 약관이 모두 체크된다', (WidgetTester tester) async {
+    await pumpSignupScreen(tester);
+
+    Color? agreementIconColor(String label) {
+      final icon = tester.widget<Icon>(
+        find
+            .descendant(
+              of: find.ancestor(of: find.text(label), matching: find.byType(Row)),
+              matching: find.byType(Icon),
+            )
+            .first,
+      );
+      return icon.color;
+    }
+
+    await tester.ensureVisible(find.text('전체 동의'));
+    await tester.tap(find.text('전체 동의'));
+    await tester.pump();
+
+    expect(agreementIconColor('(필수) 서비스 이용약관 동의'), AppTheme.primaryColor);
+    expect(agreementIconColor('(필수) 개인정보 수집·이용 동의'), AppTheme.primaryColor);
+
+    // 다시 누르면 전부 해제된다
+    await tester.tap(find.text('전체 동의'));
+    await tester.pump();
+
+    expect(agreementIconColor('(필수) 서비스 이용약관 동의'), isNot(AppTheme.primaryColor));
+  });
+
+  testWidgets('중복확인 없이 제출하면 안내 스낵바가 표시된다', (WidgetTester tester) async {
+    await pumpSignupScreen(tester);
+    await fillValidForm(tester);
+
+    // 약관 동의 후 중복확인 없이 제출
+    await tester.ensureVisible(find.text('전체 동의'));
+    await tester.tap(find.text('전체 동의'));
+    await tester.pump();
+
+    await tester.ensureVisible(find.text('가입 완료하기'));
+    await tester.tap(find.text('가입 완료하기'));
+    await tester.pump();
+
+    expect(find.text('이메일 중복확인을 해주세요.'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 개요
회원가입 기능 전반 개선

## 주요 변경

### Backend
- 비밀번호 정책 강화: 영문·숫자·특수문자 각 1자 이상, 8~64자, 공백 불가 (`@Pattern`)
- `AuthExceptionHandler` 신규: `@Valid` 실패 시 `AuthResponse` 포맷의 400 응답 (auth 컨트롤러 한정)
- 중복확인 API 신규: `GET /api/v1/users/exists?email=...` / `?nickname=...` (비로그인 허용)
- 가입 시점 닉네임 중복 체크 추가 + `users.nickname` unique 제약
- 이메일/닉네임 trim 저장, 검증 단위 테스트 9건 추가

### Flutter
- 이메일/닉네임 중복확인 버튼 + 결과 색상 표시, 미확인 시 제출 차단
- 비밀번호 조건 체크리스트(8자 이상/영문/숫자/특수문자) 실시간 색상 변경
- 비밀번호 확인 실시간 일치 검사 (`AutovalidateMode.onUserInteraction`)
- 비밀번호 표시/숨김 토글, 성별 기본값 제거(명시적 선택)
- 약관 동의 섹션(전체 동의 + 필수 2건, 전문 다이얼로그) — 문구는 법적 검토 전 초안
- 가입 성공 다이얼로그 → 자동 로그인 상태로 온보딩 이동 (뒤로가기 방지)
- 응답 body 디버그 print 제거 (민감정보 로그 방지)
- 깨진 템플릿 카운터 테스트 → 회원가입 위젯 테스트 7건으로 교체
- `pubspec.yaml` `url_launcher` 중복 키 제거 (analyze 실행 불가 문제)

## ⚠️ 팀원 로컬 DB 작업 필요
`users.nickname`에 unique 제약이 추가되었습니다. 각자 로컬 DB에 아래 DDL을 적용해 주세요
(`ddl-auto: update`는 기존 테이블에 제약을 자동 추가하지 않습니다):

```sql
ALTER TABLE users ADD CONSTRAINT uk_users_nickname UNIQUE (nickname);
-- 롤백: DROP INDEX uk_users_nickname ON users;
```
※ 중복 닉네임이 이미 있으면 실패하므로 먼저 확인:
`SELECT nickname, COUNT(*) FROM users GROUP BY nickname HAVING COUNT(*) > 1;`

## 테스트
- `./gradlew test` 통과 (검증 테스트 9건 포함)
- `flutter analyze` 에러 0 (수정 파일 경고 0)
- `flutter test` 7건 전부 통과