### PR TITLE
refactor: 로그인 잠금 카운터 Redis 이전 — #189

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/User.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/entity/User.java
@@ -4,8 +4,6 @@ import capstone.ai_meal_assistant_backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Table(name = "users")
 @Getter
@@ -40,14 +38,6 @@ public class User extends BaseEntity {
     // 아이디(이메일) 찾기용 휴대폰 번호 — 기존 가입자를 고려해 nullable (숫자만 저장, 예: 01012345678)
     @Column(unique = true)
     private String phoneNumber;
-
-    // --- 로그인 브루트포스 방지 필드 ---
-    // 갱신은 UserRepository의 원자적 UPDATE 쿼리로만 수행 (동시 로그인 시도 시 lost update 방지)
-    @Column(nullable = false)
-    @Builder.Default
-    private int failedLoginCount = 0;
-
-    private LocalDateTime lockedUntil;
 
     @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private UserHealthProfile healthProfile;

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/repository/UserRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/repository/UserRepository.java
@@ -2,12 +2,8 @@ package capstone.ai_meal_assistant_backend.domain.user.repository;
 
 import capstone.ai_meal_assistant_backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
@@ -17,26 +13,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
     boolean existsByPhoneNumber(String phoneNumber);
-
-    // --- 로그인 브루트포스 방지: 동시 로그인 시도에도 카운트가 누락되지 않도록(lost update 방지) DB 원자적 갱신 사용 ---
-
-    // 실패 1회 기록 — 잠금이 만료된 상태면 초기화 후 1부터, 아니면 +1.
-    // 만료 판정과 갱신을 단일 쿼리로 묶어 만료 직후 동시 실패가 몰려도 과소 집계되지 않는다 (행 잠금으로 직렬화)
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE User u SET "
-            + "u.failedLoginCount = CASE WHEN u.lockedUntil IS NOT NULL AND u.lockedUntil <= :now THEN 1 ELSE u.failedLoginCount + 1 END, "
-            + "u.lockedUntil = CASE WHEN u.lockedUntil IS NOT NULL AND u.lockedUntil <= :now THEN NULL ELSE u.lockedUntil END "
-            + "WHERE u.id = :id")
-    void recordLoginFailure(@Param("id") Long id, @Param("now") LocalDateTime now);
-
-    @Query("SELECT u.failedLoginCount FROM User u WHERE u.id = :id")
-    int findFailedLoginCountById(@Param("id") Long id);
-
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE User u SET u.lockedUntil = :until WHERE u.id = :id")
-    void lockUntil(@Param("id") Long id, @Param("until") LocalDateTime until);
-
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE User u SET u.failedLoginCount = 0, u.lockedUntil = null WHERE u.id = :id")
-    void resetLoginFailure(@Param("id") Long id);
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthService.java
@@ -119,9 +119,8 @@ public class AuthService {
         return visible + "***" + domain;
     }
 
