### PR TITLE
fix: AI픽 피드백 삭제 시 추천 이력 보존 — (#185)

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
@@ -119,6 +119,8 @@ public class RecommendationLogController {
         try {
             recommendationLogService.clearAiPickFeedback(email, id);
             return ResponseEntity.ok(Map.of("success", true));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("success", false, "error", e.getMessage()));
         } catch (SecurityException e) {
             return ResponseEntity.status(403).body(Map.of("success", false, "error", e.getMessage()));
         }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/controller/RecommendationLogController.java
@@ -106,6 +106,24 @@ public class RecommendationLogController {
         }
     }
 
+    @PatchMapping("/{id}/clear-feedback")
+    public ResponseEntity<?> clearAiPickFeedback(
+            @RequestHeader(value = "Authorization", required = false) String authHeader,
+            @PathVariable("id") Long id) {
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return ResponseEntity.status(401).body(Map.of("success", false, "error", "인증이 필요합니다."));
+        }
+
+        String email = jwtUtil.getEmailFromToken(authHeader.substring(7));
+        try {
+            recommendationLogService.clearAiPickFeedback(email, id);
+            return ResponseEntity.ok(Map.of("success", true));
+        } catch (SecurityException e) {
+            return ResponseEntity.status(403).body(Map.of("success", false, "error", e.getMessage()));
+        }
+    }
+
     @PatchMapping("/{id}/unsave")
     public ResponseEntity<?> unsaveAiResult(
             @RequestHeader(value = "Authorization", required = false) String authHeader,

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/service/RecommendationLogService.java
@@ -45,6 +45,21 @@ public class RecommendationLogService {
     }
 
     @Transactional
+    public void clearAiPickFeedback(String email, Long logId) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        RecommendationLog log = recommendationLogRepository.findById(logId)
+                .orElseThrow(() -> new IllegalArgumentException("이력을 찾을 수 없습니다."));
+        if (!log.getUser().getId().equals(user.getId())) {
+            throw new SecurityException("권한이 없습니다.");
+        }
+        log.setStarRating(null);
+        log.setFeedbackReason(null);
+        log.setFeedbackScore(null);
+        recommendationLogRepository.save(log);
+    }
+
+    @Transactional
     public void unsaveAiResult(String email, Long logId) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -371,12 +371,12 @@ class _MyPageScreenState extends State<MyPageScreen>
     );
     if (confirmed != true || !mounted) return;
     final jwt = await TokenStorage.getAccessToken();
-    final success = await RecommendationService.deleteFeedback(item.id, jwt);
+    final success = await RecommendationService.clearAiPickFeedback(item.id, jwt);
     if (!mounted) return;
     if (success) {
       setState(() => _aiPickFeedbackItems.removeWhere((i) => i.id == item.id));
       ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('이력이 삭제되었습니다.')));
+          .showSnackBar(const SnackBar(content: Text('AI 피드백이 삭제되었습니다.')));
     } else {
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('삭제에 실패했습니다.')));

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -352,11 +352,14 @@ class _MyPageScreenState extends State<MyPageScreen>
   }
 
   Future<void> _confirmDeleteAiPick(AiPickItem item) async {
+    final content = item.isDisliked
+        ? '"${item.menuName}" AI 피드백을 삭제할까요?\n삭제 시 다음 추천에서 제외가 해제됩니다.'
+        : '"${item.menuName}" AI 피드백을 삭제할까요?';
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (dialogCtx) => AlertDialog(
         title: const Text('AI 피드백 삭제'),
-        content: Text('"${item.menuName}" AI 피드백을 삭제할까요?'),
+        content: Text(content),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(dialogCtx, false),
@@ -374,7 +377,11 @@ class _MyPageScreenState extends State<MyPageScreen>
     final success = await RecommendationService.clearAiPickFeedback(item.id, jwt);
     if (!mounted) return;
     if (success) {
-      setState(() => _aiPickFeedbackItems.removeWhere((i) => i.id == item.id));
+      setState(() {
+        _aiPickFeedbackItems.removeWhere((i) => i.id == item.id);
+        // feedbackScore도 null 처리되므로 피드백 탭(좋아요/싫어요)에서도 제거
+        _feedbackItems.removeWhere((i) => i.menuId == item.menuId);
+      });
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('AI 피드백이 삭제되었습니다.')));
     } else {

--- a/flutter_app/lib/services/recommendation_service.dart
+++ b/flutter_app/lib/services/recommendation_service.dart
@@ -168,6 +168,22 @@ class RecommendationService {
     }
   }
 
+  static Future<bool> clearAiPickFeedback(int logId, String? jwt) async {
+    if (jwt == null || jwt.isEmpty) return false;
+    final uri = Uri.parse(
+        '${ApiConfig.baseUrl}/api/recommendation-logs/$logId/clear-feedback');
+    try {
+      final response = await http
+          .patch(uri, headers: {'Authorization': 'Bearer $jwt'})
+          .timeout(const Duration(seconds: 10));
+      final json = jsonDecode(utf8.decode(response.bodyBytes));
+      return json['success'] == true;
+    } catch (e) {
+      debugPrint('AI픽 피드백 삭제 실패: $e');
+      return false;
+    }
+  }
+
   static Future<bool> unsaveAiResult(int logId, String? jwt) async {
     if (jwt == null || jwt.isEmpty) return false;
     final uri = Uri.parse(


### PR DESCRIPTION
Summary

- PR #181 병합 이후 누락된 커밋(f879954) 1건을 dev에 반영하는 핫픽스
- AI픽 탭에서 피드백 삭제 시 DELETE(행 전체 삭제)를 사용해 추천 이력(aiResultJson)까지 함께 삭제되던 버그 수정

Changes

Backend

- PATCH /api/recommendation-logs/{id}/clear-feedback 엔드포인트 신설
- RecommendationLogService.clearAiPickFeedback() — starRating, feedbackReason, feedbackScore만 null 처리, aiResultJson 보존

Flutter

- RecommendationService.clearAiPickFeedback() 추가
- 마이페이지 AI픽 탭 삭제: deleteFeedback → clearAiPickFeedback 교체
- 싫어요 항목 삭제 시 feedbackScore도 null → 다음 추천 후보 제외 해제

기대 동작

┌─────────────────────┬─────────────────────────────────┬────────────────────────────────────────────┐
│        액션         │              이전               │                    이후                    │
├─────────────────────┼─────────────────────────────────┼────────────────────────────────────────────┤
│ AI픽 탭 피드백 삭제 │ 행 전체 삭제 (이력도 사라짐)    │ 별점·이유·feedbackScore만 null (이력 보존) │
├─────────────────────┼─────────────────────────────────┼────────────────────────────────────────────┤
│ 추천 이력 화면 삭제 │ aiResultJson null (이력만 제거) │ 동일                                       │
└─────────────────────┴─────────────────────────────────┴────────────────────────────────────────────┘

Test plan

- [ ] AI픽 별점 → 마이페이지 AI픽 탭 삭제 → 추천 이력 화면에서 항목 여전히 존재 확인
- [ ] 싫어요 처리된 AI픽 탭 항목 삭제 → 다음 추천에서 해당 메뉴 다시 노출 확인