### PR TITLE
feat: 추천 이력·피드백 분리 및 마이페이지 피드백 탭 통합 개편 (#172)

### DIFF
--- a/flutter_app/lib/notifiers.dart
+++ b/flutter_app/lib/notifiers.dart
@@ -1,0 +1,4 @@
+import 'package:flutter/foundation.dart';
+
+/// 피드백 목록 새로고침 트리거 — MyPageScreen이 리슨, 피드백 저장 시 increment
+final feedbackRefreshNotifier = ValueNotifier<int>(0);

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_app/models/recommendation_models.dart';
 import 'package:flutter_app/models/user_profile_models.dart';
+import 'package:flutter_app/notifiers.dart';
 import 'package:flutter_app/services/recommendation_service.dart';
 import 'package:flutter_app/services/user_profile_service.dart';
 import 'package:flutter_app/screens/price_alert_screen.dart';
@@ -65,10 +66,11 @@ class _MyPageScreenState extends State<MyPageScreen>
 
   // ── 피드백 탭 상태 ──────────────────────────────
   List<FeedbackHistoryItem> _feedbackItems = [];
+  List<AiPickItem> _aiPickFeedbackItems = [];
   bool _feedbackLoading = false;
   final TextEditingController _searchController = TextEditingController();
   String _searchQuery = '';
-  bool _showLiked = true;
+  int _feedbackTab = 0; // 0=좋아요, 1=싫어요, 2=AI피드백
 
   // ── 옵션 상수 ────────────────────────────────────
   final List<String> _healthConditionOptions = [
@@ -100,8 +102,13 @@ class _MyPageScreenState extends State<MyPageScreen>
     super.initState();
     _tabController = TabController(length: 2, vsync: this);
     _tabController.addListener(() {
-      if (!_tabController.indexIsChanging) setState(() {});
+      if (!_tabController.indexIsChanging) {
+        setState(() {});
+        // 피드백 탭으로 전환될 때 최신 데이터 로드
+        if (_tabController.index == 1) _loadFeedbacks();
+      }
     });
+    feedbackRefreshNotifier.addListener(_loadFeedbacks);
     _loadProfile();
     _loadBasicUserInfoFromLocal();
     _loadFeedbacks();
@@ -109,6 +116,7 @@ class _MyPageScreenState extends State<MyPageScreen>
 
   @override
   void dispose() {
+    feedbackRefreshNotifier.removeListener(_loadFeedbacks);
     _tabController.dispose();
     _nicknameController.dispose();
     _heightController.dispose();
@@ -321,9 +329,16 @@ class _MyPageScreenState extends State<MyPageScreen>
     setState(() => _feedbackLoading = true);
     try {
       final jwt = await TokenStorage.getAccessToken();
-      final items = await RecommendationService.fetchMyFeedbacks(jwt);
+      final feedbackFuture = RecommendationService.fetchMyFeedbacks(jwt);
+      final aiPickFuture = RecommendationService.fetchMyAiPicks(jwt);
+      final feedbacks = await feedbackFuture;
+      final aiPicks = await aiPickFuture;
       if (!mounted) return;
-      setState(() => _feedbackItems = items);
+      setState(() {
+        _feedbackItems = feedbacks;
+        _aiPickFeedbackItems =
+            aiPicks.where((i) => i.starRating != null).toList();
+      });
     } finally {
       if (mounted) setState(() => _feedbackLoading = false);
     }
@@ -542,7 +557,7 @@ class _MyPageScreenState extends State<MyPageScreen>
           MaterialPageRoute(
             builder: (_) => RecommendationHistoryScreen(jwt: jwt),
           ),
-        );
+        ).then((_) { if (mounted) _loadFeedbacks(); });
       },
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
@@ -1000,22 +1015,40 @@ class _MyPageScreenState extends State<MyPageScreen>
       return const Center(child: CircularProgressIndicator());
     }
 
-    final filtered = _searchQuery.isEmpty
-        ? _feedbackItems
-        : _feedbackItems
-            .where((item) => item.menuName.contains(_searchQuery))
-            .toList();
-
-    final liked = filtered.where((i) => i.feedbackScore == 1).toList();
-    final disliked = filtered.where((i) => i.feedbackScore == -1).toList();
-    final activeItems = _showLiked ? liked : disliked;
-
-    final likedTotal = _feedbackItems.where((i) => i.feedbackScore == 1).length;
+    final likedTotal =
+        _feedbackItems.where((i) => i.feedbackScore == 1).length;
     final dislikedTotal =
         _feedbackItems.where((i) => i.feedbackScore == -1).length;
