### PR TITLE
feat: AI 픽 메뉴 싫어요(제외) 기능 추가 (#179)

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
@@ -106,6 +106,24 @@ public class RecommendationLogController {
         }
     }
 
+    @PatchMapping("/{id}/unsave")
+    public ResponseEntity<?> unsaveAiResult(
+            @RequestHeader(value = "Authorization", required = false) String authHeader,
+            @PathVariable("id") Long id) {
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return ResponseEntity.status(401).body(Map.of("success", false, "error", "인증이 필요합니다."));
+        }
+
+        String email = jwtUtil.getEmailFromToken(authHeader.substring(7));
+        try {
+            recommendationLogService.unsaveAiResult(email, id);
+            return ResponseEntity.ok(Map.of("success", true));
+        } catch (SecurityException e) {
+            return ResponseEntity.status(403).body(Map.of("success", false, "error", e.getMessage()));
+        }
+    }
+
     @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteFeedback(
             @RequestHeader(value = "Authorization", required = false) String authHeader,

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
@@ -99,7 +99,7 @@ public class RecommendationLogController {
 
         String email = jwtUtil.getEmailFromToken(authHeader.substring(7));
         try {
-            recommendationLogService.updateFeedback(email, id, request.getStarRating(), request.getFeedbackReason());
+            recommendationLogService.updateFeedback(email, id, request.getFeedbackScore(), request.getStarRating(), request.getFeedbackReason());
             return ResponseEntity.ok(Map.of("success", true));
         } catch (SecurityException e) {
             return ResponseEntity.status(403).body(Map.of("success", false, "error", e.getMessage()));

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
@@ -64,7 +64,7 @@ public class RecommendationLogService {
     }
 
     @Transactional
-    public void updateFeedback(String email, Long logId, Integer starRating, String feedbackReason) {
+    public void updateFeedback(String email, Long logId, Integer feedbackScore, Integer starRating, String feedbackReason) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
         RecommendationLog log = recommendationLogRepository.findById(logId)
@@ -72,8 +72,9 @@ public class RecommendationLogService {
         if (!log.getUser().getId().equals(user.getId())) {
             throw new SecurityException("권한이 없습니다.");
         }
-        log.setStarRating(starRating);
-        log.setFeedbackReason(feedbackReason);
+        if (feedbackScore != null) log.setFeedbackScore(feedbackScore);
+        if (starRating != null) log.setStarRating(starRating);
+        if (feedbackReason != null) log.setFeedbackReason(feedbackReason);
         recommendationLogRepository.save(log);
     }
 
@@ -108,6 +109,7 @@ public class RecommendationLogService {
                         .menuId(log.getSelectedMenu().getId())
                         .menuName(log.getSelectedMenu().getName())
                         .menuImageUrl(log.getSelectedMenu().getMainImageUrl())
+                        .feedbackScore(log.getFeedbackScore())
                         .starRating(log.getStarRating())
                         .feedbackReason(log.getFeedbackReason())
                         .aiResultJson(log.getAiResultJson())

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
@@ -38,9 +38,9 @@ public class RecommendationLogService {
                     newLog.setSelectedMenu(menu);
                     return newLog;
                 });
-        log.setFeedbackScore(feedbackScore);
-        log.setStarRating(starRating);
-        log.setFeedbackReason(feedbackReason);
+        if (feedbackScore != null) log.setFeedbackScore(feedbackScore);
+        if (starRating != null) log.setStarRating(starRating);
+        if (feedbackReason != null) log.setFeedbackReason(feedbackReason);
         recommendationLogRepository.save(log);
     }
 

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
@@ -45,6 +45,19 @@ public class RecommendationLogService {
     }
 
     @Transactional
+    public void unsaveAiResult(String email, Long logId) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        RecommendationLog log = recommendationLogRepository.findById(logId)
+                .orElseThrow(() -> new IllegalArgumentException("이력을 찾을 수 없습니다."));
+        if (!log.getUser().getId().equals(user.getId())) {
+            throw new SecurityException("권한이 없습니다.");
+        }
+        log.setAiResultJson(null);
+        recommendationLogRepository.save(log);
+    }
+
+    @Transactional
     public Long saveAiResult(String email, Long menuId, String aiResultJson) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));

--- a/flutter_app/lib/models/recommendation_models.dart
+++ b/flutter_app/lib/models/recommendation_models.dart
@@ -345,6 +345,7 @@ class AiPickItem {
   final int menuId;
   final String menuName;
   final String? menuImageUrl;
+  final int? feedbackScore;
   final int? starRating;
   final String? feedbackReason;
   final String? aiResultJson;
@@ -355,17 +356,21 @@ class AiPickItem {
     required this.menuId,
     required this.menuName,
     this.menuImageUrl,
+    this.feedbackScore,
     this.starRating,
     this.feedbackReason,
     this.aiResultJson,
     this.createdAt,
   });
 
