### PR TITLE
[CHORE] DropdownButtonFormField value → initialValue 마이그레이션

### DIFF
--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -797,7 +797,7 @@ class _MyPageScreenState extends State<MyPageScreen>
                   filled: true,
                   fillColor: Colors.white,
                 ),
-                value: _selectedGender,
+                initialValue: _selectedGender,
                 onChanged: (v) => setState(() => _selectedGender = v!),
                 items: ['남성', '여성']
                     .map((s) => DropdownMenuItem(value: s, child: Text(s)))
@@ -846,7 +846,7 @@ class _MyPageScreenState extends State<MyPageScreen>
                   filled: true,
                   fillColor: Colors.white,
                 ),
-                value: _selectedVegType,
+                initialValue: _selectedVegType,
                 onChanged: (v) => setState(() => _selectedVegType = v!),
                 items: _vegOptions.entries
                     .map((e) =>

--- a/flutter_app/lib/screens/onboarding_screen.dart
+++ b/flutter_app/lib/screens/onboarding_screen.dart
@@ -184,7 +184,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                     fillColor: Colors.white,
                     // 💡 theme.dart의 16px 라운딩이 자동으로 적용됨
                   ),
-                  value: _selectedVegType,
+                  initialValue: _selectedVegType,
                   onChanged: (v) => setState(() => _selectedVegType = v!),
                   items: _vegOptions.entries.map((e) => DropdownMenuItem(value: e.key, child: Text(e.value))).toList(),
                 ),


### PR DESCRIPTION
## 개요
Flutter `v3.33.0-1.0.pre` 이후 deprecated된 `DropdownButtonFormField`의 `value:` 파라미터를 `initialValue:`로 치환합니다. `flutter analyze`의 `deprecated_member_use` 경고를 제거합니다.

closes #178

## 변경 사항
- `onboarding_screen.dart` — 채식 유형 드롭다운 `value` → `initialValue`
- `mypage_screen.dart` — 성별 드롭다운 `value` → `initialValue`
- `mypage_screen.dart` — 채식 유형 드롭다운 `value` → `initialValue`

`signup_screen.dart`는 이미 마이그레이션되어 있어 제외했습니다.

## 동작 보존 근거
이름은 `initialValue`("초기값")지만 **controlled 동작이 유지**되므로 기존 `value`와 동일하게 작동합니다. Flutter SDK(`material/dropdown.dart`) 기준:

1. 생성자가 `super(initialValue: initialValue ?? value)`로 매핑 → `value`/`initialValue` 둘 다 같은 `FormField.initialValue`로 들어감 (기능적으로 identical).
2. `_DropdownButtonFormFieldState.didUpdateWidget`가 리빌드 시 `initialValue` 변화를 감지하면 `setValue(widget.initialValue)`로 갱신:
   ```dart
   if (oldWidget.initialValue != widget.initialValue) {
     setValue(widget.initialValue);
   }
   ```
   → mypage에서 `_loadProfile`/`_loadBasicUserInfoFromLocal`가 첫 빌드 이후 `setState`로 `_selectedGender`/`_selectedVegType`를 바꿔도 드롭다운이 정상 반영됨.

즉 이 변경은 **동작상 no-op**입니다.

## 검증
- `flutter analyze` → `DropdownButtonFormField.value` 관련 `deprecated_member_use` 경고 **0건** 확인
- 변경은 `+3 -3` (라인 치환만, 로직 변경 없음)

## 참고 (이 PR 범위 밖)
`onboarding_screen.dart`에 기존 `withOpacity` deprecation 5건이 별도로 존재합니다(`origin/dev`에도 존재). #178 스코프와 무관하여 이 PR에 포함하지 않았으며, 필요 시 별도 이슈/PR로 처리 권장합니다.
