### PR TITLE
feat: refresh token Redis 저장 — 진짜 회전 + 로그아웃 무효화 — #188

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/AuthController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/AuthController.java
@@ -43,6 +43,13 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
+    // 로그아웃 — 서버에 저장된 refresh token 무효화 (멱등)
+    @PostMapping("/logout")
+    public ResponseEntity<AuthResponse> logout(@Valid @RequestBody RefreshRequest request) {
+        AuthResponse response = authService.logout(request);
+        return ResponseEntity.ok(response);
+    }
+
     // 아이디(이메일) 찾기 — 가입 시 등록한 휴대폰 번호로 마스킹된 이메일 조회
     @PostMapping("/find-email")
     public ResponseEntity<ApiResponse<FindEmailResponse>> findEmail(@Valid @RequestBody FindEmailRequest request) {

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthService.java
@@ -24,6 +24,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     private final LoginAttemptService loginAttemptService;
+    private final RefreshTokenService refreshTokenService;
     
     @Transactional
     public AuthResponse signup(SignupRequest request) {
@@ -62,9 +63,10 @@ public class AuthService {
             // 저장 — unique 제약 위반을 이 메서드 안에서 잡을 수 있도록 즉시 flush
             userRepository.saveAndFlush(user);
 
-            // JWT 토큰 생성
+            // JWT 토큰 생성 — refresh token은 서버(Redis)에도 저장 (회전/로그아웃 무효화용)
             String accessToken = jwtUtil.generateAccessToken(user.getEmail());
             String refreshToken = jwtUtil.generateRefreshToken(user.getEmail());
+            refreshTokenService.store(user.getEmail(), refreshToken);
 
             // UserInfo 생성
             UserInfo userInfo = new UserInfo(user.getEmail(), user.getNickname(),
@@ -149,10 +151,11 @@ public class AuthService {
             // 로그인 성공 — 실패 기록 초기화
             loginAttemptService.onLoginSuccess(user);
 
-            // JWT 토큰 생성
+            // JWT 토큰 생성 — refresh token은 서버(Redis)에도 저장 (회전/로그아웃 무효화용)
             String accessToken = jwtUtil.generateAccessToken(user.getEmail());
             String refreshToken = jwtUtil.generateRefreshToken(user.getEmail());
-            
+            refreshTokenService.store(user.getEmail(), refreshToken);
+
             // UserInfo 생성
             UserInfo userInfo = new UserInfo(user.getEmail(), user.getNickname(),
                     user.getGender() != null ? user.getGender().name() : null);
@@ -189,12 +192,15 @@ public class AuthService {
                 return AuthResponse.failure("존재하지 않는 사용자입니다");
             }
 
-            // 새 토큰 발급
-            // ⚠️ 한계: JWT는 stateless라 기존 refreshToken을 서버에서 무효화(revoke)할 수 없음.
-            //    새 토큰을 발급해도 구 토큰은 만료(7일) 전까지 계속 유효하다.
-            //    진짜 회전(rotation)은 서버 측 토큰 저장소 도입 시 가능 — Redis 도입(#176)에서 처리 예정.
+            // 서버(Redis)에 저장된 최신 토큰과 일치해야 함 — 회전된 구 토큰/로그아웃된 토큰 차단
+            if (!refreshTokenService.matches(email, refreshToken)) {
+                return AuthResponse.failure("유효하지 않은 리프레시 토큰입니다");
+            }
+
+            // 새 토큰 발급 후 저장소 갱신 — 구 refresh token은 이 시점부터 즉시 무효 (진짜 회전)
             String accessToken = jwtUtil.generateAccessToken(user.getEmail());
             String newRefreshToken = jwtUtil.generateRefreshToken(user.getEmail());
+            refreshTokenService.store(user.getEmail(), newRefreshToken);
 
             // UserInfo 생성
             UserInfo userInfo = new UserInfo(user.getEmail(), user.getNickname(),
@@ -208,6 +214,22 @@ public class AuthService {
         } catch (Exception e) {
             log.error("토큰 갱신 중 오류 발생", e);
             return AuthResponse.failure("토큰 갱신 중 알 수 없는 오류가 발생했습니다");
+        }
+    }
+
+    // 로그아웃 — 서버에 저장된 refresh token 무효화.
+    // 토큰이 이미 만료/무효여도 성공으로 처리(멱등) — 클라이언트는 항상 로컬 토큰을 비우면 된다.
+    public AuthResponse logout(RefreshRequest request) {
+        try {
+            String refreshToken = request.getRefreshToken();
+            if (jwtUtil.validateToken(refreshToken)) {
+                String email = jwtUtil.getEmailFromToken(refreshToken);
+                refreshTokenService.invalidate(email);
+            }
+            return AuthResponse.success(null);
+        } catch (Exception e) {
+            log.error("로그아웃 처리 중 오류 발생", e);
+            return AuthResponse.success(null); // 멱등 — 서버 오류여도 클라이언트 로그아웃은 진행
         }
     }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthService.java
@@ -178,8 +178,8 @@ public class AuthService {
         try {
             String refreshToken = request.getRefreshToken();
 
-            // 리프레시 토큰 유효성 검증 (서명/만료)
-            if (!jwtUtil.validateToken(refreshToken)) {
+            // 리프레시 토큰 유효성 검증 (서명/만료 + type — access 토큰의 refresh 오용 차단)
+            if (!jwtUtil.validateToken(refreshToken) || !jwtUtil.isRefreshToken(refreshToken)) {
                 return AuthResponse.failure("유효하지 않은 리프레시 토큰입니다");
             }
 
@@ -192,15 +192,13 @@ public class AuthService {
                 return AuthResponse.failure("존재하지 않는 사용자입니다");
             }
 
-            // 서버(Redis)에 저장된 최신 토큰과 일치해야 함 — 회전된 구 토큰/로그아웃된 토큰 차단
-            if (!refreshTokenService.matches(email, refreshToken)) {
-                return AuthResponse.failure("유효하지 않은 리프레시 토큰입니다");
-            }
-
-            // 새 토큰 발급 후 저장소 갱신 — 구 refresh token은 이 시점부터 즉시 무효 (진짜 회전)
+            // 새 토큰 발급 후 원자적 비교+교체(CAS) — 저장된 최신 토큰과 일치할 때만 성공.
+            // 같은 구 토큰으로 동시 refresh가 들어와도 한쪽만 성공해, 회전된 토큰 재사용을 확실히 차단한다
             String accessToken = jwtUtil.generateAccessToken(user.getEmail());
             String newRefreshToken = jwtUtil.generateRefreshToken(user.getEmail());
-            refreshTokenService.store(user.getEmail(), newRefreshToken);
+            if (!refreshTokenService.rotate(email, refreshToken, newRefreshToken)) {
+                return AuthResponse.failure("유효하지 않은 리프레시 토큰입니다");
+            }
 
             // UserInfo 생성
             UserInfo userInfo = new UserInfo(user.getEmail(), user.getNickname(),
@@ -222,7 +220,8 @@ public class AuthService {
     public AuthResponse logout(RefreshRequest request) {
         try {
             String refreshToken = request.getRefreshToken();
-            if (jwtUtil.validateToken(refreshToken)) {
+            // type 검증 포함 — access 토큰으로는 refresh 무효화 불가
+            if (jwtUtil.validateToken(refreshToken) && jwtUtil.isRefreshToken(refreshToken)) {
                 String email = jwtUtil.getEmailFromToken(refreshToken);
                 refreshTokenService.invalidate(email);
             }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/RefreshTokenService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/RefreshTokenService.java
@@ -3,7 +3,10 @@ package capstone.ai_meal_assistant_backend.domain.user.service;
 import capstone.ai_meal_assistant_backend.global.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 /**
  * Refresh token 서버 측 저장소 (Redis).
@@ -17,6 +20,13 @@ public class RefreshTokenService {
 
     private static final String KEY_PREFIX = "refresh:token:";
 
+    // 비교+교체(CAS)를 단일 스크립트로 원자 처리 — 같은 구 토큰으로 동시 refresh가 들어와도 한쪽만 성공
+    private static final RedisScript<Long> ROTATE_SCRIPT = RedisScript.of(
+            "if redis.call('GET', KEYS[1]) == ARGV[1] then "
+                    + "redis.call('SET', KEYS[1], ARGV[2], 'PX', ARGV[3]) return 1 "
+                    + "else return 0 end",
+            Long.class);
+
     private final StringRedisTemplate redisTemplate;
     private final JwtUtil jwtUtil;
 
@@ -26,10 +36,13 @@ public class RefreshTokenService {
                 .set(KEY_PREFIX + email, refreshToken, jwtUtil.getRefreshTokenValidity());
     }
 
-    // 제시된 토큰이 서버에 저장된 최신 토큰과 일치하는지 확인
-    public boolean matches(String email, String refreshToken) {
-        String saved = redisTemplate.opsForValue().get(KEY_PREFIX + email);
-        return saved != null && saved.equals(refreshToken);
+    // 저장된 토큰이 oldToken과 일치할 때만 newToken으로 원자적 교체. 교체 성공 여부를 반환
+    public boolean rotate(String email, String oldToken, String newToken) {
+        Long result = redisTemplate.execute(
+                ROTATE_SCRIPT,
+                List.of(KEY_PREFIX + email),
+                oldToken, newToken, String.valueOf(jwtUtil.getRefreshTokenValidity().toMillis()));
+        return Long.valueOf(1L).equals(result);
     }
 
     // 로그아웃 — 저장된 토큰 삭제로 이후 refresh 불가 처리

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/RefreshTokenService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/RefreshTokenService.java
@@ -1,0 +1,39 @@
+package capstone.ai_meal_assistant_backend.domain.user.service;
+
+import capstone.ai_meal_assistant_backend.global.security.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Refresh token 서버 측 저장소 (Redis).
+ * 발급한 최신 refresh token만 유효하게 유지해 진짜 회전(rotation)과
+ * 로그아웃 시 즉시 무효화를 가능하게 한다.
+ * 이메일당 토큰 1개만 저장하는 단일 세션 정책 — 새 로그인/회전 시 이전 토큰은 즉시 무효.
+ */
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private static final String KEY_PREFIX = "refresh:token:";
+
+    private final StringRedisTemplate redisTemplate;
+    private final JwtUtil jwtUtil;
+
+    // 발급한 refresh token 저장 — 기존 토큰은 덮어써서 즉시 무효화 (TTL은 토큰 만료와 동일)
+    public void store(String email, String refreshToken) {
+        redisTemplate.opsForValue()
+                .set(KEY_PREFIX + email, refreshToken, jwtUtil.getRefreshTokenValidity());
+    }
+
+    // 제시된 토큰이 서버에 저장된 최신 토큰과 일치하는지 확인
+    public boolean matches(String email, String refreshToken) {
+        String saved = redisTemplate.opsForValue().get(KEY_PREFIX + email);
+        return saved != null && saved.equals(refreshToken);
+    }
+
+    // 로그아웃 — 저장된 토큰 삭제로 이후 refresh 불가 처리
+    public void invalidate(String email) {
+        redisTemplate.delete(KEY_PREFIX + email);
+    }
+}

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/global/security/JwtUtil.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/global/security/JwtUtil.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Date;
 
 @Component
@@ -30,6 +31,11 @@ public class JwtUtil {
                 .compact();
     }
     
+    // Refresh 토큰 유효기간 — 서버 측 저장소(Redis) TTL과 동기화용
+    public Duration getRefreshTokenValidity() {
+        return Duration.ofMillis(refreshTokenExpiration);
+    }
+
     // Refresh Token 생성
     public String generateRefreshToken(String email) {
         return Jwts.builder()

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/global/security/JwtUtil.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/global/security/JwtUtil.java
@@ -9,6 +9,7 @@ import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Date;
+import java.util.UUID;
 
 @Component
 public class JwtUtil {
@@ -21,29 +22,47 @@ public class JwtUtil {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
     
-    // Access Token 생성
+    // Access Token 생성 — type claim으로 refresh와 구분 (access 토큰의 refresh/logout 오용 방지)
     public String generateAccessToken(String email) {
         return Jwts.builder()
                 .subject(email)
+                .claim("type", "access")
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
                 .signWith(secretKey)
                 .compact();
     }
-    
+
     // Refresh 토큰 유효기간 — 서버 측 저장소(Redis) TTL과 동기화용
     public Duration getRefreshTokenValidity() {
         return Duration.ofMillis(refreshTokenExpiration);
     }
 
-    // Refresh Token 생성
+    // Refresh Token 생성 — jti(랜덤)로 같은 초에 발급돼도 토큰이 항상 유일함을 보장 (회전 무효화 엣지 방지)
     public String generateRefreshToken(String email) {
         return Jwts.builder()
                 .subject(email)
+                .claim("type", "refresh")
+                .id(UUID.randomUUID().toString())
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))
                 .signWith(secretKey)
                 .compact();
+    }
+
+    // type claim 확인 — refresh 토큰일 때만 true (구버전 토큰 등 type 없음은 false)
+    public boolean isRefreshToken(String token) {
+        try {
+            String type = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .get("type", String.class);
+            return "refresh".equals(type);
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
     }
     
     // 토큰에서 이메일 추출

--- a/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthServiceFindEmailTest.java
+++ b/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthServiceFindEmailTest.java
@@ -29,6 +29,12 @@ class AuthServiceFindEmailTest {
     @Mock
     private JwtUtil jwtUtil;
 
+    @Mock
+    private LoginAttemptService loginAttemptService;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
     @InjectMocks
     private AuthService authService;
 

--- a/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthServiceLoginLockTest.java
+++ b/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthServiceLoginLockTest.java
@@ -42,13 +42,16 @@ class AuthServiceLoginLockTest {
     @Mock
     private JwtUtil jwtUtil;
 
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
     private AuthService authService;
 
     @BeforeEach
     void setUp() {
         // LoginAttemptService가 UserRepository를 필요로 하므로 직접 조립
         LoginAttemptService loginAttemptService = new LoginAttemptService(userRepository);
-        authService = new AuthService(userRepository, passwordEncoder, jwtUtil, loginAttemptService);
+        authService = new AuthService(userRepository, passwordEncoder, jwtUtil, loginAttemptService, refreshTokenService);
     }
 
     private LoginRequest createRequest(String email, String password) {

--- a/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthServiceRefreshTest.java
+++ b/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthServiceRefreshTest.java
@@ -62,21 +62,22 @@ class AuthServiceRefreshTest {
                 .build();
 
         given(jwtUtil.validateToken(refreshToken)).willReturn(true);
+        given(jwtUtil.isRefreshToken(refreshToken)).willReturn(true);
         given(jwtUtil.getEmailFromToken(refreshToken)).willReturn("test@example.com");
         given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
-        given(refreshTokenService.matches("test@example.com", refreshToken)).willReturn(true);
         given(jwtUtil.generateAccessToken("test@example.com")).willReturn("new-access-token");
         given(jwtUtil.generateRefreshToken("test@example.com")).willReturn("new-refresh-token");
+        given(refreshTokenService.rotate("test@example.com", refreshToken, "new-refresh-token"))
+                .willReturn(true);
 
         // When
         AuthResponse response = authService.refresh(createRequest(refreshToken));
 
-        // Then — 새 토큰 발급 + 저장소 갱신(회전)
+        // Then — 새 토큰 발급 + 원자적 교체(회전)
         assertThat(response.isSuccess()).isTrue();
         assertThat(response.getData().getAccessToken()).isEqualTo("new-access-token");
         assertThat(response.getData().getRefreshToken()).isEqualTo("new-refresh-token");
         assertThat(response.getData().getUser().getEmail()).isEqualTo("test@example.com");
-        then(refreshTokenService).should().store("test@example.com", "new-refresh-token");
     }
 
     @Test
@@ -91,17 +92,51 @@ class AuthServiceRefreshTest {
                 .build();
 
         given(jwtUtil.validateToken(oldToken)).willReturn(true);
+        given(jwtUtil.isRefreshToken(oldToken)).willReturn(true);
         given(jwtUtil.getEmailFromToken(oldToken)).willReturn("test@example.com");
         given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
-        given(refreshTokenService.matches("test@example.com", oldToken)).willReturn(false);
+        given(jwtUtil.generateAccessToken("test@example.com")).willReturn("new-access-token");
+        given(jwtUtil.generateRefreshToken("test@example.com")).willReturn("new-refresh-token");
+        given(refreshTokenService.rotate("test@example.com", oldToken, "new-refresh-token"))
+                .willReturn(false);
 
         // When
         AuthResponse response = authService.refresh(createRequest(oldToken));
 
-        // Then — 서명이 유효해도 저장소 불일치면 거부, 새 토큰도 발급하지 않는다
+        // Then — 서명이 유효해도 CAS 교체 실패(저장소 불일치)면 거부
         assertThat(response.isSuccess()).isFalse();
         assertThat(response.getError()).isEqualTo("유효하지 않은 리프레시 토큰입니다");
-        then(refreshTokenService).should(never()).store(anyString(), anyString());
+    }
+
+    @Test
+    void access_토큰으로는_refresh할_수_없다() {
+        // Given — 서명은 유효하지만 type이 refresh가 아님
+        String accessToken = "valid-access-token";
+        given(jwtUtil.validateToken(accessToken)).willReturn(true);
+        given(jwtUtil.isRefreshToken(accessToken)).willReturn(false);
+
+        // When
+        AuthResponse response = authService.refresh(createRequest(accessToken));
+
+        // Then
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getError()).isEqualTo("유효하지 않은 리프레시 토큰입니다");
+        then(refreshTokenService).should(never()).rotate(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void access_토큰으로는_로그아웃해도_무효화하지_않는다() {
+        // Given — access 토큰의 logout 오용 차단 (응답은 멱등 성공)
+        String accessToken = "valid-access-token";
+        given(jwtUtil.validateToken(accessToken)).willReturn(true);
+        given(jwtUtil.isRefreshToken(accessToken)).willReturn(false);
+
+        // When
+        AuthResponse response = authService.logout(createRequest(accessToken));
+
+        // Then
+        assertThat(response.isSuccess()).isTrue();
+        then(refreshTokenService).should(never()).invalidate(anyString());
     }
 
     @Test
@@ -109,6 +144,7 @@ class AuthServiceRefreshTest {
         // Given
         String refreshToken = "valid-refresh-token";
         given(jwtUtil.validateToken(refreshToken)).willReturn(true);
+        given(jwtUtil.isRefreshToken(refreshToken)).willReturn(true);
         given(jwtUtil.getEmailFromToken(refreshToken)).willReturn("test@example.com");
 
         // When
@@ -153,6 +189,7 @@ class AuthServiceRefreshTest {
         // Given
         String refreshToken = "valid-refresh-token";
         given(jwtUtil.validateToken(refreshToken)).willReturn(true);
+        given(jwtUtil.isRefreshToken(refreshToken)).willReturn(true);
         given(jwtUtil.getEmailFromToken(refreshToken)).willReturn("ghost@example.com");
         given(userRepository.findByEmail("ghost@example.com")).willReturn(Optional.empty());
 

--- a/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthServiceRefreshTest.java
+++ b/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthServiceRefreshTest.java
@@ -18,7 +18,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceRefreshTest {
@@ -31,6 +34,12 @@ class AuthServiceRefreshTest {
 
     @Mock
     private JwtUtil jwtUtil;
+
+    @Mock
+    private LoginAttemptService loginAttemptService;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
 
     @InjectMocks
     private AuthService authService;
@@ -55,17 +64,73 @@ class AuthServiceRefreshTest {
         given(jwtUtil.validateToken(refreshToken)).willReturn(true);
         given(jwtUtil.getEmailFromToken(refreshToken)).willReturn("test@example.com");
         given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
+        given(refreshTokenService.matches("test@example.com", refreshToken)).willReturn(true);
         given(jwtUtil.generateAccessToken("test@example.com")).willReturn("new-access-token");
         given(jwtUtil.generateRefreshToken("test@example.com")).willReturn("new-refresh-token");
 
         // When
         AuthResponse response = authService.refresh(createRequest(refreshToken));
 
-        // Then
+        // Then — 새 토큰 발급 + 저장소 갱신(회전)
         assertThat(response.isSuccess()).isTrue();
         assertThat(response.getData().getAccessToken()).isEqualTo("new-access-token");
         assertThat(response.getData().getRefreshToken()).isEqualTo("new-refresh-token");
         assertThat(response.getData().getUser().getEmail()).isEqualTo("test@example.com");
+        then(refreshTokenService).should().store("test@example.com", "new-refresh-token");
+    }
+
+    @Test
+    void 서버에_저장된_토큰과_일치하지_않으면_실패_응답을_반환한다() {
+        // Given — 회전으로 무효화됐거나 로그아웃된 구 토큰
+        String oldToken = "rotated-old-token";
+        User user = User.builder()
+                .email("test@example.com")
+                .nickname("닉네임")
+                .gender(Gender.MALE)
+                .role(Role.USER)
+                .build();
+
+        given(jwtUtil.validateToken(oldToken)).willReturn(true);
+        given(jwtUtil.getEmailFromToken(oldToken)).willReturn("test@example.com");
+        given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
+        given(refreshTokenService.matches("test@example.com", oldToken)).willReturn(false);
+
+        // When
+        AuthResponse response = authService.refresh(createRequest(oldToken));
+
+        // Then — 서명이 유효해도 저장소 불일치면 거부, 새 토큰도 발급하지 않는다
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getError()).isEqualTo("유효하지 않은 리프레시 토큰입니다");
+        then(refreshTokenService).should(never()).store(anyString(), anyString());
+    }
+
+    @Test
+    void 로그아웃하면_저장된_토큰이_무효화된다() {
+        // Given
+        String refreshToken = "valid-refresh-token";
+        given(jwtUtil.validateToken(refreshToken)).willReturn(true);
+        given(jwtUtil.getEmailFromToken(refreshToken)).willReturn("test@example.com");
+
+        // When
+        AuthResponse response = authService.logout(createRequest(refreshToken));
+
+        // Then
+        assertThat(response.isSuccess()).isTrue();
+        then(refreshTokenService).should().invalidate("test@example.com");
+    }
+
+    @Test
+    void 유효하지_않은_토큰으로_로그아웃해도_성공으로_처리한다() {
+        // Given — 멱등: 만료/위조 토큰이어도 클라이언트 로그아웃은 진행돼야 한다
+        String invalidToken = "expired-token";
+        given(jwtUtil.validateToken(invalidToken)).willReturn(false);
+
+        // When
+        AuthResponse response = authService.logout(createRequest(invalidToken));
+
+        // Then
+        assertThat(response.isSuccess()).isTrue();
+        then(refreshTokenService).should(never()).invalidate(anyString());
     }
 
     @Test

--- a/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthServiceSignupTest.java
+++ b/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthServiceSignupTest.java
@@ -42,6 +42,9 @@ class AuthServiceSignupTest {
     @Mock
     private LoginAttemptService loginAttemptService;
 
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
     @InjectMocks
     private AuthService authService;
 

--- a/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/RefreshTokenServiceTest.java
+++ b/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/RefreshTokenServiceTest.java
@@ -1,0 +1,85 @@
+package capstone.ai_meal_assistant_backend.domain.user.service;
+
+import capstone.ai_meal_assistant_backend.global.security.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+    private static final String EMAIL = "test@example.com";
+    private static final String KEY = "refresh:token:" + EMAIL;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    void 토큰을_저장하면_만료기간과_함께_기록된다() {
+        // Given — TTL은 JWT refresh 토큰 유효기간과 동일
+        given(jwtUtil.getRefreshTokenValidity()).willReturn(Duration.ofDays(7));
+
+        // When
+        refreshTokenService.store(EMAIL, "token-1");
+
+        // Then
+        then(valueOperations).should().set(KEY, "token-1", Duration.ofDays(7));
+    }
+
+    @Test
+    void 저장된_토큰과_일치하면_true를_반환한다() {
+        // Given
+        given(valueOperations.get(KEY)).willReturn("token-1");
+
+        // When & Then
+        assertThat(refreshTokenService.matches(EMAIL, "token-1")).isTrue();
+    }
+
+    @Test
+    void 저장된_토큰과_다르거나_없으면_false를_반환한다() {
+        // Given — 회전으로 교체된 구 토큰 또는 로그아웃 후
+        given(valueOperations.get(KEY)).willReturn("token-2");
+
+        // When & Then
+        assertThat(refreshTokenService.matches(EMAIL, "token-1")).isFalse();
+
+        // Given — 저장된 토큰 자체가 없는 경우
+        given(valueOperations.get(KEY)).willReturn(null);
+        assertThat(refreshTokenService.matches(EMAIL, "token-1")).isFalse();
+    }
+
+    @Test
+    void 무효화하면_저장된_토큰이_삭제된다() {
+        // When
+        refreshTokenService.invalidate(EMAIL);
+
+        // Then
+        then(redisTemplate).should().delete(KEY);
+    }
+}

--- a/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/RefreshTokenServiceTest.java
+++ b/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/RefreshTokenServiceTest.java
@@ -4,15 +4,20 @@ import capstone.ai_meal_assistant_backend.global.security.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
 
 import java.time.Duration;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.lenient;
@@ -53,25 +58,31 @@ class RefreshTokenServiceTest {
     }
 
     @Test
-    void 저장된_토큰과_일치하면_true를_반환한다() {
-        // Given
-        given(valueOperations.get(KEY)).willReturn("token-1");
+    void 저장된_토큰과_일치하면_원자적으로_교체하고_true를_반환한다() {
+        // Given — CAS 스크립트가 1(교체 성공)을 반환
+        given(jwtUtil.getRefreshTokenValidity()).willReturn(Duration.ofDays(7));
+        given(redisTemplate.execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                eq(List.of(KEY)),
+                eq("token-1"), eq("token-2"), anyString()))
+                .willReturn(1L);
 
         // When & Then
-        assertThat(refreshTokenService.matches(EMAIL, "token-1")).isTrue();
+        assertThat(refreshTokenService.rotate(EMAIL, "token-1", "token-2")).isTrue();
     }
 
     @Test
-    void 저장된_토큰과_다르거나_없으면_false를_반환한다() {
-        // Given — 회전으로 교체된 구 토큰 또는 로그아웃 후
-        given(valueOperations.get(KEY)).willReturn("token-2");
+    void 저장된_토큰과_다르면_교체하지_않고_false를_반환한다() {
+        // Given — 이미 회전됐거나 로그아웃된 구 토큰 (스크립트가 0 반환)
+        given(jwtUtil.getRefreshTokenValidity()).willReturn(Duration.ofDays(7));
+        given(redisTemplate.execute(
+                ArgumentMatchers.<RedisScript<Long>>any(),
+                eq(List.of(KEY)),
+                eq("stale-token"), eq("token-2"), anyString()))
+                .willReturn(0L);
 
         // When & Then
-        assertThat(refreshTokenService.matches(EMAIL, "token-1")).isFalse();
-
-        // Given — 저장된 토큰 자체가 없는 경우
-        given(valueOperations.get(KEY)).willReturn(null);
-        assertThat(refreshTokenService.matches(EMAIL, "token-1")).isFalse();
+        assertThat(refreshTokenService.rotate(EMAIL, "stale-token", "token-2")).isFalse();
     }
 
     @Test

--- a/flutter_app/lib/services/auth_service.dart
+++ b/flutter_app/lib/services/auth_service.dart
@@ -274,8 +274,26 @@ class AuthService {
     }
   }
 
-  // 로그아웃
+  // 로그아웃 — 서버에 저장된 refresh token 무효화 후 로컬 토큰 정리
   static Future<void> logout() async {
+    // 서버 무효화는 best-effort: 네트워크 오류여도 로컬 로그아웃은 항상 완료돼야 한다
+    try {
+      final refreshToken = await TokenStorage.getRefreshToken();
+      if (refreshToken != null && refreshToken.isNotEmpty) {
+        final url = Uri.parse('${ApiConfig.baseUrl}${ApiConfig.apiVersion}/auth/logout');
+        await http.post(
+          url,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: jsonEncode({
+            'refreshToken': refreshToken,
+          }),
+        ).timeout(const Duration(seconds: 5));
+      }
+    } catch (_) {
+      // 무시 — 서버 측 토큰은 TTL(7일)로 결국 만료된다
+    }
     await TokenStorage.clearAll();
   }
 


### PR DESCRIPTION
## 개요
발급한 최신 refresh token을 Redis에 저장하고 refresh 시 저장값과 일치할 때만 갱신을 허용해,
진짜 회전(rotation)과 로그아웃 즉시 무효화를 구현합니다. (#188, #174에서 약속한 한계 해결)

## 주요 변경 사항

### Backend
- `RefreshTokenService` 신규 — `refresh:token:{email}` 키에 최신 토큰 저장
  - TTL은 `JwtUtil.getRefreshTokenValidity()`(7일)와 동기화 — 단일 소스
  - 이메일당 1개 저장 (단일 세션 정책 — 새 로그인 시 이전 세션 무효)
- `AuthService`
  - signup/login: 발급한 refresh token Redis 저장
  - refresh: JWT 서명 검증 + **저장값 일치 검증** → 새 토큰 발급 후 덮어쓰기 (구 토큰 즉시 무효)
  - `logout()` 추가 — 저장 토큰 삭제, 멱등 처리(무효 토큰이어도 성공 응답)
- `POST /api/v1/auth/logout` 엔드포인트 추가 (body: `refreshToken`)
- 기존 `refresh()`의 "⚠️ stateless 한계" 주석 제거 (해결됨)

### Flutter
- `AuthService.logout()` — 서버 무효화 호출 후 로컬 토큰 정리 (best-effort, 5초 타임아웃, 실패해도 로컬 로그아웃 진행)

## 테스트
- 단위 테스트 전체 통과 (`RefreshTokenServiceTest` 4건 신규, `AuthServiceRefreshTest` 회전 거부/로그아웃 멱등 3건 추가)
- `flutter analyze` error 0
- 실서버 E2E 전 단계 검증:
  1. signup → Redis 저장 (TTL 정확히 7일) ✅
  2. refresh T1→T2 성공 ✅
  3. **구 토큰 T1 재사용 → 거부** (진짜 회전) ✅
  4. logout → **T2 즉시 거부** + Redis 키 삭제 ✅

## 참고
- 단일 세션 트레이드오프: 기기 2대 동시 로그인 시 먼저 로그인한 기기의 refresh가 끊김 (access 1시간은 유효). 멀티 디바이스 필요 시 jti 기반 확장.
- 후속: #189 (로그인 잠금 카운터 Redis 이전) — 이 PR 머지 후 진행