+    final aiTotal = _aiPickFeedbackItems.length;
+
+    // 현재 탭에 맞는 목록 계산
+    List<Widget> listItems;
+    if (_feedbackTab == 2) {
+      final filtered = _searchQuery.isEmpty
+          ? _aiPickFeedbackItems
+          : _aiPickFeedbackItems
+              .where((i) => i.menuName.contains(_searchQuery))
+              .toList();
+      listItems = filtered.isEmpty
+          ? [_buildFeedbackEmpty()]
+          : filtered.map(_buildAiPickFeedbackItem).toList();
+    } else {
+      final targetScore = _feedbackTab == 0 ? 1 : -1;
+      final filtered = (_searchQuery.isEmpty
+              ? _feedbackItems
+              : _feedbackItems
+                  .where((i) => i.menuName.contains(_searchQuery))
+                  .toList())
+          .where((i) => i.feedbackScore == targetScore)
+          .toList();
+      listItems = filtered.isEmpty
+          ? [_buildFeedbackEmpty()]
+          : filtered.map(_buildFeedbackItem).toList();
+    }
 
     return Column(
       children: [
+        // ── 검색 바 ──
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
           child: TextField(
@@ -1040,6 +1073,7 @@ class _MyPageScreenState extends State<MyPageScreen>
             ),
           ),
         ),
+        // ── 3-버튼 토글 ──
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: Row(
@@ -1049,9 +1083,9 @@ class _MyPageScreenState extends State<MyPageScreen>
                   label: '좋아요',
                   count: likedTotal,
                   icon: Icons.thumb_up,
-                  isActive: _showLiked,
+                  isActive: _feedbackTab == 0,
                   activeColor: AppTheme.primaryColor,
-                  onTap: () => setState(() => _showLiked = true),
+                  onTap: () => setState(() => _feedbackTab = 0),
                 ),
               ),
               const SizedBox(width: 8),
@@ -1060,40 +1094,48 @@ class _MyPageScreenState extends State<MyPageScreen>
                   label: '싫어요',
                   count: dislikedTotal,
                   icon: Icons.thumb_down,
-                  isActive: !_showLiked,
+                  isActive: _feedbackTab == 1,
                   activeColor: Colors.redAccent,
-                  onTap: () => setState(() => _showLiked = false),
+                  onTap: () => setState(() => _feedbackTab = 1),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _buildToggleButton(
+                  label: 'AI피드백',
+                  count: aiTotal,
+                  icon: Icons.auto_awesome_rounded,
+                  isActive: _feedbackTab == 2,
+                  activeColor: AppTheme.primaryColor,
+                  activeGradient: AppTheme.aiGradient,
+                  onTap: () => setState(() => _feedbackTab = 2),
                 ),
               ),
             ],
           ),
         ),
+        // ── 목록 ──
         Expanded(
           child: RefreshIndicator(
             onRefresh: _loadFeedbacks,
-            child: activeItems.isEmpty
-                ? ListView(
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.only(top: 80),
-                        child: Center(
-                          child: Text(
-                            _searchQuery.isEmpty
-                                ? '아직 피드백한 메뉴가 없습니다.'
-                                : '검색 결과가 없습니다.',
-                            style: TextStyle(color: Colors.grey.shade500),
-                          ),
-                        ),
-                      ),
-                    ],
-                  )
-                : ListView.builder(
-                    itemCount: activeItems.length,
-                    itemBuilder: (_, i) => _buildFeedbackItem(activeItems[i]),
-                  ),
+            child: ListView(
+              children: [...listItems, const SizedBox(height: 16)],
+            ),
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildFeedbackEmpty() {
+    return Padding(
+      padding: const EdgeInsets.only(top: 60),
+      child: Center(
+        child: Text(
+          _searchQuery.isEmpty ? '아직 피드백한 메뉴가 없습니다.' : '검색 결과가 없습니다.',
+          style: TextStyle(color: Colors.grey.shade500),
+        ),
+      ),
     );
   }
 
@@ -1103,48 +1145,267 @@ class _MyPageScreenState extends State<MyPageScreen>
     required IconData icon,
     required bool isActive,
     required Color activeColor,