+  bool get isDisliked => feedbackScore != null && feedbackScore! < 0;
+
   factory AiPickItem.fromJson(Map<String, dynamic> json) => AiPickItem(
         id: (json['id'] as num).toInt(),
         menuId: (json['menuId'] as num).toInt(),
         menuName: json['menuName'] ?? '',
         menuImageUrl: json['menuImageUrl'],
+        feedbackScore: (json['feedbackScore'] as num?)?.toInt(),
         starRating: (json['starRating'] as num?)?.toInt(),
         feedbackReason: json['feedbackReason'],
         aiResultJson: json['aiResultJson'],

--- a/flutter_app/lib/screens/dashboard_screen.dart
+++ b/flutter_app/lib/screens/dashboard_screen.dart
@@ -45,6 +45,7 @@ class _DashboardScreenState extends State<DashboardScreen>
   // ── 카드 3: AI 픽 이력 ────────────────────────────
   List<AiPickItem> _aiPicks = [];
   bool _isAiPickLoading = true;
+  final Set<int> _dislikedAiPickIds = {}; // 세션 내 싫어요 처리된 로그 ID
 
   // ── 카드 4: 프로필 요약 ───────────────────────────
   UserProfileData? _profileData;
@@ -191,6 +192,23 @@ class _DashboardScreenState extends State<DashboardScreen>
       }
     } catch (_) {
       if (mounted) setState(() => _isAiPickLoading = false);
+    }
+  }
+
+  Future<void> _dislikeAiPick(AiPickItem item) async {
+    final jwt = await TokenStorage.getAccessToken();
+    if (jwt == null || !mounted) return;
+    final success = await RecommendationService.updateAiPickFeedbackScore(
+        item.id, -1, jwt);
+    if (!mounted) return;
+    if (success) {
+      setState(() => _dislikedAiPickIds.add(item.id));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('다음 추천에서 제외됩니다'),
+          duration: Duration(seconds: 2),
+        ),
+      );
     }
   }
 
@@ -513,6 +531,8 @@ class _DashboardScreenState extends State<DashboardScreen>
   }
 
   Widget _buildAiPickRow(AiPickItem item) {
+    final isDisliked =
+        item.isDisliked || _dislikedAiPickIds.contains(item.id);
     return Row(
       children: [
         ClipRRect(
@@ -531,22 +551,39 @@ class _DashboardScreenState extends State<DashboardScreen>
         Expanded(
           child: Text(
             item.menuName,
-            style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w500),
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w500,
+              color: isDisliked ? Colors.grey.shade400 : null,
+              decoration:
+                  isDisliked ? TextDecoration.lineThrough : null,
+            ),
             overflow: TextOverflow.ellipsis,
           ),
         ),
-        if (item.starRating != null)
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(Icons.star_rounded, size: 13, color: Colors.amber),
-              const SizedBox(width: 2),
-              Text(
-                '${item.starRating}',
-                style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600),
-              ),
-            ],
+        if (isDisliked)
+          Icon(Icons.block_rounded, size: 14, color: Colors.grey.shade400)
+        else ...[
+          if (item.starRating != null)
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.star_rounded, size: 13, color: Colors.amber),
+                const SizedBox(width: 2),
+                Text(
+                  '${item.starRating}',
+                  style: const TextStyle(
+                      fontSize: 12, fontWeight: FontWeight.w600),
+                ),
+              ],
+            ),
+          const SizedBox(width: 4),
+          GestureDetector(
+            onTap: () => _dislikeAiPick(item),
+            child: Icon(Icons.close_rounded,
+                size: 16, color: Colors.grey.shade400),
           ),
+        ],
       ],
     );
   }

--- a/flutter_app/lib/screens/dashboard_screen.dart
+++ b/flutter_app/lib/screens/dashboard_screen.dart
@@ -45,7 +45,6 @@ class _DashboardScreenState extends State<DashboardScreen>
   // ── 카드 3: AI 픽 이력 ────────────────────────────
   List<AiPickItem> _aiPicks = [];
   bool _isAiPickLoading = true;
-  final Set<int> _dislikedAiPickIds = {}; // 세션 내 싫어요 처리된 로그 ID
 
   // ── 카드 4: 프로필 요약 ───────────────────────────
   UserProfileData? _profileData;
@@ -192,23 +191,6 @@ class _DashboardScreenState extends State<DashboardScreen>
       }
     } catch (_) {
       if (mounted) setState(() => _isAiPickLoading = false);
-    }
-  }
-
-  Future<void> _dislikeAiPick(AiPickItem item) async {
-    final jwt = await TokenStorage.getAccessToken();
-    if (jwt == null || !mounted) return;
-    final success = await RecommendationService.updateAiPickFeedbackScore(
-        item.id, -1, jwt);
-    if (!mounted) return;
-    if (success) {
-      setState(() => _dislikedAiPickIds.add(item.id));
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('다음 추천에서 제외됩니다'),
-          duration: Duration(seconds: 2),
-        ),
-      );
     }
   }
 
