### PR TITLE
feat: 로그아웃·회원탈퇴 기능 구현 — #192

### DIFF
--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/repository/RecommendationLogRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/repository/RecommendationLogRepository.java
@@ -25,4 +25,7 @@ public interface RecommendationLogRepository extends JpaRepository<Recommendatio
     List<RecommendationLog> findAiPicksByUser(@Param("user") User user);
 
     Optional<RecommendationLog> findByUserAndSelectedMenu(User user, Menu menu);
+
+    // 회원탈퇴 시 일괄 삭제
+    void deleteByUser(User user);
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/repository/RecommendationLogRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/history/repository/RecommendationLogRepository.java
@@ -26,6 +26,10 @@ public interface RecommendationLogRepository extends JpaRepository<Recommendatio
 
     Optional<RecommendationLog> findByUserAndSelectedMenu(User user, Menu menu);
 
+    // 회원탈퇴 시 RAG(ChromaDB) 임베딩 정리용 — 사용자의 모든 로그 ID 조회
+    @Query("SELECT r.id FROM RecommendationLog r WHERE r.user = :user")
+    List<Long> findIdsByUser(@Param("user") User user);
+
     // 회원탈퇴 시 일괄 삭제
     void deleteByUser(User user);
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/UserFavoriteIngredientRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/ingredient/repository/UserFavoriteIngredientRepository.java
@@ -1,6 +1,7 @@
 package capstone.ai_meal_assistant_backend.domain.ingredient.repository;
 
 import capstone.ai_meal_assistant_backend.domain.ingredient.entity.UserFavoriteIngredient;