+    LinearGradient? activeGradient,
     required VoidCallback onTap,
   }) {
+    final useGradient = isActive && activeGradient != null;
+    final contentColor = useGradient ? activeGradient.colors.last : activeColor;
+
     return GestureDetector(
       onTap: onTap,
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 150),
         padding: const EdgeInsets.symmetric(vertical: 10),
         decoration: BoxDecoration(
-          color: isActive
-              ? activeColor.withValues(alpha: 0.1)
-              : Colors.grey.shade100,
+          gradient: useGradient
+              ? LinearGradient(
+                  colors: activeGradient.colors
+                      .map((c) => c.withValues(alpha: 0.15))
+                      .toList(),
+                  begin: activeGradient.begin,
+                  end: activeGradient.end,
+                )
+              : null,
+          color: useGradient
+              ? null
+              : isActive
+                  ? activeColor.withValues(alpha: 0.1)
+                  : Colors.grey.shade100,
           borderRadius: BorderRadius.circular(10),
           border: Border.all(
-            color: isActive ? activeColor : Colors.grey.shade300,
+            color: isActive ? contentColor : Colors.grey.shade300,
             width: isActive ? 1.5 : 1,
           ),
         ),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(icon,
-                size: 16,
-                color: isActive ? activeColor : Colors.grey.shade500),
+            useGradient
+                ? ShaderMask(
+                    blendMode: BlendMode.srcIn,
+                    shaderCallback: (b) => activeGradient.createShader(b),
+                    child: Icon(icon, size: 16),
+                  )
+                : Icon(icon,
+                    size: 16,
+                    color: isActive ? activeColor : Colors.grey.shade500),
             const SizedBox(width: 6),
-            Text(
-              label,
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                color: isActive ? activeColor : Colors.grey.shade500,
-              ),
-            ),
+            useGradient
+                ? ShaderMask(
+                    blendMode: BlendMode.srcIn,
+                    shaderCallback: (b) => activeGradient.createShader(b),
+                    child: Text(
+                      label,
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  )
+                : Text(
+                    label,
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      color: isActive ? activeColor : Colors.grey.shade500,
+                    ),
+                  ),
             const SizedBox(width: 4),
             Text(
               '$count',
               style: TextStyle(
                 fontSize: 12,
-                color: isActive ? activeColor : Colors.grey.shade400,
+                color: isActive ? contentColor : Colors.grey.shade400,
               ),
             ),
           ],
         ),
       ),