@@ -531,8 +513,6 @@ class _DashboardScreenState extends State<DashboardScreen>
   }
 
   Widget _buildAiPickRow(AiPickItem item) {
-    final isDisliked =
-        item.isDisliked || _dislikedAiPickIds.contains(item.id);
     return Row(
       children: [
         ClipRRect(
@@ -554,36 +534,26 @@ class _DashboardScreenState extends State<DashboardScreen>
             style: TextStyle(
               fontSize: 13,
               fontWeight: FontWeight.w500,
-              color: isDisliked ? Colors.grey.shade400 : null,
-              decoration:
-                  isDisliked ? TextDecoration.lineThrough : null,
+              color: item.isDisliked ? Colors.grey.shade400 : null,
+              decoration: item.isDisliked ? TextDecoration.lineThrough : null,
             ),
             overflow: TextOverflow.ellipsis,
           ),
         ),
-        if (isDisliked)
+        if (item.isDisliked)
           Icon(Icons.block_rounded, size: 14, color: Colors.grey.shade400)
-        else ...[
-          if (item.starRating != null)
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(Icons.star_rounded, size: 13, color: Colors.amber),
-                const SizedBox(width: 2),
-                Text(
-                  '${item.starRating}',
-                  style: const TextStyle(
-                      fontSize: 12, fontWeight: FontWeight.w600),
-                ),
-              ],
-            ),
-          const SizedBox(width: 4),
-          GestureDetector(
-            onTap: () => _dislikeAiPick(item),
-            child: Icon(Icons.close_rounded,
-                size: 16, color: Colors.grey.shade400),
+        else if (item.starRating != null)
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.star_rounded, size: 13, color: Colors.amber),
+              const SizedBox(width: 2),
+              Text(
+                '${item.starRating}',
+                style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600),
+              ),
+            ],
           ),
-        ],
       ],
     );
   }

--- a/flutter_app/lib/screens/menu_detail_screen.dart
+++ b/flutter_app/lib/screens/menu_detail_screen.dart
@@ -146,8 +146,7 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
               ),
               const SizedBox(height: 20),
               Builder(builder: (_) {
-                final canSubmit = _feedbackRating > 0 &&
-                    _feedbackController.text.trim().isNotEmpty;
+                final canSubmit = _feedbackRating > 0;
                 return SizedBox(
                   height: 52,
                   child: ElevatedButton(

--- a/flutter_app/lib/screens/menu_detail_screen.dart
+++ b/flutter_app/lib/screens/menu_detail_screen.dart
@@ -35,6 +35,7 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
   // ── 저장 상태 ──
   bool _saving = false;
   bool _saved = false;
+  int? _savedLogId;
 
   // ── 피드백 상태 ──
   int _feedbackRating = 0;
@@ -182,18 +183,26 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
     );
   }
 
-  Future<void> _saveAiResult(RecommendationResult result) async {
+  Future<void> _toggleSave(RecommendationResult result) async {
     if (_saving || widget.jwt == null) return;
     setState(() => _saving = true);
-    final id = await RecommendationService.saveAiResult(result, widget.jwt);
-    if (!mounted) return;
-    setState(() { _saving = false; _saved = id != null; });
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
+    if (_saved && _savedLogId != null) {
+      final ok = await RecommendationService.deleteFeedback(_savedLogId!, widget.jwt);
+      if (!mounted) return;
+      setState(() { _saving = false; if (ok) { _saved = false; _savedLogId = null; } });
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text(ok ? '저장이 취소됐습니다' : '취소에 실패했습니다'),
+        duration: const Duration(seconds: 2),
+      ));
+    } else {
+      final id = await RecommendationService.saveAiResult(result, widget.jwt);
+      if (!mounted) return;
+      setState(() { _saving = false; _saved = id != null; _savedLogId = id; });
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
         content: Text(id != null ? '추천 이력에 저장됐습니다' : '저장에 실패했습니다'),
         duration: const Duration(seconds: 2),
-      ),
-    );
+      ));
+    }
   }
 
   Future<void> _requestAiAnalysis() async {
@@ -264,37 +273,30 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         actions: shownAi != null && widget.jwt != null
             ? [
-                TextButton(
-                  onPressed: () =>
-                      _showFeedbackBottomSheet(shownAi.menuId),
-                  child: Text(
-                    'AI 픽 별점',
-                    style: TextStyle(
-                        fontSize: 13, color: Colors.grey[600]),
-                  ),
+                IconButton(
+                  onPressed: () => _showFeedbackBottomSheet(shownAi.menuId),
+                  tooltip: 'AI 픽 별점',
+                  icon: const Icon(Icons.star_outline_rounded),
+                  color: Colors.grey[600],
                 ),
-                TextButton(
-                  onPressed:
-                      _saving ? null : () => _saveAiResult(shownAi),
-                  child: _saving
-                      ? const SizedBox(
-                          width: 14,
-                          height: 14,
+                _saving
+                    ? const Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 12),
+                        child: SizedBox(
+                          width: 20,
+                          height: 20,
                           child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              color: AppTheme.primaryColor),
-                        )
-                      : Text(
-                          _saved ? '저장됨' : '추천 결과 저장',
-                          style: TextStyle(
-                            fontSize: 13,
-                            fontWeight: FontWeight.w600,
-                            color: _saved
-                                ? AppTheme.primaryColor
-                                : Colors.grey[600],
-                          ),
+                              strokeWidth: 2, color: AppTheme.primaryColor),
                         ),
-                ),
+                      )
+                    : IconButton(
+                        onPressed: () => _toggleSave(shownAi),
+                        tooltip: _saved ? '저장 취소' : '추천 결과 저장',
+                        icon: Icon(_saved
+                            ? Icons.bookmark_rounded
+                            : Icons.bookmark_add_outlined),
+                        color: _saved ? AppTheme.primaryColor : Colors.grey[600],
+                      ),
                 const SizedBox(width: 4),
               ]
             : null,