-    // 실패 횟수/잠금 상태를 기록해야 하므로 쓰기 트랜잭션 사용.
-    // AccountLockedException 발생 시에도 실패 누적은 저장되도록 noRollbackFor 지정.
-    @Transactional(noRollbackFor = AccountLockedException.class)
+    // 실패 횟수/잠금 상태는 Redis에 기록되므로 DB 트랜잭션은 조회 전용이면 충분
+    @Transactional(readOnly = true)
     public AuthResponse login(LoginRequest request) {
         try {
             // 이메일로 사용자 조회 (가입 시와 동일하게 소문자 정규화)
@@ -134,14 +133,14 @@ public class AuthService {
             }
 
             // 계정 잠금 상태 확인 (잠겨 있으면 비밀번호 검증 없이 차단)
-            long remainingLockSeconds = loginAttemptService.getRemainingLockSeconds(user);
+            long remainingLockSeconds = loginAttemptService.getRemainingLockSeconds(email);
             if (remainingLockSeconds > 0) {
                 throw new AccountLockedException(remainingLockSeconds, false);
             }
 
             // 비밀번호 검증 (실패 시 횟수 누적, 최대치 도달 시 계정 잠금)
             if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-                boolean lockedNow = loginAttemptService.onLoginFailure(user);
+                boolean lockedNow = loginAttemptService.onLoginFailure(email);
                 if (lockedNow) {
                     throw new AccountLockedException(LoginAttemptService.LOCK_DURATION.getSeconds(), true);
                 }
@@ -149,7 +148,7 @@ public class AuthService {
             }
 
             // 로그인 성공 — 실패 기록 초기화
-            loginAttemptService.onLoginSuccess(user);
+            loginAttemptService.onLoginSuccess(email);
 
             // JWT 토큰 생성 — refresh token은 서버(Redis)에도 저장 (회전/로그아웃 무효화용)
             String accessToken = jwtUtil.generateAccessToken(user.getEmail());

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/LoginAttemptService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/LoginAttemptService.java
@@ -1,18 +1,16 @@
 package capstone.ai_meal_assistant_backend.domain.user.service;
 
-import capstone.ai_meal_assistant_backend.domain.user.entity.User;
-import capstone.ai_meal_assistant_backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
 
 /**
- * 로그인 실패 횟수 추적 및 계정 잠금 정책을 담당하는 서비스.
- * 실패 횟수 갱신은 DB 원자적 UPDATE로 처리해 동시 로그인 시도에도
- * 카운트가 누락(lost update)되지 않는다.
- * 추후 Redis 도입 시 이 클래스의 구현만 교체하면 된다.
+ * 로그인 실패 횟수 추적 및 계정 잠금 정책을 담당하는 서비스 (Redis 기반).
+ * - 실패 횟수는 INCR로 원자 누적 — 동시 로그인 시도에도 카운트가 누락되지 않는다
+ * - 잠금/실패 윈도우는 키 TTL로 자동 만료 — 만료 판정 쿼리가 필요 없다
+ * - 브루트포스 트래픽이 메인 DB 쓰기 부하로 이어지지 않는다 (#175 후속, #189)
  */
 @Service
 @RequiredArgsConstructor
@@ -20,40 +18,36 @@ public class LoginAttemptService {
 
     public static final int MAX_FAILED_ATTEMPTS = 5; // 연속 실패 허용 횟수
     public static final Duration LOCK_DURATION = Duration.ofMinutes(5); // 잠금 유지 시간
+    public static final Duration FAIL_COUNT_WINDOW = Duration.ofMinutes(5); // 실패 횟수 집계 윈도우
 
-    private final UserRepository userRepository;
+    private static final String FAIL_KEY_PREFIX = "login:fail:";
+    private static final String LOCK_KEY_PREFIX = "login:lock:";
 
-    // 남은 잠금 시간(초)을 반환. 잠겨 있지 않으면 0
-    public long getRemainingLockSeconds(User user) {
-        LocalDateTime lockedUntil = user.getLockedUntil();
-        if (lockedUntil == null) {
-            return 0;
-        }
-        LocalDateTime now = LocalDateTime.now();
-        if (!now.isBefore(lockedUntil)) {
-            return 0;
-        }
-        return Duration.between(now, lockedUntil).getSeconds();
+    private final StringRedisTemplate redisTemplate;
+
+    // 남은 잠금 시간(초)을 반환. 잠겨 있지 않으면 0 — 잠금 키의 TTL이 곧 남은 시간
+    public long getRemainingLockSeconds(String email) {
+        Long ttl = redisTemplate.getExpire(LOCK_KEY_PREFIX + email);
+        return (ttl == null || ttl < 0) ? 0 : ttl;
     }
 
-    // 로그인 실패 처리 — 실패 횟수 원자적 누적, 최대치 도달 시 잠금. 이번 실패로 잠겼는지 여부를 반환
-    public boolean onLoginFailure(User user) {
-        // 잠금 만료 시 초기화(1부터)와 증가(+1)를 단일 쿼리로 처리 —
-        // stale 엔티티 기준의 별도 리셋이 없어 만료 직후 동시 실패가 몰려도 카운트가 덮어써지지 않는다
-        userRepository.recordLoginFailure(user.getId(), LocalDateTime.now());
-        int failedCount = userRepository.findFailedLoginCountById(user.getId());
+    // 로그인 실패 처리 — 실패 횟수 원자적 누적(INCR), 최대치 도달 시 잠금. 이번 실패로 잠겼는지 여부를 반환
+    public boolean onLoginFailure(String email) {
+        String failKey = FAIL_KEY_PREFIX + email;
+        Long failedCount = redisTemplate.opsForValue().increment(failKey);
+        redisTemplate.expire(failKey, FAIL_COUNT_WINDOW);
 
-        if (failedCount >= MAX_FAILED_ATTEMPTS) {
-            userRepository.lockUntil(user.getId(), LocalDateTime.now().plus(LOCK_DURATION));
+        if (failedCount != null && failedCount >= MAX_FAILED_ATTEMPTS) {
+            redisTemplate.opsForValue().set(LOCK_KEY_PREFIX + email, "1", LOCK_DURATION);
+            redisTemplate.delete(failKey); // 잠금 만료 후 첫 실패는 1부터 다시 카운트
             return true;
         }
         return false;
     }
 
-    // 로그인 성공 처리 — 실패 기록 초기화
-    public void onLoginSuccess(User user) {
-        if (user.getFailedLoginCount() > 0 || user.getLockedUntil() != null) {
-            userRepository.resetLoginFailure(user.getId());
-        }
+    // 로그인 성공 처리 — 실패 기록/잠금 키 정리 (DEL은 멱등이라 무조건 호출해도 안전)
+    public void onLoginSuccess(String email) {
+        redisTemplate.delete(FAIL_KEY_PREFIX + email);
+        redisTemplate.delete(LOCK_KEY_PREFIX + email);
     }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/LoginAttemptService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/LoginAttemptService.java
@@ -1,6 +1,8 @@
 package capstone.ai_meal_assistant_backend.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -11,7 +13,11 @@ import java.time.Duration;
  * - 실패 횟수는 INCR로 원자 누적 — 동시 로그인 시도에도 카운트가 누락되지 않는다
  * - 잠금/실패 윈도우는 키 TTL로 자동 만료 — 만료 판정 쿼리가 필요 없다
  * - 브루트포스 트래픽이 메인 DB 쓰기 부하로 이어지지 않는다 (#175 후속, #189)
+ *
+ * 장애 정책: fail-open — Redis 장애 시 잠금 검사/기록을 건너뛰고 로그인을 허용한다.
+ * (가용성 우선. 장애 동안 브루트포스 방어가 일시 정지되는 트레이드오프는 팀 합의됨)
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class LoginAttemptService {
@@ -27,27 +33,41 @@ public class LoginAttemptService {
 
     // 남은 잠금 시간(초)을 반환. 잠겨 있지 않으면 0 — 잠금 키의 TTL이 곧 남은 시간
     public long getRemainingLockSeconds(String email) {
-        Long ttl = redisTemplate.getExpire(LOCK_KEY_PREFIX + email);
-        return (ttl == null || ttl < 0) ? 0 : ttl;
+        try {
+            Long ttl = redisTemplate.getExpire(LOCK_KEY_PREFIX + email);
+            return (ttl == null || ttl < 0) ? 0 : ttl;
+        } catch (DataAccessException e) {
+            log.warn("Redis 장애 — 잠금 검사 생략(fail-open): email={}", email, e);
+            return 0;
+        }
     }
 
     // 로그인 실패 처리 — 실패 횟수 원자적 누적(INCR), 최대치 도달 시 잠금. 이번 실패로 잠겼는지 여부를 반환
     public boolean onLoginFailure(String email) {
-        String failKey = FAIL_KEY_PREFIX + email;
-        Long failedCount = redisTemplate.opsForValue().increment(failKey);
-        redisTemplate.expire(failKey, FAIL_COUNT_WINDOW);
+        try {
+            String failKey = FAIL_KEY_PREFIX + email;
+            Long failedCount = redisTemplate.opsForValue().increment(failKey);
+            redisTemplate.expire(failKey, FAIL_COUNT_WINDOW);
 
-        if (failedCount != null && failedCount >= MAX_FAILED_ATTEMPTS) {
-            redisTemplate.opsForValue().set(LOCK_KEY_PREFIX + email, "1", LOCK_DURATION);
-            redisTemplate.delete(failKey); // 잠금 만료 후 첫 실패는 1부터 다시 카운트
-            return true;
+            if (failedCount != null && failedCount >= MAX_FAILED_ATTEMPTS) {
+                redisTemplate.opsForValue().set(LOCK_KEY_PREFIX + email, "1", LOCK_DURATION);
+                redisTemplate.delete(failKey); // 잠금 만료 후 첫 실패는 1부터 다시 카운트
+                return true;
+            }
+            return false;
+        } catch (DataAccessException e) {
+            log.warn("Redis 장애 — 실패 횟수 기록 생략(fail-open): email={}", email, e);
+            return false;
         }
-        return false;
     }
 
     // 로그인 성공 처리 — 실패 기록/잠금 키 정리 (DEL은 멱등이라 무조건 호출해도 안전)
     public void onLoginSuccess(String email) {
-        redisTemplate.delete(FAIL_KEY_PREFIX + email);
-        redisTemplate.delete(LOCK_KEY_PREFIX + email);
+        try {
+            redisTemplate.delete(FAIL_KEY_PREFIX + email);
+            redisTemplate.delete(LOCK_KEY_PREFIX + email);
+        } catch (DataAccessException e) {
+            log.warn("Redis 장애 — 실패 기록 정리 생략(fail-open): email={}", email, e);
+        }
     }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/RefreshTokenService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/RefreshTokenService.java
@@ -2,6 +2,8 @@ package capstone.ai_meal_assistant_backend.domain.user.service;
 
 import capstone.ai_meal_assistant_backend.global.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
@@ -14,6 +16,7 @@ import java.util.List;
  * 로그아웃 시 즉시 무효화를 가능하게 한다.
  * 이메일당 토큰 1개만 저장하는 단일 세션 정책 — 새 로그인/회전 시 이전 토큰은 즉시 무효.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenService {
@@ -31,9 +34,14 @@ public class RefreshTokenService {
     private final JwtUtil jwtUtil;
 
     // 발급한 refresh token 저장 — 기존 토큰은 덮어써서 즉시 무효화 (TTL은 토큰 만료와 동일)
+    // fail-open: Redis 장애 시 저장을 건너뛰고 로그인은 허용 (미저장 토큰은 이후 refresh에서 거부 → 재로그인)
     public void store(String email, String refreshToken) {
-        redisTemplate.opsForValue()
-                .set(KEY_PREFIX + email, refreshToken, jwtUtil.getRefreshTokenValidity());
+        try {
+            redisTemplate.opsForValue()
+                    .set(KEY_PREFIX + email, refreshToken, jwtUtil.getRefreshTokenValidity());
+        } catch (DataAccessException e) {
+            log.warn("Redis 장애 — refresh token 저장 생략(fail-open): email={}", email, e);
+        }
     }
 
     // 저장된 토큰이 oldToken과 일치할 때만 newToken으로 원자적 교체. 교체 성공 여부를 반환

--- a/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthServiceLoginLockTest.java
+++ b/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthServiceLoginLockTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -26,6 +27,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
@@ -133,6 +135,25 @@ class AuthServiceLoginLockTest {
         assertThat(response.isSuccess()).isTrue();
         then(redisTemplate).should().delete(FAIL_KEY);
         then(redisTemplate).should().delete(LOCK_KEY);
+    }
+
+    @Test
+    void Redis_장애_시에도_로그인이_가능하다() {
+        // Given — fail-open: 잠금 검사/기록이 모두 Redis 예외를 던지는 전면 장애 상황
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(createUser()));
+        given(redisTemplate.getExpire(LOCK_KEY))
+                .willThrow(new RedisConnectionFailureException("redis down"));
+        willThrow(new RedisConnectionFailureException("redis down"))
+                .given(redisTemplate).delete(FAIL_KEY);
+        given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
+        given(jwtUtil.generateAccessToken(EMAIL)).willReturn("access-token");
+        given(jwtUtil.generateRefreshToken(EMAIL)).willReturn("refresh-token");
+
+        // When
+        AuthResponse response = authService.login(createRequest(EMAIL, "password1!"));
+
+        // Then — 가용성 우선: 로그인은 성공한다
+        assertThat(response.isSuccess()).isTrue();
     }
 
     @Test

--- a/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthServiceLoginLockTest.java
+++ b/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AuthServiceLoginLockTest.java
@@ -13,25 +13,27 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceLoginLockTest {
 
-    private static final long USER_ID = 1L;
+    private static final String EMAIL = "test@example.com";
+    private static final String FAIL_KEY = "login:fail:" + EMAIL;
+    private static final String LOCK_KEY = "login:lock:" + EMAIL;
 
     @Mock
     private UserRepository userRepository;
@@ -45,12 +47,19 @@ class AuthServiceLoginLockTest {
     @Mock
     private RefreshTokenService refreshTokenService;
 
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
     private AuthService authService;
 
     @BeforeEach
     void setUp() {
-        // LoginAttemptService가 UserRepository를 필요로 하므로 직접 조립
-        LoginAttemptService loginAttemptService = new LoginAttemptService(userRepository);
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        // LoginAttemptService는 실제 구현 + Redis mock으로 조립해 잠금 정책 흐름을 검증
+        LoginAttemptService loginAttemptService = new LoginAttemptService(redisTemplate);
         authService = new AuthService(userRepository, passwordEncoder, jwtUtil, loginAttemptService, refreshTokenService);
     }
 
@@ -62,31 +71,24 @@ class AuthServiceLoginLockTest {
     }
 
     private User createUser() {
-        return createUser(0, null);
-    }
-
-    private User createUser(int failedLoginCount, LocalDateTime lockedUntil) {
         return User.builder()
-                .id(USER_ID)
-                .email("test@example.com")
+                .id(1L)
+                .email(EMAIL)
                 .password("encoded-password")
                 .nickname("닉네임")
                 .gender(Gender.MALE)
                 .role(Role.USER)
-                .failedLoginCount(failedLoginCount)
-                .lockedUntil(lockedUntil)
                 .build();
     }
 
     @Test
     void 잠금_상태에서_로그인하면_AccountLockedException이_발생한다() {
-        // Given
-        User user = createUser(LoginAttemptService.MAX_FAILED_ATTEMPTS,
-                LocalDateTime.now().plusMinutes(5));
-        given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
+        // Given — 잠금 키 TTL이 남아 있음
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(createUser()));
+        given(redisTemplate.getExpire(LOCK_KEY)).willReturn(300L);
 
         // When & Then — 잠금 중에는 비밀번호 검증 없이 차단된다 (이미 잠긴 상태이므로 lockedNow=false)
-        assertThatThrownBy(() -> authService.login(createRequest("test@example.com", "password1!")))
+        assertThatThrownBy(() -> authService.login(createRequest(EMAIL, "password1!")))
                 .isInstanceOf(AccountLockedException.class)
                 .matches(e -> !((AccountLockedException) e).isLockedNow());
         then(passwordEncoder).should(never()).matches(anyString(), anyString());
@@ -94,54 +96,56 @@ class AuthServiceLoginLockTest {
 
     @Test
     void 비밀번호_5회_실패하면_계정이_잠기고_AccountLockedException이_발생한다() {
-        // Given
-        User user = createUser();
-        given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
+        // Given — 잠겨 있지 않은 상태에서 INCR이 1→5로 누적
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(createUser()));
+        given(redisTemplate.getExpire(LOCK_KEY)).willReturn(-2L);
         given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
-        given(userRepository.findFailedLoginCountById(USER_ID)).willReturn(1, 2, 3, 4, 5);
+        given(valueOperations.increment(FAIL_KEY)).willReturn(1L, 2L, 3L, 4L, 5L);
 
         // When — 4회까지는 동일한 실패 응답
         for (int i = 0; i < LoginAttemptService.MAX_FAILED_ATTEMPTS - 1; i++) {
-            AuthResponse response = authService.login(createRequest("test@example.com", "wrong-password1!"));
+            AuthResponse response = authService.login(createRequest(EMAIL, "wrong-password1!"));
             assertThat(response.isSuccess()).isFalse();
             assertThat(response.getError()).isEqualTo("이메일 또는 비밀번호가 일치하지 않습니다");
         }
 
-        // Then — 5번째 실패에서 잠금 처리 및 예외 발생 (이번 실패로 잠겼으므로 lockedNow=true)
-        assertThatThrownBy(() -> authService.login(createRequest("test@example.com", "wrong-password1!")))
+        // Then — 5번째 실패에서 잠금 키 설정 및 예외 발생 (이번 실패로 잠겼으므로 lockedNow=true)
+        assertThatThrownBy(() -> authService.login(createRequest(EMAIL, "wrong-password1!")))
                 .isInstanceOf(AccountLockedException.class)
                 .matches(e -> ((AccountLockedException) e).isLockedNow());
-        then(userRepository).should().lockUntil(eq(USER_ID), any(LocalDateTime.class));
+        then(valueOperations).should()
+                .set(LOCK_KEY, "1", LoginAttemptService.LOCK_DURATION);
     }
 
     @Test
-    void 로그인_성공하면_실패_횟수가_초기화된다() {
-        // Given — 2회 실패가 누적된 사용자
-        User user = createUser(2, null);
-        given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
+    void 로그인_성공하면_실패_기록이_정리된다() {
+        // Given
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(createUser()));
+        given(redisTemplate.getExpire(LOCK_KEY)).willReturn(-2L);
         given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
-        given(jwtUtil.generateAccessToken("test@example.com")).willReturn("access-token");
-        given(jwtUtil.generateRefreshToken("test@example.com")).willReturn("refresh-token");
+        given(jwtUtil.generateAccessToken(EMAIL)).willReturn("access-token");
+        given(jwtUtil.generateRefreshToken(EMAIL)).willReturn("refresh-token");
 
         // When
-        AuthResponse response = authService.login(createRequest("test@example.com", "password1!"));
+        AuthResponse response = authService.login(createRequest(EMAIL, "password1!"));
 
-        // Then
+        // Then — 실패 카운터/잠금 키 모두 정리
         assertThat(response.isSuccess()).isTrue();
-        then(userRepository).should().resetLoginFailure(USER_ID);
+        then(redisTemplate).should().delete(FAIL_KEY);
+        then(redisTemplate).should().delete(LOCK_KEY);
     }
 
     @Test
     void 비밀번호가_틀리면_존재하지_않는_이메일과_동일한_메시지를_반환한다() {
         // Given — 이메일 존재 여부가 노출되지 않아야 한다
-        User user = createUser();
-        given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(createUser()));
         given(userRepository.findByEmail("ghost@example.com")).willReturn(Optional.empty());
+        given(redisTemplate.getExpire(LOCK_KEY)).willReturn(-2L);
         given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
-        given(userRepository.findFailedLoginCountById(USER_ID)).willReturn(1);
+        given(valueOperations.increment(FAIL_KEY)).willReturn(1L);
 
         // When
-        AuthResponse wrongPassword = authService.login(createRequest("test@example.com", "wrong-password1!"));
+        AuthResponse wrongPassword = authService.login(createRequest(EMAIL, "wrong-password1!"));
         AuthResponse unknownEmail = authService.login(createRequest("ghost@example.com", "wrong-password1!"));
 
         // Then

--- a/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/LoginAttemptServiceTest.java
+++ b/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/LoginAttemptServiceTest.java
@@ -1,134 +1,108 @@
 package capstone.ai_meal_assistant_backend.domain.user.service;
 
-import capstone.ai_meal_assistant_backend.domain.user.entity.Gender;
-import capstone.ai_meal_assistant_backend.domain.user.entity.Role;
-import capstone.ai_meal_assistant_backend.domain.user.entity.User;
-import capstone.ai_meal_assistant_backend.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
-import java.time.LocalDateTime;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class LoginAttemptServiceTest {
 
-    private static final long USER_ID = 1L;
+    private static final String EMAIL = "test@example.com";
+    private static final String FAIL_KEY = "login:fail:" + EMAIL;
+    private static final String LOCK_KEY = "login:lock:" + EMAIL;
 
     @Mock
-    private UserRepository userRepository;
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
 
     @InjectMocks
     private LoginAttemptService loginAttemptService;
 
-    private User createUser() {
-        return createUser(0, null);
-    }
-
-    private User createUser(int failedLoginCount, LocalDateTime lockedUntil) {
-        return User.builder()
-                .id(USER_ID)
-                .email("test@example.com")
-                .password("encoded-password")
-                .nickname("닉네임")
-                .gender(Gender.MALE)
-                .role(Role.USER)
-                .failedLoginCount(failedLoginCount)
-                .lockedUntil(lockedUntil)
-                .build();
+    @BeforeEach
+    void setUp() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
     }
 
     @Test
     void 실패가_5회_누적되면_계정이_잠긴다() {
-        // Given — 이번 실패로 누적 횟수가 최대치에 도달
-        User user = createUser();
-        given(userRepository.findFailedLoginCountById(USER_ID))
-                .willReturn(LoginAttemptService.MAX_FAILED_ATTEMPTS);
+        // Given — INCR 결과가 최대치 도달
+        given(valueOperations.increment(FAIL_KEY))
+                .willReturn((long) LoginAttemptService.MAX_FAILED_ATTEMPTS);
 
         // When
-        boolean locked = loginAttemptService.onLoginFailure(user);
+        boolean locked = loginAttemptService.onLoginFailure(EMAIL);
 
-        // Then — 원자적 증가 후 잠금 처리
+        // Then — 잠금 키 TTL 설정 + 실패 카운터 정리 (잠금 만료 후 1부터 다시 카운트)
         assertThat(locked).isTrue();
-        then(userRepository).should().recordLoginFailure(eq(USER_ID), any(LocalDateTime.class));
-        then(userRepository).should().lockUntil(eq(USER_ID), any(LocalDateTime.class));
+        then(valueOperations).should()
+                .set(LOCK_KEY, "1", LoginAttemptService.LOCK_DURATION);
+        then(redisTemplate).should().delete(FAIL_KEY);
     }
 
     @Test
     void 실패가_5회_미만이면_잠기지_않는다() {
         // Given
-        User user = createUser();
-        given(userRepository.findFailedLoginCountById(USER_ID))
-                .willReturn(LoginAttemptService.MAX_FAILED_ATTEMPTS - 1);
+        given(valueOperations.increment(FAIL_KEY))
+                .willReturn((long) LoginAttemptService.MAX_FAILED_ATTEMPTS - 1);
 
         // When
-        boolean locked = loginAttemptService.onLoginFailure(user);
+        boolean locked = loginAttemptService.onLoginFailure(EMAIL);
 
-        // Then
+        // Then — 실패 윈도우 TTL만 갱신, 잠금 키는 만들지 않는다
         assertThat(locked).isFalse();
-        then(userRepository).should().recordLoginFailure(eq(USER_ID), any(LocalDateTime.class));
-        then(userRepository).should(never()).lockUntil(eq(USER_ID), any(LocalDateTime.class));
+        then(redisTemplate).should().expire(FAIL_KEY, LoginAttemptService.FAIL_COUNT_WINDOW);
+        then(valueOperations).should(never())
+                .set(LOCK_KEY, "1", LoginAttemptService.LOCK_DURATION);
     }
 
     @Test
-    void 잠금이_만료되면_남은_잠금_시간이_0이다() {
+    void 잠긴_계정은_잠금_키의_TTL이_남은_시간이다() {
         // Given
-        User user = createUser(LoginAttemptService.MAX_FAILED_ATTEMPTS,
-                LocalDateTime.now().minusSeconds(1));
+        given(redisTemplate.getExpire(LOCK_KEY)).willReturn(120L);
 
-        // When
-        long remaining = loginAttemptService.getRemainingLockSeconds(user);
-
-        // Then
-        assertThat(remaining).isZero();
+        // When & Then
+        assertThat(loginAttemptService.getRemainingLockSeconds(EMAIL)).isEqualTo(120L);
     }
 
     @Test
-    void 잠금_만료_후_실패하면_횟수를_초기화하고_다시_카운트한다() {
-        // Given — 잠금 시간이 지난 상태에서 다시 실패 (초기화+증가는 recordLoginFailure 단일 쿼리가 처리)
-        User user = createUser(LoginAttemptService.MAX_FAILED_ATTEMPTS,
-                LocalDateTime.now().minusSeconds(1));
-        given(userRepository.findFailedLoginCountById(USER_ID)).willReturn(1);
+    void 잠겨_있지_않으면_남은_잠금_시간이_0이다() {
+        // Given — 키가 없으면 -2 반환 (null 포함 0으로 처리)
+        given(redisTemplate.getExpire(LOCK_KEY)).willReturn(-2L);
 
-        // When
-        boolean locked = loginAttemptService.onLoginFailure(user);
-
-        // Then — 초기화 후 1부터 다시 시작하므로 잠기지 않는다. 별도 리셋 쿼리는 사용하지 않는다
-        assertThat(locked).isFalse();
-        then(userRepository).should().recordLoginFailure(eq(USER_ID), any(LocalDateTime.class));
-        then(userRepository).should(never()).resetLoginFailure(USER_ID);
+        // When & Then
+        assertThat(loginAttemptService.getRemainingLockSeconds(EMAIL)).isZero();
     }
 
     @Test
-    void 로그인_성공하면_실패_기록이_초기화된다() {
-        // Given — 실패가 누적된 사용자
-        User user = createUser(2, null);
-
+    void 로그인_성공하면_실패_기록과_잠금이_정리된다() {
         // When
-        loginAttemptService.onLoginSuccess(user);
+        loginAttemptService.onLoginSuccess(EMAIL);
 
         // Then
-        then(userRepository).should().resetLoginFailure(USER_ID);
+        then(redisTemplate).should().delete(FAIL_KEY);
+        then(redisTemplate).should().delete(LOCK_KEY);
     }
 
+    // 정책 상수 고정 (변경 시 테스트도 함께 갱신)
     @Test
-    void 실패_기록이_없으면_로그인_성공_시_초기화하지_않는다() {
-        // Given — 불필요한 UPDATE 쿼리 방지
-        User user = createUser();
-
-        // When
-        loginAttemptService.onLoginSuccess(user);
-
-        // Then
-        then(userRepository).should(never()).resetLoginFailure(USER_ID);
+    void 잠금_정책_상수를_확인한다() {
+        assertThat(LoginAttemptService.MAX_FAILED_ATTEMPTS).isEqualTo(5);
+        assertThat(LoginAttemptService.LOCK_DURATION).isEqualTo(Duration.ofMinutes(5));
+        assertThat(LoginAttemptService.FAIL_COUNT_WINDOW).isEqualTo(Duration.ofMinutes(5));
     }
 }

--- a/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/LoginAttemptServiceTest.java
+++ b/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/LoginAttemptServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
@@ -96,6 +97,36 @@ class LoginAttemptServiceTest {
         // Then
         then(redisTemplate).should().delete(FAIL_KEY);
         then(redisTemplate).should().delete(LOCK_KEY);
+    }
+
+    @Test
+    void Redis_장애_시_잠금_검사를_생략하고_0을_반환한다() {
+        // Given — fail-open: 가용성 우선
+        given(redisTemplate.getExpire(LOCK_KEY))
+                .willThrow(new RedisConnectionFailureException("redis down"));
+
+        // When & Then
+        assertThat(loginAttemptService.getRemainingLockSeconds(EMAIL)).isZero();
+    }
+
+    @Test
+    void Redis_장애_시_실패_기록을_생략하고_잠그지_않는다() {
+        // Given
+        given(valueOperations.increment(FAIL_KEY))
+                .willThrow(new RedisConnectionFailureException("redis down"));
+
+        // When & Then — 예외를 전파하지 않고 false 반환 (로그인 흐름 유지)
+        assertThat(loginAttemptService.onLoginFailure(EMAIL)).isFalse();
+    }
+
+    @Test
+    void Redis_장애_시_성공_처리도_예외를_전파하지_않는다() {
+        // Given
+        given(redisTemplate.delete(FAIL_KEY))
+                .willThrow(new RedisConnectionFailureException("redis down"));
+
+        // When & Then — 예외 없이 종료
+        loginAttemptService.onLoginSuccess(EMAIL);
     }
 
     // 정책 상수 고정 (변경 시 테스트도 함께 갱신)

--- a/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/RefreshTokenServiceTest.java
+++ b/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/RefreshTokenServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.script.RedisScript;
@@ -20,6 +21,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
@@ -92,5 +94,16 @@ class RefreshTokenServiceTest {
 
         // Then
         then(redisTemplate).should().delete(KEY);
+    }
+
+    @Test
+    void Redis_장애_시_저장을_생략하고_예외를_전파하지_않는다() {
+        // Given — fail-open: 토큰 저장 실패가 로그인을 막지 않는다 (미저장 토큰은 refresh에서 거부 → 재로그인)
+        given(jwtUtil.getRefreshTokenValidity()).willReturn(Duration.ofDays(7));
+        willThrow(new RedisConnectionFailureException("redis down"))
+                .given(valueOperations).set(KEY, "token-1", Duration.ofDays(7));
+
+        // When & Then — 예외 없이 종료
+        refreshTokenService.store(EMAIL, "token-1");
     }
 }


### PR DESCRIPTION
## 개요
#175의 로그인 잠금 카운터(failedLoginCount/lockedUntil)를 MySQL 컬럼에서 Redis로 이전합니다.
브루트포스 트래픽이 메인 DB 쓰기 부하로 이어지지 않고, 잠금 만료가 TTL로 자동 처리됩니다.

## 주요 변경
- `LoginAttemptService` Redis 재작성: `login:fail:{email}` INCR(5분 윈도우) / `login:lock:{email}` TTL=남은 잠금시간
- 인터페이스 User 엔티티 → email 기반, `login()` readOnly 트랜잭션화
- User 필드 2개 + UserRepository 원자적 쿼리 4종 제거 (조건부 CASE 단일 쿼리도 INCR로 대체돼 불필요)

## ⚠️ 배포/로컬 DB 주의
엔티티 필드 제거로 기존 컬럼이 남아 있으면 **신규 가입 INSERT가 실패**합니다. 각자 로컬 DB에서 실행 필요:
\`\`\`sql
ALTER TABLE users DROP COLUMN failed_login_count, DROP COLUMN locked_until;
\`\`\`

## 동작 차이 (의도됨)
- 실패 횟수가 무기한 유지 → 5분 슬라이딩 윈도우 내 연속 실패만 집계 (일반적 방식)

## 테스트
- 단위 테스트 전체 통과 (Redis mock 재작성)
- E2E: 동시 5발 원자 카운팅 → 잠금 / 잠금 중 정상 비밀번호 차단(423) / 성공 시 키 정리 / 컬럼 제거 후 가입 정상