+    );
+  }
+
+  Future<void> _showAiPickEditSheet(AiPickItem item) async {
+    int starRating = item.starRating ?? 0;
+    final reasonController =
+        TextEditingController(text: item.feedbackReason ?? '');
+    bool submitting = false; // 빌더 밖에서 선언 — rebuild 시 리셋 방지
+    bool? result;
+
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.white,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (sheetCtx) => StatefulBuilder(
+        builder: (_, setSheetState) {
+          return Padding(
+            padding: EdgeInsets.fromLTRB(
+                24, 20, 24, MediaQuery.of(sheetCtx).viewInsets.bottom + 24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Center(
+                  child: Container(
+                    width: 40, height: 4,
+                    decoration: BoxDecoration(
+                      color: Colors.grey.shade300,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(item.menuName,
+                    style: const TextStyle(
+                        fontSize: 16, fontWeight: FontWeight.w700),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis),
+                const SizedBox(height: 4),
+                Text('이 추천은 어떠셨나요?',
+                    style: TextStyle(fontSize: 13, color: Colors.grey[500])),
+                const SizedBox(height: 16),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: List.generate(
+                    5,
+                    (i) => IconButton(
+                      icon: Icon(
+                        i < starRating
+                            ? Icons.star_rounded
+                            : Icons.star_outline_rounded,
+                        size: 38,
+                        color: i < starRating ? Colors.amber : Colors.grey[300],
+                      ),
+                      onPressed: () =>
+                          setSheetState(() => starRating = i + 1),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: reasonController,
+                  maxLines: 3,
+                  decoration: InputDecoration(
+                    hintText: '한 줄 코멘트 (선택)',
+                    hintStyle:
+                        TextStyle(color: Colors.grey[400], fontSize: 14),
+                    filled: true,
+                    fillColor: Colors.grey.shade100,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                SizedBox(
+                  height: 50,
+                  child: ElevatedButton(
+                    onPressed: submitting || starRating == 0
+                        ? null
+                        : () async {
+                            setSheetState(() => submitting = true);
+                            final jwt = await TokenStorage.getAccessToken();
+                            final ok =
+                                await RecommendationService.updateFeedback(
+                              item.id,
+                              starRating,
+                              reasonController.text.trim(),
+                              jwt,
+                            );
+                            result = ok;
+                            if (sheetCtx.mounted) Navigator.pop(sheetCtx);
+                          },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppTheme.primaryColor,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12)),
+                    ),
+                    child: submitting
+                        ? const SizedBox(
+                            width: 20, height: 20,
+                            child: CircularProgressIndicator(
+                                strokeWidth: 2, color: Colors.white))
+                        : const Text('피드백 저장',
+                            style: TextStyle(
+                                fontSize: 15, fontWeight: FontWeight.w600)),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+
+    WidgetsBinding.instance.addPostFrameCallback((_) => reasonController.dispose());
+    if (!mounted) return;
+    if (result == true) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('피드백이 수정됐습니다')));
+      await _loadFeedbacks();
+    } else if (result == false) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('저장에 실패했습니다')));
+    }
+  }
+
+  Widget _buildAiPickFeedbackItem(AiPickItem item) {
+    return ListTile(
+      contentPadding:
+          const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      onTap: () => _showAiPickEditSheet(item),
+      leading: ClipRRect(
+        borderRadius: BorderRadius.circular(8),
+        child: item.menuImageUrl != null && item.menuImageUrl!.isNotEmpty
+            ? Image.network(
+                item.menuImageUrl!,
+                width: 48,
+                height: 48,
+                fit: BoxFit.cover,
+                errorBuilder: (_, e, s) => _defaultMenuIcon(),
+              )
+            : _defaultMenuIcon(),
+      ),
+      title: Text(item.menuName,
+          style: const TextStyle(fontWeight: FontWeight.w500)),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const SizedBox(height: 2),
+          Row(
+            children: List.generate(
+              5,
+              (i) => Icon(
+                i < item.starRating!
+                    ? Icons.star_rounded
+                    : Icons.star_outline_rounded,
+                size: 14,
+                color: Colors.amber,
+              ),
+            ),
+          ),
+          if (item.feedbackReason != null &&
+              item.feedbackReason!.isNotEmpty) ...[
+            const SizedBox(height: 2),
+            Text(
+              item.feedbackReason!,
+              style: TextStyle(fontSize: 12, color: Colors.grey.shade600),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+          if (item.createdAt != null) ...[
+            const SizedBox(height: 2),
+            Text(
+              item.createdAt!,
+              style: TextStyle(fontSize: 11, color: Colors.grey.shade400),
+            ),
+          ],
+        ],
+      ),
+      isThreeLine: true,
+      trailing: Icon(Icons.edit_outlined, size: 16, color: Colors.grey.shade400),
     );
   }
 

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -326,6 +326,7 @@ class _MyPageScreenState extends State<MyPageScreen>
   // ── 피드백 탭 로직 ────────────────────────────────
 
   Future<void> _loadFeedbacks() async {
+    if (_feedbackLoading) return; // 재진입 방지 — 중복 호출 시 먼저 완료된 결과 유지
     setState(() => _feedbackLoading = true);
     try {
       final jwt = await TokenStorage.getAccessToken();
@@ -557,7 +558,7 @@ class _MyPageScreenState extends State<MyPageScreen>
           MaterialPageRoute(
             builder: (_) => RecommendationHistoryScreen(jwt: jwt),
           ),
-        ).then((_) { if (mounted) _loadFeedbacks(); });
+        );
       },
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
@@ -1377,7 +1378,7 @@ class _MyPageScreenState extends State<MyPageScreen>
             children: List.generate(
               5,
               (i) => Icon(
-                i < item.starRating!
+                i < (item.starRating ?? 0)
                     ? Icons.star_rounded
                     : Icons.star_outline_rounded,
                 size: 14,

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -68,6 +68,7 @@ class _MyPageScreenState extends State<MyPageScreen>
   List<FeedbackHistoryItem> _feedbackItems = [];
   List<AiPickItem> _aiPickFeedbackItems = [];
   bool _feedbackLoading = false;
+  bool _feedbackPending = false;
   final TextEditingController _searchController = TextEditingController();
   String _searchQuery = '';
   int _feedbackTab = 0; // 0=좋아요, 1=싫어요, 2=AI피드백
@@ -326,7 +327,11 @@ class _MyPageScreenState extends State<MyPageScreen>
   // ── 피드백 탭 로직 ────────────────────────────────
 
   Future<void> _loadFeedbacks() async {
-    if (_feedbackLoading) return; // 재진입 방지 — 중복 호출 시 먼저 완료된 결과 유지
+    if (_feedbackLoading) {
+      _feedbackPending = true; // 로딩 중 재요청 — 완료 후 한 번 더 실행
+      return;
+    }
+    _feedbackPending = false;
     setState(() => _feedbackLoading = true);
     try {
       final jwt = await TokenStorage.getAccessToken();
@@ -342,6 +347,7 @@ class _MyPageScreenState extends State<MyPageScreen>
       });
     } finally {
       if (mounted) setState(() => _feedbackLoading = false);
+      if (_feedbackPending) _loadFeedbacks();
     }
   }
 

--- a/flutter_app/lib/screens/recommendation_history_detail_screen.dart
+++ b/flutter_app/lib/screens/recommendation_history_detail_screen.dart
@@ -1,78 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_app/models/recommendation_models.dart';
 import 'package:flutter_app/screens/menu_detail_screen.dart' show AiPickBody;
-import 'package:flutter_app/services/recommendation_service.dart';
 import 'package:flutter_app/theme.dart';
 
-class RecommendationHistoryDetailScreen extends StatefulWidget {
-  final int logId;
+class RecommendationHistoryDetailScreen extends StatelessWidget {
   final RecommendationResult result;
-  final int? initialStarRating;
-  final String? initialFeedbackReason;
-  final String jwt;
 
   const RecommendationHistoryDetailScreen({
     super.key,
-    required this.logId,
     required this.result,
-    this.initialStarRating,
-    this.initialFeedbackReason,
-    required this.jwt,
   });
-
-  @override
-  State<RecommendationHistoryDetailScreen> createState() =>
-      _RecommendationHistoryDetailScreenState();
-}
-
-class _RecommendationHistoryDetailScreenState
-    extends State<RecommendationHistoryDetailScreen> {
-  late int _starRating;
-  late TextEditingController _reasonController;
-  bool _submitting = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _starRating = widget.initialStarRating ?? 0;
-    _reasonController =
-        TextEditingController(text: widget.initialFeedbackReason ?? '');
-  }
-
-  @override
-  void dispose() {
-    _reasonController.dispose();
-    super.dispose();
-  }
-
-  Future<void> _submitFeedback() async {
-    if (_starRating == 0) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('별점을 선택해주세요')),
-      );
-      return;
-    }
-    setState(() => _submitting = true);
-    final ok = await RecommendationService.updateFeedback(
-      widget.logId,
-      _starRating,
-      _reasonController.text.trim(),
-      widget.jwt,
-    );
-    if (!mounted) return;
-    setState(() => _submitting = false);
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(ok ? '피드백이 저장됐습니다' : '저장에 실패했습니다')),
-    );
-    if (ok) Navigator.pop(context);
-  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppTheme.backgroundColor,
       appBar: AppBar(
-        title: Text(widget.result.menuName,
+        title: Text(result.menuName,
             style: const TextStyle(fontWeight: FontWeight.bold),
             overflow: TextOverflow.ellipsis),
         centerTitle: true,
@@ -81,8 +25,7 @@ class _RecommendationHistoryDetailScreenState
         actions: [
           Container(
             margin: const EdgeInsets.only(right: 16),
-            padding:
-                const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
             decoration: BoxDecoration(
               gradient: AppTheme.aiGradient,
               borderRadius: BorderRadius.circular(20),
@@ -105,95 +48,10 @@ class _RecommendationHistoryDetailScreenState
       body: SingleChildScrollView(
         child: Column(
           children: [
-            // AI 결과 본문 재현
-            AiPickBody(result: widget.result),
-            // 피드백 폼
-            _buildFeedbackSection(),
+            AiPickBody(result: result),
             const SizedBox(height: 32),
           ],
         ),
-      ),
-    );
-  }
-
-  Widget _buildFeedbackSection() {
-    return Container(
-      margin: const EdgeInsets.fromLTRB(20, 0, 20, 0),
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.04),
-            blurRadius: 8,
-            offset: const Offset(0, 2),
-          ),
-        ],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          const Text('이 추천은 어떠셨나요?',
-              style: TextStyle(
-                  fontSize: 15, fontWeight: FontWeight.w700)),
-          const SizedBox(height: 16),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: List.generate(
-              5,
-              (i) => IconButton(
-                icon: Icon(
-                  i < _starRating
-                      ? Icons.star_rounded
-                      : Icons.star_outline_rounded,
-                  size: 40,
-                  color: i < _starRating ? Colors.amber : Colors.grey[300],
-                ),
-                onPressed: () => setState(() => _starRating = i + 1),
-              ),
-            ),
-          ),
-          const SizedBox(height: 12),
-          TextField(
-            controller: _reasonController,
-            maxLines: 3,
-            decoration: InputDecoration(
-              hintText: '한 줄 코멘트 (선택)',
-              hintStyle:
-                  TextStyle(color: Colors.grey[400], fontSize: 14),
-              filled: true,
-              fillColor: Colors.grey.shade100,
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide.none,
-              ),
-            ),
-          ),
-          const SizedBox(height: 16),
-          SizedBox(
-            height: 50,
-            child: ElevatedButton(
-              onPressed: _submitting ? null : _submitFeedback,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppTheme.primaryColor,
-                foregroundColor: Colors.white,
-                shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12)),
-              ),
-              child: _submitting
-                  ? const SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(
-                          strokeWidth: 2, color: Colors.white),
-                    )
-                  : const Text('피드백 저장',
-                      style: TextStyle(
-                          fontSize: 15, fontWeight: FontWeight.w600)),
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/flutter_app/lib/screens/recommendation_history_screen.dart
+++ b/flutter_app/lib/screens/recommendation_history_screen.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_app/models/recommendation_models.dart';
+import 'package:flutter_app/notifiers.dart';
 import 'package:flutter_app/screens/recommendation_history_detail_screen.dart';
 import 'package:flutter_app/services/recommendation_service.dart';
 import 'package:flutter_app/theme.dart';