--- a/flutter_app/lib/screens/menu_detail_screen.dart
+++ b/flutter_app/lib/screens/menu_detail_screen.dart
@@ -195,7 +195,7 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
     if (_saving || widget.jwt == null) return;
     setState(() => _saving = true);
     if (_saved && _savedLogId != null) {
-      final ok = await RecommendationService.deleteFeedback(_savedLogId!, widget.jwt);
+      final ok = await RecommendationService.unsaveAiResult(_savedLogId!, widget.jwt);
       if (!mounted) return;
       setState(() { _saving = false; if (ok) { _saved = false; _savedLogId = null; } });
       ScaffoldMessenger.of(context).showSnackBar(SnackBar(

--- a/flutter_app/lib/screens/menu_detail_screen.dart
+++ b/flutter_app/lib/screens/menu_detail_screen.dart
@@ -68,7 +68,8 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
     super.dispose();
   }
 
-  void _showFeedbackBottomSheet(int menuId) {
+  void _showFeedbackBottomSheet(RecommendationResult result) {
+    final menuId = result.menuId;
     _feedbackRating = 0;
     _feedbackController.clear();
     final messenger = ScaffoldMessenger.of(context);
@@ -146,7 +147,8 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
               ),
               const SizedBox(height: 20),
               Builder(builder: (_) {
-                final canSubmit = _feedbackRating > 0;
+                final canSubmit = _feedbackRating > 0 &&
+                    _feedbackController.text.trim().isNotEmpty;
                 return SizedBox(
                   height: 52,
                   child: ElevatedButton(
@@ -155,6 +157,13 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
                             final rating = _feedbackRating;
                             final reason = _feedbackController.text;
                             Navigator.pop(ctx);
+                            // 미저장 상태면 AI 결과 먼저 저장 — mypage AI픽 탭 조회 조건(aiResultJson IS NOT NULL) 충족
+                            if (!_saved) {
+                              final id = await RecommendationService.saveAiResult(result, widget.jwt);
+                              if (mounted && id != null) {
+                                setState(() { _saved = true; _savedLogId = id; });
+                              }
+                            }
                             await RecommendationService.saveDetailedFeedback(
                                 menuId, rating, reason, widget.jwt);
                             messenger.showSnackBar(const SnackBar(
@@ -273,7 +282,7 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
         actions: shownAi != null && widget.jwt != null
             ? [
                 IconButton(
-                  onPressed: () => _showFeedbackBottomSheet(shownAi.menuId),
+                  onPressed: () => _showFeedbackBottomSheet(shownAi),
                   tooltip: 'AI 픽 별점',
                   icon: const Icon(Icons.star_outline_rounded),
                   color: Colors.grey[600],

--- a/flutter_app/lib/screens/menu_detail_screen.dart
+++ b/flutter_app/lib/screens/menu_detail_screen.dart
@@ -268,7 +268,7 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
                   onPressed: () =>
                       _showFeedbackBottomSheet(shownAi.menuId),
                   child: Text(
-                    '피드백',
+                    'AI 픽 별점',
                     style: TextStyle(
                         fontSize: 13, color: Colors.grey[600]),
                   ),
@@ -285,7 +285,7 @@ class _MenuDetailScreenState extends State<MenuDetailScreen> {
                               color: AppTheme.primaryColor),
                         )
                       : Text(
-                          _saved ? '저장됨' : '저장',
+                          _saved ? '저장됨' : '추천 결과 저장',
                           style: TextStyle(
                             fontSize: 13,
                             fontWeight: FontWeight.w600,

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -351,6 +351,38 @@ class _MyPageScreenState extends State<MyPageScreen>
     }
   }
 
+  Future<void> _confirmDeleteAiPick(AiPickItem item) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogCtx) => AlertDialog(
+        title: const Text('이력 삭제'),
+        content: Text('"${item.menuName}" AI픽 이력을 삭제할까요?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogCtx, false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(dialogCtx, true),
+            child: const Text('삭제', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    final jwt = await TokenStorage.getAccessToken();
+    final success = await RecommendationService.deleteFeedback(item.id, jwt);
+    if (!mounted) return;
+    if (success) {
+      setState(() => _aiPickFeedbackItems.removeWhere((i) => i.id == item.id));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('이력이 삭제되었습니다.')));
+    } else {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('삭제에 실패했습니다.')));
+    }
+  }
+
   Future<void> _confirmDeleteFeedback(FeedbackHistoryItem item) async {
     final confirmed = await showDialog<bool>(
       context: context,
@@ -1425,9 +1457,19 @@ class _MyPageScreenState extends State<MyPageScreen>
         ],
       ),
       isThreeLine: true,
-      trailing: item.isDisliked
-          ? null
-          : Icon(Icons.edit_outlined, size: 16, color: Colors.grey.shade400),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (!item.isDisliked)
+            Icon(Icons.edit_outlined, size: 16, color: Colors.grey.shade400),
+          if (!item.isDisliked) const SizedBox(width: 8),
+          GestureDetector(
+            onTap: () => _confirmDeleteAiPick(item),
+            child: Icon(Icons.delete_outline_rounded,
+                size: 16, color: Colors.grey.shade400),
+          ),
+        ],
+      ),
     );
   }
 

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -1360,7 +1360,7 @@ class _MyPageScreenState extends State<MyPageScreen>
     return ListTile(
       contentPadding:
           const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-      onTap: () => _showAiPickEditSheet(item),
+      onTap: item.isDisliked ? null : () => _showAiPickEditSheet(item),
       leading: ClipRRect(
         borderRadius: BorderRadius.circular(8),
         child: item.menuImageUrl != null && item.menuImageUrl!.isNotEmpty

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -343,7 +343,7 @@ class _MyPageScreenState extends State<MyPageScreen>
       setState(() {
         _feedbackItems = feedbacks;
         _aiPickFeedbackItems =
-            aiPicks.where((i) => i.starRating != null).toList();
+            aiPicks.where((i) => i.starRating != null || i.isDisliked).toList();
       });
     } finally {
       if (mounted) setState(() => _feedbackLoading = false);
@@ -1380,19 +1380,32 @@ class _MyPageScreenState extends State<MyPageScreen>
         mainAxisSize: MainAxisSize.min,
         children: [
           const SizedBox(height: 2),
-          Row(
-            children: List.generate(
-              5,
-              (i) => Icon(
-                i < (item.starRating ?? 0)
-                    ? Icons.star_rounded
-                    : Icons.star_outline_rounded,
-                size: 14,
-                color: Colors.amber,
+          if (item.isDisliked)
+            Row(
+              children: [
+                Icon(Icons.block_rounded, size: 13, color: Colors.red.shade300),
+                const SizedBox(width: 4),
+                Text(
+                  '다시 추천 안함',
+                  style: TextStyle(fontSize: 12, color: Colors.red.shade300),
+                ),
+              ],
+            )
+          else
+            Row(
+              children: List.generate(
+                5,
+                (i) => Icon(
+                  i < (item.starRating ?? 0)
+                      ? Icons.star_rounded
+                      : Icons.star_outline_rounded,
+                  size: 14,
+                  color: Colors.amber,
+                ),
               ),
             ),
-          ),
-          if (item.feedbackReason != null &&
+          if (!item.isDisliked &&
+              item.feedbackReason != null &&
               item.feedbackReason!.isNotEmpty) ...[
             const SizedBox(height: 2),
             Text(
@@ -1412,7 +1425,9 @@ class _MyPageScreenState extends State<MyPageScreen>
         ],
       ),
       isThreeLine: true,
-      trailing: Icon(Icons.edit_outlined, size: 16, color: Colors.grey.shade400),
+      trailing: item.isDisliked
+          ? null
+          : Icon(Icons.edit_outlined, size: 16, color: Colors.grey.shade400),
     );
   }
 

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -355,8 +355,8 @@ class _MyPageScreenState extends State<MyPageScreen>
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (dialogCtx) => AlertDialog(
-        title: const Text('이력 삭제'),
-        content: Text('"${item.menuName}" AI픽 이력을 삭제할까요?'),
+        title: const Text('AI 피드백 삭제'),
+        content: Text('"${item.menuName}" AI 피드백을 삭제할까요?'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(dialogCtx, false),

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -354,16 +354,16 @@ class _MyPageScreenState extends State<MyPageScreen>
   Future<void> _confirmDeleteFeedback(FeedbackHistoryItem item) async {
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (_) => AlertDialog(
+      builder: (dialogCtx) => AlertDialog(
         title: const Text('피드백 삭제'),
         content: Text('"${item.menuName}" 피드백을 삭제할까요?'),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context, false),
+            onPressed: () => Navigator.pop(dialogCtx, false),
             child: const Text('취소'),
           ),
           TextButton(
-            onPressed: () => Navigator.pop(context, true),
+            onPressed: () => Navigator.pop(dialogCtx, true),
             child: const Text('삭제', style: TextStyle(color: Colors.red)),
           ),
         ],

--- a/flutter_app/lib/screens/recommendation_history_screen.dart
+++ b/flutter_app/lib/screens/recommendation_history_screen.dart
@@ -186,16 +186,16 @@ class _RecommendationHistoryScreenState
   Future<void> _confirmDelete(AiPickItem item) async {
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (_) => AlertDialog(
+      builder: (dialogCtx) => AlertDialog(
         title: const Text('이력 삭제'),
         content: Text('"${item.menuName}" 추천 이력을 삭제할까요?'),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context, false),
+            onPressed: () => Navigator.pop(dialogCtx, false),
             child: const Text('취소'),
           ),
           TextButton(
-            onPressed: () => Navigator.pop(context, true),
+            onPressed: () => Navigator.pop(dialogCtx, true),
             child: const Text('삭제', style: TextStyle(color: Colors.red)),
           ),
         ],

--- a/flutter_app/lib/screens/recommendation_history_screen.dart
+++ b/flutter_app/lib/screens/recommendation_history_screen.dart
@@ -174,14 +174,44 @@ class _RecommendationHistoryScreenState
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('피드백이 저장됐습니다')),
       );
-      feedbackRefreshNotifier.value++; // MyPageScreen에 변경 알림
+      feedbackRefreshNotifier.value++;
       await _load(silent: true);
     } else if (feedbackResult == false) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('저장에 실패했습니다')),
       );
     }
-    // feedbackResult == null: 사용자가 시트를 그냥 닫음 → 아무 처리 없음
+  }
+
+  Future<void> _confirmDelete(AiPickItem item) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('이력 삭제'),
+        content: Text('"${item.menuName}" 추천 이력을 삭제할까요?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('삭제', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    final ok = await RecommendationService.deleteFeedback(item.id, widget.jwt);
+    if (!mounted) return;
+    if (ok) {
+      feedbackRefreshNotifier.value++;
+      await _load(silent: true);
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('삭제에 실패했습니다')),
+      );
+    }
   }
 
   // ── 빌드 ──────────────────────────────────────────