+import capstone.ai_meal_assistant_backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,6 +11,9 @@ import java.util.List;
 public interface UserFavoriteIngredientRepository extends JpaRepository<UserFavoriteIngredient, Long> {
 
     boolean existsByUserIdAndIngredientId(Long userId, Long ingredientId);
+
+    // 회원탈퇴 시 일괄 삭제
+    void deleteByUser(User user);
 
     void deleteByUserIdAndIngredientId(Long userId, Long ingredientId);
 

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/notification/repository/UserDeviceTokenRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/notification/repository/UserDeviceTokenRepository.java
@@ -16,4 +16,7 @@ public interface UserDeviceTokenRepository extends JpaRepository<UserDeviceToken
     List<UserDeviceToken> findByUser(User user);
 
     void deleteByUserAndFcmToken(User user, String fcmToken);
+
+    // 회원탈퇴 시 일괄 삭제
+    void deleteByUser(User user);
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/notification/repository/UserIngredientAlertRepository.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/notification/repository/UserIngredientAlertRepository.java
@@ -21,6 +21,9 @@ public interface UserIngredientAlertRepository extends JpaRepository<UserIngredi
 
     void deleteByUserAndKamisItemCode(User user, String kamisItemCode);
 
+    // 회원탈퇴 시 일괄 삭제
+    void deleteByUser(User user);
+
     /** 특정 KAMIS 코드를 팔로우 중인 모든 사용자의 FCM 토큰 조회 */
     @Query("""
             SELECT t.fcmToken

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/UserController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/UserController.java
@@ -1,11 +1,16 @@
 package capstone.ai_meal_assistant_backend.domain.user.controller;
 
 import capstone.ai_meal_assistant_backend.domain.user.dto.ExistsResponse;
+import capstone.ai_meal_assistant_backend.domain.user.service.AccountDeletionService;
 import capstone.ai_meal_assistant_backend.domain.user.service.AuthService;
 import capstone.ai_meal_assistant_backend.global.dto.ApiResponse;
+import capstone.ai_meal_assistant_backend.global.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,6 +21,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final AuthService authService;
+    private final AccountDeletionService accountDeletionService;
+    private final JwtUtil jwtUtil;
 
     /**
      * 회원가입 화면의 이메일/닉네임/휴대폰 번호 중복확인 API (비로그인 호출 허용)
@@ -40,5 +47,25 @@ public class UserController {
         }
 
         return ResponseEntity.ok(ApiResponse.ok(new ExistsResponse(exists)));
+    }
+
+    /**
+     * 회원탈퇴 — Bearer access token으로 본인 확인 후 계정과 연관 데이터를 모두 삭제
+     * DELETE /api/v1/users/me
+     */
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> deleteMe(
+            @RequestHeader(value = "Authorization", required = false) String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.fail("유효하지 않은 인증 헤더입니다"));
+        }
+        String token = authHeader.substring(7);
+        if (!jwtUtil.validateToken(token)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.fail("유효하지 않은 토큰입니다"));
+        }
+        String email = jwtUtil.getEmailFromToken(token);
+        return ResponseEntity.ok(accountDeletionService.deleteAccount(email));
     }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/UserController.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import capstone.ai_meal_assistant_backend.domain.user.service.AuthService;
 import capstone.ai_meal_assistant_backend.global.dto.ApiResponse;
 import capstone.ai_meal_assistant_backend.global.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -61,11 +63,20 @@ public class UserController {
                     .body(ApiResponse.fail("유효하지 않은 인증 헤더입니다"));
         }
         String token = authHeader.substring(7);
-        if (!jwtUtil.validateToken(token)) {
+        // access 토큰만 허용 — refresh 토큰으로는 탈퇴 불가 (#188 type claim과 일관)
+        if (!jwtUtil.validateToken(token) || jwtUtil.isRefreshToken(token)) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(ApiResponse.fail("유효하지 않은 토큰입니다"));
         }
         String email = jwtUtil.getEmailFromToken(token);
-        return ResponseEntity.ok(accountDeletionService.deleteAccount(email));
+
+        // 트랜잭션 밖에서 예외를 잡아야 rollback-only 커밋 충돌 없이 사용자 안내 가능
+        // (추후 User 참조 테이블이 추가되고 정리 목록에서 누락되면 FK 위반이 여기서 잡힌다)
+        try {
+            return ResponseEntity.ok(accountDeletionService.deleteAccount(email));
+        } catch (Exception e) {
+            log.error("회원탈퇴 처리 중 오류 발생: email={}", email, e);
+            return ResponseEntity.ok(ApiResponse.fail("회원탈퇴 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요"));
+        }
     }
 }

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/AccountDeletionService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/AccountDeletionService.java
@@ -7,12 +7,15 @@ import capstone.ai_meal_assistant_backend.domain.notification.repository.UserDev
 import capstone.ai_meal_assistant_backend.domain.notification.repository.UserIngredientAlertRepository;
 import capstone.ai_meal_assistant_backend.domain.user.entity.User;
 import capstone.ai_meal_assistant_backend.domain.user.repository.UserRepository;
+import capstone.ai_meal_assistant_backend.global.client.AiHistoryClient;
 import capstone.ai_meal_assistant_backend.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 /**
  * 회원탈퇴 — 사용자와 연관된 모든 데이터를 삭제한다.
@@ -31,6 +34,7 @@ public class AccountDeletionService {
     private final UserIngredientAlertRepository userIngredientAlertRepository;
     private final RecommendationLogRepository recommendationLogRepository;
     private final RefreshTokenService refreshTokenService;
+    private final AiHistoryClient aiHistoryClient;
 
     @Transactional
     public ApiResponse<Void> deleteAccount(String email) {
@@ -39,17 +43,22 @@ public class AccountDeletionService {
             return ApiResponse.fail("사용자를 찾을 수 없습니다");
         }
 
-        // 1. cascade 미설정 자식 데이터부터 정리 (FK 제약)
+        // 1. RAG(ChromaDB)에 적재된 피드백 임베딩 정리 — 하드 삭제 정책 (#171 연동분, 개인 코멘트 포함)
+        //    AiHistoryClient는 내부에서 실패를 로깅만 하는 best-effort라 AI 서버 장애여도 탈퇴는 진행된다
+        List<Long> logIds = recommendationLogRepository.findIdsByUser(user);
+        logIds.forEach(aiHistoryClient::deleteHistory);
+
+        // 2. cascade 미설정 자식 데이터부터 정리 (FK 제약)
         userAllergyRepository.deleteByUser(user);
         userFavoriteIngredientRepository.deleteByUser(user);
         userDeviceTokenRepository.deleteByUser(user);
         userIngredientAlertRepository.deleteByUser(user);
         recommendationLogRepository.deleteByUser(user);
 
-        // 2. 계정 삭제 — healthProfile/preference는 cascade ALL로 함께 삭제
+        // 3. 계정 삭제 — healthProfile/preference는 cascade ALL로 함께 삭제
         userRepository.delete(user);
 
-        // 3. 세션 정리 — refresh token 즉시 무효화 (Redis 장애여도 탈퇴는 완료, TTL로 결국 만료)
+        // 4. 세션 정리 — refresh token 즉시 무효화 (Redis 장애여도 탈퇴는 완료, TTL로 결국 만료)
         try {
             refreshTokenService.invalidate(email);
         } catch (DataAccessException e) {

--- a/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/AccountDeletionService.java
+++ b/ai-meal-assistant-backend/src/main/java/capstone/ai_meal_assistant_backend/domain/user/service/AccountDeletionService.java
@@ -1,0 +1,62 @@
+package capstone.ai_meal_assistant_backend.domain.user.service;
+
+import capstone.ai_meal_assistant_backend.domain.history.repository.RecommendationLogRepository;
+import capstone.ai_meal_assistant_backend.domain.ingredient.repository.UserFavoriteIngredientRepository;
+import capstone.ai_meal_assistant_backend.domain.menu.repository.UserAllergyRepository;
+import capstone.ai_meal_assistant_backend.domain.notification.repository.UserDeviceTokenRepository;
+import capstone.ai_meal_assistant_backend.domain.notification.repository.UserIngredientAlertRepository;
+import capstone.ai_meal_assistant_backend.domain.user.entity.User;
+import capstone.ai_meal_assistant_backend.domain.user.repository.UserRepository;
+import capstone.ai_meal_assistant_backend.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 회원탈퇴 — 사용자와 연관된 모든 데이터를 삭제한다.
+ * cascade가 없는 자식 엔티티(알레르기/즐겨찾기/디바이스토큰/가격알림/추천이력)를
+ * 먼저 정리해야 FK 제약 위반 없이 계정을 삭제할 수 있다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AccountDeletionService {
+
+    private final UserRepository userRepository;
+    private final UserAllergyRepository userAllergyRepository;
+    private final UserFavoriteIngredientRepository userFavoriteIngredientRepository;
+    private final UserDeviceTokenRepository userDeviceTokenRepository;
+    private final UserIngredientAlertRepository userIngredientAlertRepository;
+    private final RecommendationLogRepository recommendationLogRepository;
+    private final RefreshTokenService refreshTokenService;
+
+    @Transactional
+    public ApiResponse<Void> deleteAccount(String email) {
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user == null) {
+            return ApiResponse.fail("사용자를 찾을 수 없습니다");
+        }
+
+        // 1. cascade 미설정 자식 데이터부터 정리 (FK 제약)
+        userAllergyRepository.deleteByUser(user);
+        userFavoriteIngredientRepository.deleteByUser(user);
+        userDeviceTokenRepository.deleteByUser(user);
+        userIngredientAlertRepository.deleteByUser(user);
+        recommendationLogRepository.deleteByUser(user);
+
+        // 2. 계정 삭제 — healthProfile/preference는 cascade ALL로 함께 삭제
+        userRepository.delete(user);
+
+        // 3. 세션 정리 — refresh token 즉시 무효화 (Redis 장애여도 탈퇴는 완료, TTL로 결국 만료)
+        try {
+            refreshTokenService.invalidate(email);
+        } catch (DataAccessException e) {
+            log.warn("Redis 장애 — 탈퇴 계정의 refresh token 무효화 생략: email={}", email, e);
+        }
+
+        log.info("회원탈퇴 완료: email={}", email);
+        return ApiResponse.ok(null);
+    }
+}

--- a/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AccountDeletionServiceTest.java
+++ b/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AccountDeletionServiceTest.java
@@ -9,6 +9,7 @@ import capstone.ai_meal_assistant_backend.domain.user.entity.Gender;
 import capstone.ai_meal_assistant_backend.domain.user.entity.Role;
 import capstone.ai_meal_assistant_backend.domain.user.entity.User;
 import capstone.ai_meal_assistant_backend.domain.user.repository.UserRepository;
+import capstone.ai_meal_assistant_backend.global.client.AiHistoryClient;
 import capstone.ai_meal_assistant_backend.global.dto.ApiResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.RedisConnectionFailureException;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,6 +54,9 @@ class AccountDeletionServiceTest {
     @Mock
     private RefreshTokenService refreshTokenService;
 
+    @Mock
+    private AiHistoryClient aiHistoryClient;
+
     @InjectMocks
     private AccountDeletionService accountDeletionService;
 
@@ -68,15 +73,18 @@ class AccountDeletionServiceTest {
 
     @Test
     void 탈퇴하면_연관_데이터와_계정이_모두_삭제되고_토큰이_무효화된다() {
-        // Given
+        // Given — RAG에 적재된 피드백 로그 2건 보유
         User user = createUser();
         given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+        given(recommendationLogRepository.findIdsByUser(user)).willReturn(List.of(10L, 11L));
 
         // When
         ApiResponse<Void> response = accountDeletionService.deleteAccount(EMAIL);
 
-        // Then — cascade 미설정 자식 데이터 전부 정리 후 계정 삭제 + 세션 무효화
+        // Then — RAG 임베딩 + cascade 미설정 자식 데이터 전부 정리 후 계정 삭제 + 세션 무효화
         assertThat(response.isSuccess()).isTrue();
+        then(aiHistoryClient).should().deleteHistory(10L);
+        then(aiHistoryClient).should().deleteHistory(11L);
         then(userAllergyRepository).should().deleteByUser(user);
         then(userFavoriteIngredientRepository).should().deleteByUser(user);
         then(userDeviceTokenRepository).should().deleteByUser(user);

--- a/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AccountDeletionServiceTest.java
+++ b/ai-meal-assistant-backend/src/test/java/capstone/ai_meal_assistant_backend/domain/user/service/AccountDeletionServiceTest.java
@@ -1,0 +1,119 @@
+package capstone.ai_meal_assistant_backend.domain.user.service;
+
+import capstone.ai_meal_assistant_backend.domain.history.repository.RecommendationLogRepository;
+import capstone.ai_meal_assistant_backend.domain.ingredient.repository.UserFavoriteIngredientRepository;
+import capstone.ai_meal_assistant_backend.domain.menu.repository.UserAllergyRepository;
+import capstone.ai_meal_assistant_backend.domain.notification.repository.UserDeviceTokenRepository;
+import capstone.ai_meal_assistant_backend.domain.notification.repository.UserIngredientAlertRepository;
+import capstone.ai_meal_assistant_backend.domain.user.entity.Gender;
+import capstone.ai_meal_assistant_backend.domain.user.entity.Role;
+import capstone.ai_meal_assistant_backend.domain.user.entity.User;
+import capstone.ai_meal_assistant_backend.domain.user.repository.UserRepository;
+import capstone.ai_meal_assistant_backend.global.dto.ApiResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.RedisConnectionFailureException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+@ExtendWith(MockitoExtension.class)
+class AccountDeletionServiceTest {
+
+    private static final String EMAIL = "test@example.com";
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserAllergyRepository userAllergyRepository;
+
+    @Mock
+    private UserFavoriteIngredientRepository userFavoriteIngredientRepository;
+
+    @Mock
+    private UserDeviceTokenRepository userDeviceTokenRepository;
+
+    @Mock
+    private UserIngredientAlertRepository userIngredientAlertRepository;
+
+    @Mock
+    private RecommendationLogRepository recommendationLogRepository;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @InjectMocks
+    private AccountDeletionService accountDeletionService;
+
+    private User createUser() {
+        return User.builder()
+                .id(1L)
+                .email(EMAIL)
+                .password("encoded-password")
+                .nickname("닉네임")
+                .gender(Gender.MALE)
+                .role(Role.USER)
+                .build();
+    }
+
+    @Test
+    void 탈퇴하면_연관_데이터와_계정이_모두_삭제되고_토큰이_무효화된다() {
+        // Given
+        User user = createUser();
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+
+        // When
+        ApiResponse<Void> response = accountDeletionService.deleteAccount(EMAIL);
+
+        // Then — cascade 미설정 자식 데이터 전부 정리 후 계정 삭제 + 세션 무효화
+        assertThat(response.isSuccess()).isTrue();
+        then(userAllergyRepository).should().deleteByUser(user);
+        then(userFavoriteIngredientRepository).should().deleteByUser(user);
+        then(userDeviceTokenRepository).should().deleteByUser(user);
+        then(userIngredientAlertRepository).should().deleteByUser(user);
+        then(recommendationLogRepository).should().deleteByUser(user);
+        then(userRepository).should().delete(user);
+        then(refreshTokenService).should().invalidate(EMAIL);
+    }
+
+    @Test
+    void 가입되지_않은_이메일이면_실패하고_아무것도_삭제하지_않는다() {
+        // Given
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.empty());
+
+        // When
+        ApiResponse<Void> response = accountDeletionService.deleteAccount(EMAIL);
+
+        // Then
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getError()).isEqualTo("사용자를 찾을 수 없습니다");
+        then(userRepository).should(never()).delete(any(User.class));
+        then(refreshTokenService).should(never()).invalidate(EMAIL);
+    }
+
+    @Test
+    void Redis_장애여도_탈퇴는_완료된다() {
+        // Given — 토큰 무효화 실패는 탈퇴를 막지 않는다 (TTL로 결국 만료)
+        User user = createUser();
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+        willThrow(new RedisConnectionFailureException("redis down"))
+                .given(refreshTokenService).invalidate(EMAIL);
+
+        // When
+        ApiResponse<Void> response = accountDeletionService.deleteAccount(EMAIL);
+
+        // Then
+        assertThat(response.isSuccess()).isTrue();
+        then(userRepository).should().delete(user);
+    }
+}

--- a/flutter_app/lib/screens/mypage_screen.dart
+++ b/flutter_app/lib/screens/mypage_screen.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_app/models/recommendation_models.dart';
 import 'package:flutter_app/models/user_profile_models.dart';
 import 'package:flutter_app/notifiers.dart';
+import 'package:flutter_app/services/auth_service.dart';
 import 'package:flutter_app/services/recommendation_service.dart';
 import 'package:flutter_app/services/user_profile_service.dart';
+import 'package:flutter_app/screens/login_screen.dart';
 import 'package:flutter_app/screens/price_alert_screen.dart';
 import 'package:flutter_app/screens/recommendation_history_screen.dart';
 import 'package:flutter_app/services/token_storage.dart';
@@ -586,10 +588,110 @@ class _MyPageScreenState extends State<MyPageScreen>
             _buildHistoryButton(),
             const SizedBox(height: 10),
             _buildPriceAlertButton(),
+            const SizedBox(height: 24),
+            _buildLogoutButton(),
+            const SizedBox(height: 8),
+            _buildDeleteAccountButton(),
             const SizedBox(height: 32),
           ],
         ),
       ),
+    );
+  }
+
+  // ── 로그아웃 / 회원탈퇴 ──────────────────────────
+
+  Widget _buildLogoutButton() {
+    return GestureDetector(
+      onTap: () async {
+        await AuthService.logout();
+        if (!mounted) return;
+        Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(builder: (_) => const LoginScreen()),
+          (route) => false,
+        );
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.04),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            Icon(Icons.logout_rounded, size: 20, color: Colors.grey[600]),
+            const SizedBox(width: 12),
+            Text(
+              '로그아웃',
+              style: TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                  color: Colors.grey[800]),
+            ),
+            const Spacer(),
+            Icon(Icons.chevron_right_rounded,
+                color: Colors.grey[400], size: 20),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDeleteAccountButton() {
+    return Center(
+      child: TextButton(
+        onPressed: _confirmDeleteAccount,
+        child: Text(
+          '회원탈퇴',
+          style: TextStyle(
+            fontSize: 13,
+            color: Colors.grey[500],
+            decoration: TextDecoration.underline,
+          ),
+        ),
+      ),
+    );
+  }
+
+  // 회원탈퇴 확인 다이얼로그 — 모든 데이터가 삭제됨을 명확히 안내
+  Future<void> _confirmDeleteAccount() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('회원탈퇴'),
+        content: const Text(
+            '탈퇴하면 프로필, AI 추천 이력, 즐겨찾기 등 모든 데이터가 삭제되며 되돌릴 수 없습니다.\n정말 탈퇴하시겠어요?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('탈퇴하기', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    final error = await AuthService.deleteAccount();
+    if (!mounted) return;
+
+    if (error != null) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(error)));
+      return;
+    }
+    Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(builder: (_) => const LoginScreen()),
+      (route) => false,
     );
   }
 

--- a/flutter_app/lib/services/auth_service.dart
+++ b/flutter_app/lib/services/auth_service.dart
@@ -301,4 +301,34 @@ class AuthService {
   static Future<bool> isLoggedIn() async {
     return await TokenStorage.hasToken();
   }
+
+  // 회원탈퇴 — 성공 시 로컬 토큰까지 정리. 반환값: null=성공, 그 외=에러 메시지
+  static Future<String?> deleteAccount() async {
+    try {
+      final accessToken = await TokenStorage.getAccessToken();
+      if (accessToken == null || accessToken.isEmpty) {
+        return '로그인 정보가 없습니다. 다시 로그인해 주세요.';
+      }
+
+      final url = Uri.parse('${ApiConfig.baseUrl}${ApiConfig.apiVersion}/users/me');
+      final response = await http.delete(
+        url,
+        headers: {
+          'Authorization': 'Bearer $accessToken',
+        },
+      ).timeout(
+        const Duration(seconds: 10),
+        onTimeout: () => throw Exception('요청 시간 초과'),
+      );
+
+      final jsonResponse = jsonDecode(response.body);
+      if (jsonResponse['success'] == true) {
+        await TokenStorage.clearAll();
+        return null;
+      }
+      return jsonResponse['error'] ?? '회원탈퇴에 실패했습니다.';
+    } catch (e) {
+      return '요청 중 오류가 발생했습니다: $e';
+    }
+  }
 }

--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -356,10 +356,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -569,10 +569,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
## 개요
마이페이지에서 로그아웃과 회원탈퇴를 제공합니다.
로그아웃은 #188의 API를 UI에 연결하고, 회원탈퇴는 백엔드부터 신규 구현했습니다.

## 주요 변경

### Backend — 회원탈퇴
- `DELETE /api/v1/users/me` — Authorization Bearer access token으로 본인 확인 (헤더 없음/무효 토큰 → 401)
- `AccountDeletionService` — 단일 트랜잭션:
  1. cascade 미설정 자식 데이터 선삭제 (UserAllergy, UserFavoriteIngredient, UserDeviceToken, UserIngredientAlert, RecommendationLog) — 이것 없이는 FK 제약으로 User 삭제 불가
  2. 계정 삭제 (HealthProfile/Preference는 cascade ALL로 자동)
  3. refresh token 즉시 무효화 (Redis 장애 시 fail-open — TTL로 만료)
- 자식 리포지토리 4곳 `deleteByUser(User)` 추가

### Flutter
- 마이페이지 프로필 탭 하단: 로그아웃 버튼 + 회원탈퇴 버튼(확인 다이얼로그 — 데이터 삭제 경고)
- `AuthService.deleteAccount()` — 성공 시 로컬 토큰 정리, 완료 후 로그인 화면으로 스택 초기화 이동

## 테스트
- 단위 테스트 전체 통과, flutter analyze error 0
- E2E: 무인증 401 / 탈퇴 후 users·연관 테이블 잔존 0건 / 탈퇴 계정 refresh 거부 / Redis 키 삭제 확인

## 참고
- 하드 삭제 정책 (모든 개인 데이터 즉시 삭제). 소프트 삭제(유예 기간)는 필요 시 별도 이슈로