@@ -31,6 +32,159 @@ class _RecommendationHistoryScreenState
     final items = await RecommendationService.fetchMyAiPicks(widget.jwt);
     if (mounted) setState(() { _items = items; _loading = false; });
   }
+
+  // ── 피드백 BottomSheet ─────────────────────────────
+
+  Future<void> _showFeedbackBottomSheet(AiPickItem item) async {
+    int starRating = item.starRating ?? 0;
+    final reasonController =
+        TextEditingController(text: item.feedbackReason ?? '');
+    bool submitting = false; // 빌더 밖에서 선언 — rebuild 시 리셋 방지
+    bool? feedbackResult; // null=미제출, true=성공, false=실패
+
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.white,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (sheetCtx) => StatefulBuilder(
+        builder: (_, setSheetState) {
+          return Padding(
+            padding: EdgeInsets.fromLTRB(
+              24,
+              20,
+              24,
+              MediaQuery.of(sheetCtx).viewInsets.bottom + 24,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // 핸들 바
+                Center(
+                  child: Container(
+                    width: 40,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: Colors.grey.shade300,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  item.menuName,
+                  style: const TextStyle(
+                      fontSize: 16, fontWeight: FontWeight.w700),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '이 추천은 어떠셨나요?',
+                  style: TextStyle(fontSize: 13, color: Colors.grey[500]),
+                ),
+                const SizedBox(height: 16),
+                // 별점
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: List.generate(
+                    5,
+                    (i) => IconButton(
+                      icon: Icon(
+                        i < starRating
+                            ? Icons.star_rounded
+                            : Icons.star_outline_rounded,
+                        size: 38,
+                        color: i < starRating ? Colors.amber : Colors.grey[300],
+                      ),
+                      onPressed: () =>
+                          setSheetState(() => starRating = i + 1),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                // 코멘트
+                TextField(
+                  controller: reasonController,
+                  maxLines: 3,
+                  decoration: InputDecoration(
+                    hintText: '한 줄 코멘트 (선택)',
+                    hintStyle:
+                        TextStyle(color: Colors.grey[400], fontSize: 14),
+                    filled: true,
+                    fillColor: Colors.grey.shade100,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                // 저장 버튼
+                SizedBox(
+                  height: 50,
+                  child: ElevatedButton(
+                    onPressed: submitting || starRating == 0
+                        ? null
+                        : () async {
+                            setSheetState(() => submitting = true);
+                            final ok =
+                                await RecommendationService.updateFeedback(
+                              item.id,
+                              starRating,
+                              reasonController.text.trim(),
+                              widget.jwt,
+                            );
+                            feedbackResult = ok;
+                            if (sheetCtx.mounted) Navigator.pop(sheetCtx);
+                          },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppTheme.primaryColor,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12)),
+                    ),
+                    child: submitting
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(
+                                strokeWidth: 2, color: Colors.white),
+                          )
+                        : const Text('피드백 저장',
+                            style: TextStyle(
+                                fontSize: 15, fontWeight: FontWeight.w600)),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+
+    // 닫힘 애니메이션 중 리빌드가 컨트롤러를 참조할 수 있으므로 다음 프레임 후 dispose
+    WidgetsBinding.instance.addPostFrameCallback((_) => reasonController.dispose());
+
+    if (!mounted) return;
+    if (feedbackResult == true) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('피드백이 저장됐습니다')),
+      );
+      feedbackRefreshNotifier.value++; // MyPageScreen에 변경 알림
+      await _load(silent: true);
+    } else if (feedbackResult == false) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('저장에 실패했습니다')),
+      );
+    }
+    // feedbackResult == null: 사용자가 시트를 그냥 닫음 → 아무 처리 없음
+  }
+
+  // ── 빌드 ──────────────────────────────────────────
 
   @override
   Widget build(BuildContext context) {
@@ -80,100 +234,139 @@ class _RecommendationHistoryScreenState
   }
 
   Widget _buildCard(AiPickItem item) {
-    return GestureDetector(
-      onTap: () async {
-        if (item.aiResultJson == null) return;
-        RecommendationResult? result;
-        try {
-          result = RecommendationResult.fromJson(
-              jsonDecode(item.aiResultJson!) as Map<String, dynamic>);
-        } catch (_) {
-          return;
-        }
-        await Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => RecommendationHistoryDetailScreen(
-              logId: item.id,
-              result: result!,
-              initialStarRating: item.starRating,
-              initialFeedbackReason: item.feedbackReason,
-              jwt: widget.jwt,
-            ),
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.04),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
           ),
-        );
-        await _load(silent: true);
-      },
-      child: Container(
-        margin: const EdgeInsets.only(bottom: 12),
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(16),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.04),
-              blurRadius: 8,
-              offset: const Offset(0, 2),
-            ),
-          ],
-        ),
-        child: Row(
-          children: [
-            if (item.menuImageUrl != null && item.menuImageUrl!.isNotEmpty)
-              ClipRRect(
-                borderRadius: BorderRadius.circular(10),
-                child: Image.network(
-                  item.menuImageUrl!,
-                  width: 56,
-                  height: 56,
-                  fit: BoxFit.cover,
-                  errorBuilder: (_, __, ___) =>
-                      _imagePlaceholder(),
+        ],
+      ),
+      child: Column(
+        children: [
+          // ── 상단: 이력 정보 (탭 → 상세 화면) ──
+          GestureDetector(
+            onTap: () async {
+              if (item.aiResultJson == null) return;
+              RecommendationResult? result;
+              try {
+                result = RecommendationResult.fromJson(
+                    jsonDecode(item.aiResultJson!) as Map<String, dynamic>);
+              } catch (_) {
+                return;
+              }
+              await Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) =>
+                      RecommendationHistoryDetailScreen(result: result!),
                 ),
-              )
-            else
-              _imagePlaceholder(),
-            const SizedBox(width: 14),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+              );
+            },
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+              child: Row(
                 children: [
-                  Text(
-                    item.menuName,
-                    style: const TextStyle(
-                        fontSize: 15, fontWeight: FontWeight.w700),
-                  ),
-                  if (item.createdAt != null) ...[
-                    const SizedBox(height: 4),
-                    Text(
-                      item.createdAt!,
-                      style: TextStyle(
-                          fontSize: 12, color: Colors.grey[400]),
-                    ),
-                  ],
-                  if (item.starRating != null) ...[
-                    const SizedBox(height: 4),
-                    Row(
-                      children: List.generate(
-                        5,
-                        (i) => Icon(
-                          i < item.starRating!
-                              ? Icons.star_rounded
-                              : Icons.star_outline_rounded,
-                          size: 14,
-                          color: Colors.amber,
-                        ),
+                  if (item.menuImageUrl != null &&
+                      item.menuImageUrl!.isNotEmpty)
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(10),
+                      child: Image.network(
+                        item.menuImageUrl!,
+                        width: 56,
+                        height: 56,
+                        fit: BoxFit.cover,
+                        errorBuilder: (_, e, s) => _imagePlaceholder(),
                       ),
+                    )
+                  else
+                    _imagePlaceholder(),
+                  const SizedBox(width: 14),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          item.menuName,
+                          style: const TextStyle(
+                              fontSize: 15, fontWeight: FontWeight.w700),
+                        ),
+                        if (item.createdAt != null) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            item.createdAt!,
+                            style:
+                                TextStyle(fontSize: 12, color: Colors.grey[400]),
+                          ),
+                        ],
+                        if (item.starRating != null) ...[
+                          const SizedBox(height: 4),
+                          Row(
+                            children: List.generate(
+                              5,
+                              (i) => Icon(
+                                i < item.starRating!
+                                    ? Icons.star_rounded
+                                    : Icons.star_outline_rounded,
+                                size: 14,
+                                color: Colors.amber,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ],
                     ),
-                  ],
+                  ),
+                  Icon(Icons.chevron_right_rounded,
+                      color: Colors.grey[400], size: 20),
                 ],
               ),
             ),