@@ -330,40 +360,72 @@ class _RecommendationHistoryScreenState
           ),
           // ── 구분선 ──
           const Divider(height: 1, thickness: 1, color: Color(0xFFF0F0F0)),
-          // ── 하단: 피드백 버튼 ──
+          // ── 하단: 피드백 | 삭제 버튼 ──
           SizedBox(
             height: 40,
-            child: TextButton(
-              onPressed: () => _showFeedbackBottomSheet(item),
-              style: TextButton.styleFrom(
-                foregroundColor: item.starRating != null
-                    ? Colors.grey[500]
-                    : AppTheme.primaryColor,
-                shape: const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.only(
-                    bottomLeft: Radius.circular(16),
-                    bottomRight: Radius.circular(16),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextButton(
+                    onPressed: () => _showFeedbackBottomSheet(item),
+                    style: TextButton.styleFrom(
+                      foregroundColor: item.starRating != null
+                          ? Colors.grey[500]
+                          : AppTheme.primaryColor,
+                      shape: const RoundedRectangleBorder(
+                        borderRadius: BorderRadius.only(
+                          bottomLeft: Radius.circular(16),
+                        ),
+                      ),
+                    ),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          item.starRating != null
+                              ? Icons.edit_outlined
+                              : Icons.star_border_rounded,
+                          size: 14,
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          item.starRating != null ? '피드백 수정' : '피드백 남기기',
+                          style: const TextStyle(
+                              fontSize: 13, fontWeight: FontWeight.w500),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(
-                    item.starRating != null
-                        ? Icons.edit_outlined
-                        : Icons.star_border_rounded,
-                    size: 14,
+                const SizedBox(
+                    width: 1, height: 24,
+                    child: VerticalDivider(thickness: 1, color: Color(0xFFF0F0F0))),
+                Expanded(
+                  child: TextButton(
+                    onPressed: () => _confirmDelete(item),
+                    style: TextButton.styleFrom(
+                      foregroundColor: Colors.red[300],
+                      shape: const RoundedRectangleBorder(
+                        borderRadius: BorderRadius.only(
+                          bottomRight: Radius.circular(16),
+                        ),
+                      ),
+                    ),
+                    child: const Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.delete_outline_rounded, size: 14),
+                        SizedBox(width: 4),
+                        Text('삭제',
+                            style: TextStyle(
+                                fontSize: 13, fontWeight: FontWeight.w500)),
+                      ],
+                    ),
                   ),
-                  const SizedBox(width: 4),
-                  Text(
-                    item.starRating != null ? '피드백 수정' : '피드백 남기기',
-                    style: const TextStyle(
-                        fontSize: 13, fontWeight: FontWeight.w500),
-                  ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
         ],

--- a/flutter_app/lib/screens/recommendation_screen.dart
+++ b/flutter_app/lib/screens/recommendation_screen.dart
@@ -757,7 +757,7 @@ class _FeedbackGuideSheet extends StatelessWidget {
             icon: Icons.thumb_down_outlined,
             iconColor: Colors.redAccent,
             label: '싫어요',
-            description: '다음 추천부터 이 메뉴가 후보에서 제외됩니다.',
+            description: '다음 추천부터 이 메뉴가 후보에서 제외됩니다. AI 픽 메뉴에 싫어요를 누르면 AI 픽에서도 제외됩니다.',
           ),
           _GuideRow(
             icon: Icons.thumb_up_outlined,

--- a/flutter_app/lib/screens/recommendation_screen.dart
+++ b/flutter_app/lib/screens/recommendation_screen.dart
@@ -107,6 +107,16 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
   }
 
 
+  void _showFeedbackGuide(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => const _FeedbackGuideSheet(),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final aiPickIds = _aiResults.map((r) => r.menuId).toSet();
@@ -117,6 +127,13 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
         centerTitle: true,
         elevation: 0,
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.help_outline_rounded),
+            tooltip: '기능 안내',
+            onPressed: () => _showFeedbackGuide(context),
+          ),
+        ],
       ),
       body: Column(
         children: [
@@ -709,5 +726,102 @@ class _CandidateCard extends StatelessWidget {
         child: const Icon(Icons.restaurant,
             size: 24, color: AppTheme.primaryColor),
       );
+}
+
+class _FeedbackGuideSheet extends StatelessWidget {
+  const _FeedbackGuideSheet();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 20, 24, 36),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Container(
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: Colors.grey.shade300,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          const Text('버튼 기능 안내',
+              style: TextStyle(fontSize: 17, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 20),
+          _GuideRow(
+            icon: Icons.thumb_down_outlined,
+            iconColor: Colors.redAccent,
+            label: '싫어요',
+            description: '다음 추천부터 이 메뉴가 후보에서 제외됩니다.',
+          ),
+          _GuideRow(
+            icon: Icons.thumb_up_outlined,
+            iconColor: AppTheme.primaryColor,
+            label: '좋아요',
+            description: '관심 메뉴로 기록됩니다. (현재 추천 순위에는 영향 없음)',
+          ),
+          _GuideRow(
+            icon: Icons.bookmark_add_outlined,
+            iconColor: AppTheme.primaryColor,
+            label: 'AI 추천 결과 저장',
+            description: 'AI가 분석한 레시피·영양 정보를 마이페이지 이력에 보관합니다.',
+          ),
+          _GuideRow(
+            icon: Icons.star_outline_rounded,
+            iconColor: Colors.amber,
+            label: 'AI 픽 별점',
+            description: '저장된 AI 추천에 대한 만족도를 기록합니다.',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GuideRow extends StatelessWidget {
+  final IconData icon;
+  final Color iconColor;
+  final String label;
+  final String description;
+
+  const _GuideRow({
+    required this.icon,
+    required this.iconColor,
+    required this.label,
+    required this.description,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: iconColor, size: 22),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label,
+                    style: const TextStyle(
+                        fontSize: 14, fontWeight: FontWeight.w600)),
+                const SizedBox(height: 2),
+                Text(description,
+                    style: TextStyle(
+                        fontSize: 13, color: Colors.grey.shade600)),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }
 

--- a/flutter_app/lib/screens/recommendation_screen.dart
+++ b/flutter_app/lib/screens/recommendation_screen.dart
@@ -195,7 +195,7 @@ class _RecommendationScreenState extends State<RecommendationScreen> {
                             return _CandidateCard(
                               candidate: c,
                               isAiPick: isAiPick,
-                              showFeedback: !_aiLoading && !isAiPick,
+                              showFeedback: !_aiLoading,
                               feedbackGiven: feedbackGiven,
                               onFeedback: (isPos) => _onFeedback(c.id, isPos),
                               onTap: () => Navigator.push(
@@ -627,13 +627,37 @@ class _CandidateCard extends StatelessWidget {
               ),
             ),
             if (isAiPick)
-              _aiBadge()
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _aiBadge(),
+                  if (showFeedback) ...[
+                    const SizedBox(width: 6),
+                    _aiPickDislikeWidget(),
+                  ],
+                ],
+              )
             else if (showFeedback)
               _feedbackWidget(),
           ],
         ),
       ),
       ),
+    );
+  }
+
+  Widget _aiPickDislikeWidget() {
+    if (feedbackGiven == false) {
+      return const Icon(Icons.thumb_down_rounded,
+          size: 18, color: Colors.redAccent);
+    }
+    return IconButton(
+      onPressed: () => onFeedback?.call(false),
+      icon: const Icon(Icons.thumb_down_outlined, size: 18),
+      color: Colors.grey,
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+      tooltip: '다시 추천받지 않기',
     );
   }
 