-            Icon(Icons.chevron_right_rounded,
-                color: Colors.grey[400], size: 20),
-          ],
-        ),
+          ),
+          // ── 구분선 ──
+          const Divider(height: 1, thickness: 1, color: Color(0xFFF0F0F0)),
+          // ── 하단: 피드백 버튼 ──
+          SizedBox(
+            height: 40,
+            child: TextButton(
+              onPressed: () => _showFeedbackBottomSheet(item),
+              style: TextButton.styleFrom(
+                foregroundColor: item.starRating != null
+                    ? Colors.grey[500]
+                    : AppTheme.primaryColor,
+                shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.only(
+                    bottomLeft: Radius.circular(16),
+                    bottomRight: Radius.circular(16),
+                  ),
+                ),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    item.starRating != null
+                        ? Icons.edit_outlined
+                        : Icons.star_border_rounded,
+                    size: 14,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    item.starRating != null ? '피드백 수정' : '피드백 남기기',
+                    style: const TextStyle(
+                        fontSize: 13, fontWeight: FontWeight.w500),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary

- **추천 이력 ↔ 피드백 기능 분리**: 이력 상세 화면은 AI 분석 결과만 표시하고, 피드백은 이력 목록 카드에서 직접 작성
- **마이페이지 피드백 탭 통합**: 기존 좋아요/싫어요에 'AI피드백' 탭 추가, 별점+코멘트로 남긴 AI 추천 피드백을 한 곳에서 조회·수정
- **즉시 반영**: 이력 화면에서 피드백 저장 시 마이페이지 AI피드백 탭 자동 갱신

## Changes

### RecommendationHistoryDetailScreen
- `StatefulWidget` → `StatelessWidget` 단순화
- 피드백 폼(별점·코멘트·저장 버튼) 제거, AI 분석 결과(`AiPickBody`) 표시만 담당
- 불필요 파라미터 제거 (`logId`, `jwt`, `initialStarRating`, `initialFeedbackReason`)

### RecommendationHistoryScreen
- 카드 하단 구분선 + 피드백 버튼 추가
  - 피드백 없음 → **'피드백 남기기'** (파란색)
  - 피드백 있음 → **'피드백 수정'** (회색) + 별점 표시
- `_showFeedbackBottomSheet`: 별점(필수) + 코멘트(선택) 입력 후 `updateFeedback` 호출
  - `submitting`을 StatefulBuilder 밖에 선언해 rebuild 시 리셋 버그 수정
  - `addPostFrameCallback`으로 dispose 지연 → use-after-disposed 오류 수정
  - 저장 성공 시 `feedbackRefreshNotifier.value++` → 마이페이지 즉시 반영

### MyPageScreen 피드백 탭
- 3-버튼 토글: **좋아요 / 싫어요 / AI피드백**
  - AI피드백 버튼: 그린-블루 그라디언트 적용 (`AppTheme.aiGradient`)
- AI피드백 탭: `starRating != null`인 `AiPickItem` 목록 표시 (`_buildAiPickFeedbackItem`)
  - 항목 탭 → `_showAiPickEditSheet`로 수정 가능
- 검색이 선택된 탭의 목록에 적용
- `_loadFeedbacks`: `fetchMyFeedbacks` + `fetchMyAiPicks` 병렬 로드, 필터링 적용

### 즉시 반영 (notifiers.dart 신규)
- `feedbackRefreshNotifier` (`ValueNotifier<int>`) 전역 노티파이어
  - 순환 임포트 없이 두 화면이 공유
- 커버 시나리오:
  - 이력 화면 피드백 저장 → 마이페이지 AI피드백 탭 즉시 반영
  - 마이페이지 프로필→피드백 탭 전환 시 최신 데이터 로드
- `_loadFeedbacks` 재진입 방지 (`if (_feedbackLoading) return`) — 중복 API 호출 차단

### 버그 수정 (코드리뷰 반영)
| 항목 | 수정 |
|---|---|
| `_loadFeedbacks` 중복 호출 | notifier+탭전환+then 동시 발화 시 재진입 방지 가드 추가 |
| `.then(_loadFeedbacks)` 이중 호출 | notifier가 이미 처리하므로 `.then` 제거 |
| `item.starRating!` force-unwrap | `item.starRating ?? 0` null-safe 처리 |
| TextEditingController use-after-disposed | `addPostFrameCallback`으로 dispose 지연 |
| StatefulBuilder 내 submitting 리셋 버그 | 빌더 밖으로 변수 이동 |

## Test plan

- [ ] 추천 이력 카드 탭 → AI 분석 결과만 표시 (피드백 폼 없음) 확인
- [ ] 이력 카드 하단 '피드백 남기기' 탭 → 별점 선택 후 저장 → 마이페이지 AI피드백 탭 **즉시** 반영
- [ ] 이력 카드 '피드백 수정' 탭 → 기존 별점/코멘트 로드 → 수정 저장 정상
- [ ] 마이페이지 피드백 탭: 좋아요 / 싫어요 / AI피드백 3개 토글 전환
- [ ] AI피드백 탭 항목 탭 → 수정 BottomSheet 열림 → 수정 저장 정상
- [ ] 검색어 입력 시 선택된 탭 항목만 필터링
- [ ] 피드백 저장 후 중복 API 호출 없음 (로그 확인)
- [ ] 별점 없이 저장 버튼 비활성화 확인
- [ ] 비로그인 / 토큰 만료 상태에서 저장 시 '저장에 실패했습니다' 스낵바만 표시