--- a/flutter_app/lib/screens/recommendation_screen.dart
+++ b/flutter_app/lib/screens/recommendation_screen.dart
@@ -757,7 +757,7 @@ class _FeedbackGuideSheet extends StatelessWidget {
             icon: Icons.thumb_down_outlined,
             iconColor: Colors.redAccent,
             label: '싫어요',
-            description: '다음 추천부터 이 메뉴가 후보에서 제외됩니다. AI 픽 메뉴에 싫어요를 누르면 AI 픽에서도 제외됩니다.',
+            description: '다음 추천부터 일반 후보와 AI 픽 모두에서 이 메뉴가 제외됩니다.',
           ),
           _GuideRow(
             icon: Icons.thumb_up_outlined,
@@ -775,7 +775,7 @@ class _FeedbackGuideSheet extends StatelessWidget {
             icon: Icons.star_outline_rounded,
             iconColor: Colors.amber,
             label: 'AI 픽 별점',
-            description: '저장된 AI 추천에 대한 만족도를 기록합니다.',
+            description: '저장된 AI 추천에 대한 만족도를 기록합니다. 별점과 코멘트는 다음 AI 픽 추천에 반영됩니다.',
           ),
         ],
       ),

--- a/flutter_app/lib/services/recommendation_service.dart
+++ b/flutter_app/lib/services/recommendation_service.dart
@@ -242,6 +242,30 @@ class RecommendationService {
     }
   }
 
+  static Future<bool> updateAiPickFeedbackScore(
+      int logId, int feedbackScore, String? jwt) async {
+    if (jwt == null || jwt.isEmpty) return false;
+    final uri = Uri.parse(
+        '${ApiConfig.baseUrl}/api/recommendation-logs/$logId/feedback');
+    try {
+      final response = await http
+          .patch(
+            uri,
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer $jwt',
+            },
+            body: jsonEncode({'feedbackScore': feedbackScore}),
+          )
+          .timeout(const Duration(seconds: 10));
+      final json = jsonDecode(utf8.decode(response.bodyBytes));
+      return json['success'] == true;
+    } catch (e) {
+      debugPrint('AI픽 피드백 업데이트 실패: $e');
+      return false;
+    }
+  }
+
   static Future<MenuDetail?> fetchMenuDetail(int id, String? jwt) async {
     final uri = Uri.parse('${ApiConfig.baseUrl}/api/menus/$id');
     final headers = <String, String>{};

--- a/flutter_app/lib/services/recommendation_service.dart
+++ b/flutter_app/lib/services/recommendation_service.dart
@@ -168,6 +168,22 @@ class RecommendationService {
     }
   }
 
+  static Future<bool> unsaveAiResult(int logId, String? jwt) async {
+    if (jwt == null || jwt.isEmpty) return false;
+    final uri = Uri.parse(
+        '${ApiConfig.baseUrl}/api/recommendation-logs/$logId/unsave');
+    try {
+      final response = await http
+          .patch(uri, headers: {'Authorization': 'Bearer $jwt'})
+          .timeout(const Duration(seconds: 10));
+      final json = jsonDecode(utf8.decode(response.bodyBytes));
+      return json['success'] == true;
+    } catch (e) {
+      debugPrint('저장 취소 실패: $e');
+      return false;
+    }
+  }
+
   static Future<bool> deleteFeedback(int logId, String? jwt) async {
     if (jwt == null || jwt.isEmpty) return false;
     final uri =


### PR DESCRIPTION
Summary

- AI 픽으로 추천된 메뉴에 싫어요를 누르면 다음 추천 후보(일반 + AI 픽)에서 자동 제외
- 추천 화면에 기능 안내 BottomSheet 추가 (? 버튼)
- 메뉴 세부 페이지 저장 버튼 아이콘화 + 저장 토글(저장/취소) 지원
- 추천 이력에서 개별 삭제 기능 추가

Changes

Backend

- RecommendationLogService.updateFeedback() — feedbackScore 파라미터 추가 및 null-safe 저장
- RecommendationLogService.saveFeedback() — null-guard 추가 (싫어요 저장 시 기존 별점 보호)
- RecommendationLogService.getUserAiPickHistory() — 응답에 feedbackScore 포함
- RecommendationLogController — feedbackScore 서비스에 전달

Flutter

- AiPickItem 모델 — feedbackScore, isDisliked getter 추가
- RecommendationService.updateAiPickFeedbackScore() 신규 메서드
- 추천 화면: AI픽 카드에 싫어요 버튼 추가, 앱바 ? 기능 안내 BottomSheet
- 메뉴 세부 페이지: 텍스트 버튼 → 아이콘(⭐/🔖), 저장 토글 구현
- 마이페이지 AI픽 탭: 싫어요 항목 표시, '다시 추천 안함' 배지
- 추천 이력: 카드 하단 피드백/삭제 버튼 분리
- 대시보드: 조회 전용 유지 (싫어요 버튼 없음, 싫어요 항목 취소선 표시)
- AlertDialog actions outer context → dialogCtx 수정 (history, mypage)

Test plan

- [ ] 추천 화면 AI픽 카드 싫어요 → 다음 추천 시 해당 메뉴 미노출 확인
- [ ] 메뉴 세부 페이지 🔖 저장 → 저장됨 전환 → 재탭으로 취소 확인
- [ ] 추천 이력 삭제 → 마이페이지 AI픽 탭 즉시 반영 확인
- [ ] AI픽 별점 저장 후 싫어요 → 별점 유지 확인 (null-guard)
- [ ] 기능 안내 시트(?) 내용 확인